### PR TITLE
add specs for codegen CLI, API, and boot loading (tasks 15-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Legion Changelog
 
+## [Unreleased]
+
+### Added
+- Specs for `legion codegen` CLI subcommand (8 subcommands, 22 examples)
+- Specs for `/api/codegen/*` API routes (8 routes, 20 examples)
+- Specs for `setup_generated_functions` boot loading in Service (4 examples)
+
 ## [1.6.8] - 2026-03-26
 
 ### Added

--- a/spec/legion/api/codegen_spec.rb
+++ b/spec/legion/api/codegen_spec.rb
@@ -1,0 +1,309 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rack/test'
+require 'sinatra/base'
+require 'legion/api/helpers'
+require 'legion/api/codegen'
+
+RSpec.describe 'Codegen API routes' do
+  include Rack::Test::Methods
+
+  before(:all) do
+    Legion::Logging.setup(log_level: 'fatal', level: 'fatal', trace: false)
+    Legion::Settings.load(config_dir: File.expand_path('../../..', __dir__))
+  end
+
+  let(:test_app) do
+    Class.new(Sinatra::Base) do
+      helpers Legion::API::Helpers
+
+      set :show_exceptions, false
+      set :raise_errors, false
+      set :host_authorization, permitted: :any
+
+      error do
+        content_type :json
+        err = env['sinatra.error']
+        status 500
+        Legion::JSON.dump({ error: { code: 'internal_error', message: err.message } })
+      end
+
+      register Legion::API::Routes::Codegen
+    end
+  end
+
+  def app
+    test_app
+  end
+
+  describe 'GET /api/codegen/status' do
+    context 'when SelfGenerate is not available' do
+      before { hide_const('Legion::MCP::SelfGenerate') }
+
+      it 'returns 503' do
+        get '/api/codegen/status'
+        expect(last_response.status).to eq(503)
+      end
+    end
+
+    context 'when SelfGenerate is available' do
+      before do
+        self_gen = Module.new do
+          def self.status
+            { enabled: true, last_cycle_at: '2026-03-26T00:00:00Z', gaps_detected: 5 }
+          end
+        end
+        stub_const('Legion::MCP::SelfGenerate', self_gen)
+      end
+
+      it 'returns 200' do
+        get '/api/codegen/status'
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'returns status data' do
+        get '/api/codegen/status'
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data][:enabled]).to eq(true)
+        expect(body[:data][:gaps_detected]).to eq(5)
+      end
+    end
+  end
+
+  describe 'GET /api/codegen/generated' do
+    context 'when GeneratedRegistry is not available' do
+      before { hide_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry') }
+
+      it 'returns 503' do
+        get '/api/codegen/generated'
+        expect(last_response.status).to eq(503)
+      end
+    end
+
+    context 'when GeneratedRegistry is available' do
+      before do
+        registry = Module.new do
+          def self.list(status: nil)
+            records = [
+              { id: 'gen_001', name: 'fetch_weather', status: 'approved' },
+              { id: 'gen_002', name: 'parse_csv', status: 'pending' }
+            ]
+            records = records.select { |r| r[:status] == status } if status
+            records
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry', registry)
+      end
+
+      it 'returns 200 with all records' do
+        get '/api/codegen/generated'
+        expect(last_response.status).to eq(200)
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data].size).to eq(2)
+      end
+
+      it 'filters by status param' do
+        get '/api/codegen/generated', status: 'approved'
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data].size).to eq(1)
+        expect(body[:data].first[:name]).to eq('fetch_weather')
+      end
+    end
+  end
+
+  describe 'GET /api/codegen/generated/:id' do
+    context 'when GeneratedRegistry is not available' do
+      before { hide_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry') }
+
+      it 'returns 503' do
+        get '/api/codegen/generated/gen_001'
+        expect(last_response.status).to eq(503)
+      end
+    end
+
+    context 'when GeneratedRegistry is available' do
+      before do
+        registry = Module.new do
+          def self.get(id:)
+            return { id: id, name: 'fetch_weather', status: 'approved' } if id == 'gen_001'
+
+            nil
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry', registry)
+      end
+
+      it 'returns 200 for existing record' do
+        get '/api/codegen/generated/gen_001'
+        expect(last_response.status).to eq(200)
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data][:name]).to eq('fetch_weather')
+      end
+
+      it 'returns 404 for missing record' do
+        get '/api/codegen/generated/nonexistent'
+        expect(last_response.status).to eq(404)
+      end
+    end
+  end
+
+  describe 'POST /api/codegen/generated/:id/approve' do
+    context 'when ReviewHandler is not available' do
+      before { hide_const('Legion::Extensions::Codegen::Runners::ReviewHandler') }
+
+      it 'returns 503' do
+        post '/api/codegen/generated/gen_001/approve'
+        expect(last_response.status).to eq(503)
+      end
+    end
+
+    context 'when ReviewHandler is available' do
+      before do
+        handler = Module.new do
+          def self.handle_verdict(review:)
+            { generation_id: review[:generation_id], status: 'approved' }
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Runners::ReviewHandler', handler)
+      end
+
+      it 'returns 200 with approval result' do
+        post '/api/codegen/generated/gen_001/approve'
+        expect(last_response.status).to eq(200)
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data][:status]).to eq('approved')
+        expect(body[:data][:generation_id]).to eq('gen_001')
+      end
+    end
+  end
+
+  describe 'POST /api/codegen/generated/:id/reject' do
+    context 'when GeneratedRegistry is not available' do
+      before { hide_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry') }
+
+      it 'returns 503' do
+        post '/api/codegen/generated/gen_001/reject'
+        expect(last_response.status).to eq(503)
+      end
+    end
+
+    context 'when GeneratedRegistry is available' do
+      before do
+        registry = Module.new do
+          def self.update_status(id:, status:)
+            { id: id, status: status }
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry', registry)
+      end
+
+      it 'returns 200 with rejected status' do
+        post '/api/codegen/generated/gen_001/reject'
+        expect(last_response.status).to eq(200)
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data][:id]).to eq('gen_001')
+        expect(body[:data][:status]).to eq('rejected')
+      end
+    end
+  end
+
+  describe 'POST /api/codegen/generated/:id/retry' do
+    context 'when GeneratedRegistry is not available' do
+      before { hide_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry') }
+
+      it 'returns 503' do
+        post '/api/codegen/generated/gen_001/retry'
+        expect(last_response.status).to eq(503)
+      end
+    end
+
+    context 'when GeneratedRegistry is available' do
+      before do
+        registry = Module.new do
+          def self.update_status(id:, status:)
+            { id: id, status: status }
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry', registry)
+      end
+
+      it 'returns 200 with pending status' do
+        post '/api/codegen/generated/gen_001/retry'
+        expect(last_response.status).to eq(200)
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data][:id]).to eq('gen_001')
+        expect(body[:data][:status]).to eq('pending')
+      end
+    end
+  end
+
+  describe 'GET /api/codegen/gaps' do
+    context 'when GapDetector is available' do
+      before do
+        detector = Module.new do
+          def self.detect_gaps
+            [{ gap_id: 'gap_1', gap_type: :unmatched_intent, priority: 0.8 }]
+          end
+        end
+        stub_const('Legion::MCP::GapDetector', detector)
+      end
+
+      it 'returns 200 with gaps' do
+        get '/api/codegen/gaps'
+        expect(last_response.status).to eq(200)
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data].size).to eq(1)
+        expect(body[:data].first[:gap_id]).to eq('gap_1')
+      end
+    end
+
+    context 'when GapDetector is not available' do
+      before { hide_const('Legion::MCP::GapDetector') }
+
+      it 'returns 200 with empty array' do
+        get '/api/codegen/gaps'
+        expect(last_response.status).to eq(200)
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data]).to eq([])
+      end
+    end
+  end
+
+  describe 'POST /api/codegen/cycle' do
+    context 'when SelfGenerate is available' do
+      before do
+        self_gen = Module.new do
+          def self.run_cycle
+            { triggered: true, gaps_processed: 2 }
+          end
+        end
+        stub_const('Legion::MCP::SelfGenerate', self_gen)
+        allow(Legion::MCP::SelfGenerate).to receive(:instance_variable_set)
+      end
+
+      it 'returns 200 with cycle result' do
+        post '/api/codegen/cycle'
+        expect(last_response.status).to eq(200)
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data][:triggered]).to eq(true)
+      end
+
+      it 'resets cooldown before running' do
+        expect(Legion::MCP::SelfGenerate).to receive(:instance_variable_set).with(:@last_cycle_at, nil)
+        post '/api/codegen/cycle'
+      end
+    end
+
+    context 'when SelfGenerate is not available' do
+      before { hide_const('Legion::MCP::SelfGenerate') }
+
+      it 'returns 200 with triggered false' do
+        post '/api/codegen/cycle'
+        expect(last_response.status).to eq(200)
+        body = Legion::JSON.load(last_response.body)
+        expect(body[:data][:triggered]).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/legion/cli/codegen_command_spec.rb
+++ b/spec/legion/cli/codegen_command_spec.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'thor'
+require 'legion/cli/codegen_command'
+
+RSpec.describe Legion::CLI::CodegenCommand do
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  describe '#status' do
+    context 'when SelfGenerate is available' do
+      before do
+        self_gen = Module.new do
+          def self.status
+            { enabled: true, last_cycle_at: '2026-03-26T00:00:00Z', gaps_detected: 3 }
+          end
+        end
+        stub_const('Legion::MCP::SelfGenerate', self_gen)
+      end
+
+      it 'outputs JSON with data key' do
+        output = capture_stdout { described_class.start(%w[status]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data]).to be_a(Hash)
+      end
+
+      it 'includes enabled status' do
+        output = capture_stdout { described_class.start(%w[status]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data][:enabled]).to eq(true)
+      end
+
+      it 'includes gaps_detected count' do
+        output = capture_stdout { described_class.start(%w[status]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data][:gaps_detected]).to eq(3)
+      end
+    end
+
+    context 'when SelfGenerate is not available' do
+      before do
+        hide_const('Legion::MCP::SelfGenerate')
+      end
+
+      it 'outputs error' do
+        output = capture_stdout { described_class.start(%w[status]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:error]).to eq('codegen not available')
+      end
+    end
+  end
+
+  describe '#list' do
+    context 'when GeneratedRegistry is available' do
+      before do
+        registry = Module.new do
+          def self.list(status: nil)
+            records = [
+              { id: 'gen_001', name: 'fetch_weather', status: 'approved' },
+              { id: 'gen_002', name: 'parse_csv', status: 'pending' }
+            ]
+            records = records.select { |r| r[:status] == status } if status
+            records
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry', registry)
+      end
+
+      it 'outputs all records' do
+        output = capture_stdout { described_class.start(%w[list]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data].size).to eq(2)
+      end
+
+      it 'filters by status' do
+        output = capture_stdout { described_class.start(%w[list --status approved]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data].size).to eq(1)
+        expect(parsed[:data].first[:name]).to eq('fetch_weather')
+      end
+    end
+
+    context 'when GeneratedRegistry is not available' do
+      before { hide_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry') }
+
+      it 'outputs error' do
+        output = capture_stdout { described_class.start(%w[list]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:error]).to eq('codegen registry not available')
+      end
+    end
+  end
+
+  describe '#show' do
+    context 'when GeneratedRegistry is available' do
+      before do
+        registry = Module.new do
+          def self.get(id:)
+            return { id: id, name: 'fetch_weather', status: 'approved' } if id == 'gen_001'
+
+            nil
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry', registry)
+      end
+
+      it 'returns the record for a valid id' do
+        output = capture_stdout { described_class.start(%w[show gen_001]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data][:id]).to eq('gen_001')
+        expect(parsed[:data][:name]).to eq('fetch_weather')
+      end
+
+      it 'returns error for unknown id' do
+        output = capture_stdout { described_class.start(%w[show nonexistent]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:error]).to eq('not found')
+      end
+    end
+
+    context 'when GeneratedRegistry is not available' do
+      before { hide_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry') }
+
+      it 'outputs error' do
+        output = capture_stdout { described_class.start(%w[show gen_001]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:error]).to eq('codegen registry not available')
+      end
+    end
+  end
+
+  describe '#approve' do
+    context 'when ReviewHandler is available' do
+      before do
+        handler = Module.new do
+          def self.handle_verdict(review:)
+            { generation_id: review[:generation_id], status: 'approved' }
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Runners::ReviewHandler', handler)
+      end
+
+      it 'calls handle_verdict with approve and returns result' do
+        output = capture_stdout { described_class.start(%w[approve gen_001]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data][:status]).to eq('approved')
+        expect(parsed[:data][:generation_id]).to eq('gen_001')
+      end
+    end
+
+    context 'when ReviewHandler is not available' do
+      before { hide_const('Legion::Extensions::Codegen::Runners::ReviewHandler') }
+
+      it 'outputs error' do
+        output = capture_stdout { described_class.start(%w[approve gen_001]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:error]).to eq('review handler not available')
+      end
+    end
+  end
+
+  describe '#reject' do
+    context 'when GeneratedRegistry is available' do
+      before do
+        registry = Module.new do
+          def self.update_status(id:, status:)
+            { id: id, status: status }
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry', registry)
+      end
+
+      it 'updates status to rejected' do
+        output = capture_stdout { described_class.start(%w[reject gen_001]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data][:id]).to eq('gen_001')
+        expect(parsed[:data][:status]).to eq('rejected')
+      end
+    end
+
+    context 'when GeneratedRegistry is not available' do
+      before { hide_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry') }
+
+      it 'outputs error' do
+        output = capture_stdout { described_class.start(%w[reject gen_001]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:error]).to eq('codegen registry not available')
+      end
+    end
+  end
+
+  describe '#retry' do
+    context 'when GeneratedRegistry is available' do
+      before do
+        registry = Module.new do
+          def self.update_status(id:, status:)
+            { id: id, status: status }
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry', registry)
+      end
+
+      it 'updates status to pending' do
+        output = capture_stdout { described_class.start(%w[retry gen_001]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data][:id]).to eq('gen_001')
+        expect(parsed[:data][:status]).to eq('pending')
+      end
+    end
+
+    context 'when GeneratedRegistry is not available' do
+      before { hide_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry') }
+
+      it 'outputs error' do
+        output = capture_stdout { described_class.start(%w[retry gen_001]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:error]).to eq('codegen registry not available')
+      end
+    end
+  end
+
+  describe '#gaps' do
+    context 'when GapDetector is available' do
+      before do
+        detector = Module.new do
+          def self.detect_gaps
+            [
+              { gap_id: 'gap_1', gap_type: :unmatched_intent, intent: 'fetch weather', priority: 0.8 },
+              { gap_id: 'gap_2', gap_type: :frequent_failure, intent: 'parse csv', priority: 0.6 }
+            ]
+          end
+        end
+        stub_const('Legion::MCP::GapDetector', detector)
+      end
+
+      it 'outputs detected gaps' do
+        output = capture_stdout { described_class.start(%w[gaps]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data].size).to eq(2)
+      end
+
+      it 'includes gap details' do
+        output = capture_stdout { described_class.start(%w[gaps]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data].first[:gap_id]).to eq('gap_1')
+      end
+    end
+
+    context 'when GapDetector is not available' do
+      before { hide_const('Legion::MCP::GapDetector') }
+
+      it 'outputs error' do
+        output = capture_stdout { described_class.start(%w[gaps]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:error]).to eq('gap detector not available')
+      end
+    end
+  end
+
+  describe '#cycle' do
+    context 'when SelfGenerate is available' do
+      before do
+        self_gen = Module.new do
+          def self.run_cycle
+            { triggered: true, gaps_processed: 2 }
+          end
+        end
+        stub_const('Legion::MCP::SelfGenerate', self_gen)
+        allow(Legion::MCP::SelfGenerate).to receive(:instance_variable_set)
+      end
+
+      it 'triggers a cycle and returns result' do
+        output = capture_stdout { described_class.start(%w[cycle]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:data][:triggered]).to eq(true)
+        expect(parsed[:data][:gaps_processed]).to eq(2)
+      end
+
+      it 'resets cooldown before running' do
+        expect(Legion::MCP::SelfGenerate).to receive(:instance_variable_set).with(:@last_cycle_at, nil)
+        capture_stdout { described_class.start(%w[cycle]) }
+      end
+    end
+
+    context 'when SelfGenerate is not available' do
+      before { hide_const('Legion::MCP::SelfGenerate') }
+
+      it 'outputs error' do
+        output = capture_stdout { described_class.start(%w[cycle]) }
+        parsed = JSON.parse(output, symbolize_names: true)
+        expect(parsed[:error]).to eq('self_generate not available')
+      end
+    end
+  end
+end

--- a/spec/legion/service_spec.rb
+++ b/spec/legion/service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/service'
+
+RSpec.describe Legion::Service do
+  describe '#setup_generated_functions' do
+    subject(:service) { described_class.allocate }
+
+    context 'when GeneratedRegistry is defined' do
+      before do
+        registry = Module.new do
+          def self.load_on_boot
+            3
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry', registry)
+      end
+
+      it 'calls load_on_boot' do
+        expect(Legion::Extensions::Codegen::Helpers::GeneratedRegistry).to receive(:load_on_boot).and_return(3)
+        service.setup_generated_functions
+      end
+
+      it 'returns without error when load_on_boot returns zero' do
+        allow(Legion::Extensions::Codegen::Helpers::GeneratedRegistry).to receive(:load_on_boot).and_return(0)
+        expect { service.setup_generated_functions }.not_to raise_error
+      end
+    end
+
+    context 'when GeneratedRegistry is not defined' do
+      before { hide_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry') }
+
+      it 'returns without error' do
+        expect { service.setup_generated_functions }.not_to raise_error
+      end
+    end
+
+    context 'when load_on_boot raises an error' do
+      before do
+        registry = Module.new do
+          def self.load_on_boot
+            raise StandardError, 'database unavailable'
+          end
+        end
+        stub_const('Legion::Extensions::Codegen::Helpers::GeneratedRegistry', registry)
+      end
+
+      it 'rescues the error and does not propagate' do
+        expect { service.setup_generated_functions }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add 22 specs for `legion codegen` CLI subcommand (all 8 subcommands with available/unavailable guards)
- Add 20 specs for `/api/codegen/*` API routes (503/200/404 status codes, rack/test patterns)
- Add 4 specs for `setup_generated_functions` boot loading in Service (defined/undefined/error cases)
- 46 new examples, 0 failures

## Test plan
- [x] `bundle exec rspec spec/legion/cli/codegen_command_spec.rb` — 22 examples, 0 failures
- [x] `bundle exec rspec spec/legion/api/codegen_spec.rb` — 20 examples, 0 failures
- [x] `bundle exec rspec spec/legion/service_spec.rb` — 4 examples, 0 failures
- [x] `bundle exec rspec` full suite — 3658 examples, 1 pre-existing failure (unrelated)
- [x] `bundle exec rubocop` — 0 offenses on new files