### PR TITLE
add max-classification compliance profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [1.6.14] - 2026-03-27
+
+### Added
+- `Legion::Compliance` module rewritten with DEFAULTS hash, `merge_settings` registration, and clean API
+- `Compliance.setup` registers max-classification defaults: PHI, PCI, PII, FedRAMP all enabled by default
+- `Compliance.enabled?`, `.phi_enabled?`, `.pci_enabled?`, `.pii_enabled?`, `.fedramp_enabled?` convenience methods
+- `Compliance.classification_level` returns `'confidential'` by default (highest level)
+- `Compliance.profile` returns a hash with all compliance flags for downstream consumers
+- `setup_compliance` wired into Service boot sequence after settings load
+- Compliance profile spec (8 examples)
+
+### Changed
+- `Compliance.phi_enabled?` now uses `Settings.dig(:compliance, :phi_enabled)` instead of chaining `[]` calls
+- Existing PhiTag and PhiAccessLog specs updated to use `merge_settings` instead of stubbing `Settings.[]`
+
 ## [1.6.13] - 2026-03-27
 
 ### Added

--- a/lib/legion/compliance.rb
+++ b/lib/legion/compliance.rb
@@ -6,13 +6,69 @@ require 'legion/compliance/phi_erasure'
 
 module Legion
   module Compliance
-    class << self
-      def phi_enabled?
-        return false unless defined?(Legion::Settings)
+    DEFAULTS = {
+      enabled:              true,
+      classification_level: 'confidential',
+      phi_enabled:          true,
+      pci_enabled:          true,
+      pii_enabled:          true,
+      fedramp_enabled:      true,
+      log_redaction:        true,
+      cache_phi_max_ttl:    3600
+    }.freeze
 
-        Legion::Settings[:compliance][:phi_enabled] == true
+    class << self
+      def setup
+        return unless defined?(Legion::Settings)
+
+        Legion::Settings.merge_settings(:compliance, DEFAULTS)
+        Legion::Logging.info('[Compliance] max-classification profile active') if defined?(Legion::Logging)
+      end
+
+      def enabled?
+        setting(:enabled) == true
+      end
+
+      def phi_enabled?
+        setting(:phi_enabled) == true
+      end
+
+      def pci_enabled?
+        setting(:pci_enabled) == true
+      end
+
+      def pii_enabled?
+        setting(:pii_enabled) == true
+      end
+
+      def fedramp_enabled?
+        setting(:fedramp_enabled) == true
+      end
+
+      def classification_level
+        setting(:classification_level) || 'confidential'
+      end
+
+      def profile
+        {
+          classification_level: classification_level,
+          phi:                  phi_enabled?,
+          pci:                  pci_enabled?,
+          pii:                  pii_enabled?,
+          fedramp:              fedramp_enabled?,
+          log_redaction:        setting(:log_redaction) == true,
+          cache_phi_max_ttl:    setting(:cache_phi_max_ttl) || 3600
+        }
+      end
+
+      private
+
+      def setting(key)
+        return nil unless defined?(Legion::Settings)
+
+        Legion::Settings.dig(:compliance, key)
       rescue StandardError
-        false
+        nil
       end
     end
   end

--- a/lib/legion/service.rb
+++ b/lib/legion/service.rb
@@ -31,6 +31,7 @@ module Legion
       Legion::Logging.debug('Starting Legion::Service')
       setup_settings
       apply_cli_overrides(http_port: http_port)
+      setup_compliance
       setup_local_mode
       reconfigure_logging(log_level)
       Legion::Logging.info("node name: #{Legion::Settings[:client][:name]}")
@@ -223,6 +224,15 @@ module Legion
       Legion::Readiness.mark_ready(:settings)
       Legion::Logging.info('Legion::Settings Loaded')
       self.class.log_privacy_mode_status
+    end
+
+    def setup_compliance
+      require 'legion/compliance'
+      Legion::Compliance.setup
+    rescue LoadError => e
+      Legion::Logging.debug "Compliance module not available: #{e.message}"
+    rescue StandardError => e
+      Legion::Logging.warn "Compliance setup failed: #{e.message}"
     end
 
     def apply_cli_overrides(http_port: nil)

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.6.13'
+  VERSION = '1.6.14'
 end

--- a/spec/legion/compliance/phi_access_log_spec.rb
+++ b/spec/legion/compliance/phi_access_log_spec.rb
@@ -5,7 +5,7 @@ require 'legion/compliance'
 
 RSpec.describe Legion::Compliance::PhiAccessLog do
   before do
-    allow(Legion::Settings).to receive(:[]).with(:compliance).and_return({ phi_enabled: true })
+    Legion::Settings.merge_settings(:compliance, Legion::Compliance::DEFAULTS)
   end
 
   describe '.log_access' do
@@ -49,7 +49,7 @@ RSpec.describe Legion::Compliance::PhiAccessLog do
 
     context 'when phi_enabled is false' do
       before do
-        allow(Legion::Settings).to receive(:[]).with(:compliance).and_return({ phi_enabled: false })
+        allow(Legion::Compliance).to receive(:phi_enabled?).and_return(false)
         stub_const('Legion::Audit', Module.new)
         allow(Legion::Audit).to receive(:record)
       end

--- a/spec/legion/compliance/phi_tag_spec.rb
+++ b/spec/legion/compliance/phi_tag_spec.rb
@@ -5,7 +5,7 @@ require 'legion/compliance'
 
 RSpec.describe Legion::Compliance::PhiTag do
   before do
-    allow(Legion::Settings).to receive(:[]).with(:compliance).and_return({ phi_enabled: true })
+    Legion::Settings.merge_settings(:compliance, Legion::Compliance::DEFAULTS)
   end
 
   describe '.phi?' do
@@ -53,7 +53,7 @@ RSpec.describe Legion::Compliance::PhiTag do
 
   describe 'feature flag' do
     it 'returns false from phi? when phi_enabled is false' do
-      allow(Legion::Settings).to receive(:[]).with(:compliance).and_return({ phi_enabled: false })
+      allow(Legion::Compliance).to receive(:phi_enabled?).and_return(false)
       expect(described_class.phi?(phi: true)).to be false
     end
   end

--- a/spec/legion/compliance/profile_spec.rb
+++ b/spec/legion/compliance/profile_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/compliance'
+
+RSpec.describe Legion::Compliance do
+  before do
+    described_class.setup
+  end
+
+  describe '.setup' do
+    it 'registers compliance defaults' do
+      expect(Legion::Settings.dig(:compliance, :enabled)).to eq(true)
+    end
+  end
+
+  describe '.enabled?' do
+    it 'returns true by default' do
+      expect(described_class.enabled?).to be true
+    end
+  end
+
+  describe '.phi_enabled?' do
+    it 'returns true by default' do
+      expect(described_class.phi_enabled?).to be true
+    end
+  end
+
+  describe '.pci_enabled?' do
+    it 'returns true by default' do
+      expect(described_class.pci_enabled?).to be true
+    end
+  end
+
+  describe '.pii_enabled?' do
+    it 'returns true by default' do
+      expect(described_class.pii_enabled?).to be true
+    end
+  end
+
+  describe '.fedramp_enabled?' do
+    it 'returns true by default' do
+      expect(described_class.fedramp_enabled?).to be true
+    end
+  end
+
+  describe '.classification_level' do
+    it 'returns confidential by default' do
+      expect(described_class.classification_level).to eq('confidential')
+    end
+  end
+
+  describe '.profile' do
+    it 'returns a hash with all compliance flags' do
+      profile = described_class.profile
+      expect(profile[:classification_level]).to eq('confidential')
+      expect(profile[:phi]).to be true
+      expect(profile[:pci]).to be true
+      expect(profile[:pii]).to be true
+      expect(profile[:fedramp]).to be true
+      expect(profile[:log_redaction]).to be true
+      expect(profile[:cache_phi_max_ttl]).to eq(3600)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Rewrite `Legion::Compliance` with `DEFAULTS` hash and `merge_settings` registration
- All protections enabled by default: PHI, PCI, PII, FedRAMP — single max-classification, no tiers
- `classification_level` defaults to `'confidential'` (highest level)
- `setup_compliance` wired into Service boot after settings load
- Clean API: `.enabled?`, `.phi_enabled?`, `.pci_enabled?`, `.pii_enabled?`, `.fedramp_enabled?`, `.classification_level`, `.profile`
- Companion PR: legion-llm#14 (auto-enables classification step when compliance profile is active)
- Bump to v1.6.14

## Test plan
- [x] `bundle exec rspec` — 3725 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] New compliance profile spec (8 examples)
- [x] Updated PhiTag and PhiAccessLog specs to use `merge_settings` pattern