### PR TITLE
wire digital worker heartbeat, orphan detection, consent sync, SSE events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [1.6.13] - 2026-03-27
+
+### Added
+- `DigitalWorker.heartbeat` method for updating worker health status and last heartbeat timestamp
+- `DigitalWorker.detect_orphans` method to find workers with stale or nil heartbeats
+- `DigitalWorker.pause_orphans!` method to auto-pause orphaned workers with event emission
+- Consent tier sync on lifecycle transitions: `worker.update` now includes `consent_tier` from `CONSENT_MAPPING`
+- `Lifecycle.sync_consent_tier` calls `lex-consent` runner when available, graceful degradation when not
+- Per-worker SSE events at `/api/workers/:id/events?stream=true` with queue-per-client filtering
+- Polling fallback for per-worker events via ring buffer filtering (default mode)
+
 ## [1.6.11] - 2026-03-26
 
 ### Added

--- a/lib/legion/api/workers.rb
+++ b/lib/legion/api/workers.rb
@@ -120,7 +120,7 @@ module Legion
           end
         end
 
-        def self.register_sub_resources(app) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        def self.register_sub_resources(app) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           app.get '/api/workers/:id/health' do
             require_data!
             worker = Legion::Data::Model::DigitalWorker.first(worker_id: params[:id])
@@ -155,11 +155,39 @@ module Legion
             worker = Legion::Data::Model::DigitalWorker.first(worker_id: params[:id])
             halt 404, json_error('not_found', "Worker #{params[:id]} not found", status_code: 404) if worker.nil?
 
-            json_response({
-                            worker_id: params[:id],
-                            events:    [],
-                            note:      'lifecycle event persistence is not yet implemented'
-                          })
+            if params[:stream] == 'true' && defined?(Legion::Events)
+              content_type 'text/event-stream'
+              headers 'Cache-Control'     => 'no-cache',
+                      'Connection'        => 'keep-alive',
+                      'X-Accel-Buffering' => 'no'
+
+              queue = Queue.new
+              listener = Legion::Events.on('*') do |event|
+                queue.push(event) if event[:worker_id] == params[:id]
+              end
+
+              stream do |out|
+                Thread.new do
+                  loop do
+                    event = queue.pop
+                    data = Legion::JSON.dump({ **event.transform_keys(&:to_s) })
+                    out << "event: #{event[:event]}\ndata: #{data}\n\n"
+                  rescue IOError, Errno::EPIPE
+                    break
+                  end
+                ensure
+                  Legion::Events.off('*', listener)
+                end
+
+                out.callback { Legion::Events.off('*', listener) }
+                out.errback { Legion::Events.off('*', listener) }
+              end
+            else
+              count = (params[:count] || 25).to_i
+              all_events = Routes::Events.recent_events([count * 4, 100].min)
+              filtered = all_events.select { |e| e['worker_id'] == params[:id] || e[:worker_id] == params[:id] }
+              json_response({ worker_id: params[:id], events: filtered.last(count) })
+            end
           end
 
           app.get '/api/workers/:id/costs' do

--- a/lib/legion/digital_worker.rb
+++ b/lib/legion/digital_worker.rb
@@ -43,6 +43,48 @@ module Legion
         Legion::Data::Model::DigitalWorker.where(team: team)
       end
 
+      def heartbeat(worker_id:, health_status: 'healthy', health_node: nil)
+        worker = Legion::Data::Model::DigitalWorker.first(worker_id: worker_id)
+        return nil unless worker
+
+        updates = { last_heartbeat_at: Time.now.utc, health_status: health_status }
+        updates[:health_node] = health_node if health_node
+        worker.update(updates)
+        worker
+      end
+
+      def detect_orphans(stale_days: 7)
+        cutoff = Time.now.utc - (stale_days * 86_400)
+        active = Legion::Data::Model::DigitalWorker.where(lifecycle_state: 'active')
+        active.all.select do |w|
+          w.last_heartbeat_at.nil? || w.last_heartbeat_at < cutoff
+        end
+      end
+
+      def pause_orphans!(stale_days: 7, by: 'system:orphan_detection')
+        orphans = detect_orphans(stale_days: stale_days)
+        orphans.each do |worker|
+          Lifecycle.transition!(
+            worker,
+            to_state:           'paused',
+            by:                 by,
+            reason:             "no heartbeat for #{stale_days}+ days",
+            authority_verified: true
+          )
+          if defined?(Legion::Events)
+            Legion::Events.emit('worker.orphan_detected', {
+                                  worker_id:         worker.worker_id,
+                                  owner_msid:        worker.owner_msid,
+                                  last_heartbeat_at: worker.last_heartbeat_at,
+                                  at:                Time.now.utc
+                                })
+          end
+        rescue Lifecycle::InvalidTransition => e
+          Legion::Logging.debug("[OrphanDetection] skip #{worker.worker_id}: #{e.message}") if defined?(Legion::Logging)
+        end
+        orphans
+      end
+
       def active_local_ids
         return [] unless defined?(Registry)
 

--- a/lib/legion/digital_worker/lifecycle.rb
+++ b/lib/legion/digital_worker/lifecycle.rb
@@ -107,13 +107,16 @@ module Legion
           end
         end
 
+        new_consent = CONSENT_MAPPING[to_state]
         worker.update(
           lifecycle_state: to_state,
+          consent_tier:    new_consent ? new_consent.to_s : worker.consent_tier,
           updated_at:      Time.now.utc,
           retired_at:      %w[retired terminated].include?(to_state) ? Time.now.utc : worker.retired_at,
           retired_by:      %w[retired terminated].include?(to_state) ? by : worker.retired_by,
           retired_reason:  reason || worker.retired_reason
         )
+        sync_consent_tier(worker, new_consent) if new_consent
 
         if defined?(Legion::Events)
           Legion::Events.emit('worker.lifecycle', {
@@ -167,6 +170,18 @@ module Legion
       def self.consent_tier(state)
         CONSENT_MAPPING.fetch(state, :consult)
       end
+
+      def self.sync_consent_tier(worker, tier)
+        return unless defined?(Legion::Extensions::Consent::Runners::Consent)
+
+        Legion::Extensions::Consent::Runners::Consent.update_tier(
+          worker_id: worker.worker_id,
+          tier:      tier.to_s
+        )
+      rescue StandardError => e
+        Legion::Logging.debug("[Lifecycle] consent sync failed for #{worker.worker_id}: #{e.message}") if defined?(Legion::Logging)
+      end
+      private_class_method :sync_consent_tier
     end
   end
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.6.12'
+  VERSION = '1.6.13'
 end

--- a/spec/legion/digital_worker/consent_sync_spec.rb
+++ b/spec/legion/digital_worker/consent_sync_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/digital_worker/lifecycle'
+
+RSpec.describe Legion::DigitalWorker::Lifecycle, 'consent sync' do
+  let(:worker) do
+    double('Worker',
+           lifecycle_state: 'active',
+           worker_id:       'w1',
+           consent_tier:    'autonomous',
+           retired_at:      nil,
+           retired_by:      nil,
+           retired_reason:  nil,
+           owner_msid:      'owner@example.com',
+           update:          true)
+  end
+
+  before do
+    hide_const('Legion::Events') if defined?(Legion::Events)
+    hide_const('Legion::Audit') if defined?(Legion::Audit)
+    hide_const('Legion::Extensions::Governance') if defined?(Legion::Extensions::Governance)
+    hide_const('Legion::Extensions::Extinction') if defined?(Legion::Extensions::Extinction)
+    hide_const('Legion::Extensions::Consent') if defined?(Legion::Extensions::Consent)
+  end
+
+  describe 'consent tier update on transition' do
+    it 'sets consent_tier to consult when paused' do
+      expect(worker).to receive(:update).with(hash_including(consent_tier: 'consult'))
+      described_class.transition!(worker, to_state: 'paused', by: 'owner1', authority_verified: true)
+    end
+
+    it 'sets consent_tier to inform when retired' do
+      expect(worker).to receive(:update).with(hash_including(consent_tier: 'inform'))
+      described_class.transition!(worker, to_state: 'retired', by: 'owner1', authority_verified: true)
+    end
+
+    it 'sets consent_tier to inform when terminated' do
+      expect(worker).to receive(:update).with(hash_including(consent_tier: 'inform'))
+      described_class.transition!(worker, to_state: 'terminated', by: 'admin', governance_override: true)
+    end
+  end
+
+  describe 'lex-consent sync when available' do
+    let(:consent_runner) { Module.new }
+
+    before do
+      stub_const('Legion::Extensions::Consent::Runners::Consent', consent_runner)
+    end
+
+    it 'calls update_tier on lex-consent runner' do
+      allow(worker).to receive(:update)
+      expect(consent_runner).to receive(:update_tier).with(worker_id: 'w1', tier: 'consult')
+      described_class.transition!(worker, to_state: 'paused', by: 'owner1', authority_verified: true)
+    end
+
+    it 'does not raise when consent sync fails' do
+      allow(worker).to receive(:update)
+      allow(consent_runner).to receive(:update_tier).and_raise(StandardError, 'consent unavailable')
+      expect do
+        described_class.transition!(worker, to_state: 'paused', by: 'owner1', authority_verified: true)
+      end.not_to raise_error
+    end
+  end
+
+  describe 'without lex-consent loaded' do
+    it 'transitions normally without consent sync' do
+      allow(worker).to receive(:update)
+      expect do
+        described_class.transition!(worker, to_state: 'paused', by: 'owner1', authority_verified: true)
+      end.not_to raise_error
+    end
+  end
+end

--- a/spec/legion/digital_worker/heartbeat_spec.rb
+++ b/spec/legion/digital_worker/heartbeat_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+unless defined?(Legion::Data::Model::DigitalWorker)
+  module Legion
+    module Data
+      module Model
+        class DigitalWorker; end # rubocop:disable Lint/EmptyClass
+      end
+    end
+  end
+end
+
+require 'legion/digital_worker'
+
+RSpec.describe Legion::DigitalWorker do
+  describe '.heartbeat' do
+    let(:worker) { double('Worker', worker_id: 'w1') }
+
+    it 'updates last_heartbeat_at and health_status' do
+      allow(Legion::Data::Model::DigitalWorker).to receive(:first).with(worker_id: 'w1').and_return(worker)
+      expect(worker).to receive(:update).with(hash_including(
+                                                health_status:     'healthy',
+                                                last_heartbeat_at: an_instance_of(Time)
+                                              ))
+      described_class.heartbeat(worker_id: 'w1')
+    end
+
+    it 'includes health_node when provided' do
+      allow(Legion::Data::Model::DigitalWorker).to receive(:first).with(worker_id: 'w1').and_return(worker)
+      expect(worker).to receive(:update).with(hash_including(health_node: 'node-1'))
+      described_class.heartbeat(worker_id: 'w1', health_node: 'node-1')
+    end
+
+    it 'accepts custom health_status' do
+      allow(Legion::Data::Model::DigitalWorker).to receive(:first).with(worker_id: 'w1').and_return(worker)
+      expect(worker).to receive(:update).with(hash_including(health_status: 'degraded'))
+      described_class.heartbeat(worker_id: 'w1', health_status: 'degraded')
+    end
+
+    it 'returns nil when worker not found' do
+      allow(Legion::Data::Model::DigitalWorker).to receive(:first).with(worker_id: 'missing').and_return(nil)
+      expect(described_class.heartbeat(worker_id: 'missing')).to be_nil
+    end
+  end
+
+  describe '.detect_orphans' do
+    let(:stale_worker) do
+      double('Worker', worker_id: 'w-stale', lifecycle_state: 'active',
+                       last_heartbeat_at: Time.now.utc - 864_000, owner_msid: 'user1')
+    end
+    let(:nil_heartbeat_worker) do
+      double('Worker', worker_id: 'w-nil', lifecycle_state: 'active',
+                       last_heartbeat_at: nil, owner_msid: 'user2')
+    end
+    let(:healthy_worker) do
+      double('Worker', worker_id: 'w-ok', lifecycle_state: 'active',
+                       last_heartbeat_at: Time.now.utc, owner_msid: 'user3')
+    end
+    let(:dataset) { double('dataset') }
+
+    before do
+      allow(Legion::Data::Model::DigitalWorker).to receive(:where)
+        .with(lifecycle_state: 'active').and_return(dataset)
+      allow(dataset).to receive(:all).and_return([stale_worker, nil_heartbeat_worker, healthy_worker])
+    end
+
+    it 'returns workers with stale or nil heartbeats' do
+      orphans = described_class.detect_orphans(stale_days: 7)
+      expect(orphans).to contain_exactly(stale_worker, nil_heartbeat_worker)
+    end
+
+    it 'respects custom stale_days' do
+      orphans = described_class.detect_orphans(stale_days: 20)
+      expect(orphans.map(&:worker_id)).to include('w-nil')
+    end
+
+    it 'excludes healthy workers' do
+      orphans = described_class.detect_orphans(stale_days: 7)
+      expect(orphans.map(&:worker_id)).not_to include('w-ok')
+    end
+  end
+
+  describe '.pause_orphans!' do
+    let(:stale_worker) do
+      double('Worker', worker_id: 'w-stale', lifecycle_state: 'active',
+                       last_heartbeat_at: nil, owner_msid: 'user1',
+                       retired_at: nil, retired_by: nil, retired_reason: nil)
+    end
+    let(:dataset) { double('dataset') }
+
+    before do
+      allow(Legion::Data::Model::DigitalWorker).to receive(:where)
+        .with(lifecycle_state: 'active').and_return(dataset)
+      allow(dataset).to receive(:all).and_return([stale_worker])
+      hide_const('Legion::Events') if defined?(Legion::Events)
+      hide_const('Legion::Audit') if defined?(Legion::Audit)
+      hide_const('Legion::Extensions::Governance') if defined?(Legion::Extensions::Governance)
+    end
+
+    it 'transitions orphaned workers to paused' do
+      expect(stale_worker).to receive(:update).with(hash_including(lifecycle_state: 'paused'))
+      described_class.pause_orphans!(stale_days: 7)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `DigitalWorker.heartbeat`, `.detect_orphans`, `.pause_orphans!` methods for worker health monitoring
- Wire consent tier sync into `Lifecycle.transition!` — updates `consent_tier` field and optionally calls lex-consent runner
- Replace per-worker events stub at `/api/workers/:id/events` with dual-mode SSE streaming (`?stream=true`) and polling fallback via ring buffer
- 14 new spec examples (heartbeat_spec.rb + consent_sync_spec.rb), full suite: 3717 examples, 0 failures
- Bump to v1.6.13

## Test plan
- [x] `bundle exec rspec` — 3717 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] New specs cover heartbeat updates, orphan detection, pause transitions, consent tier mapping, lex-consent sync, and graceful degradation