### PR TITLE
route legion chat LLM requests through daemon (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [1.6.22] - 2026-03-27
+
+### Added
+- `POST /api/llm/inference` daemon endpoint: accepts a full messages array plus optional tool schemas, runs a single LLM completion pass, and returns `{ content, tool_calls, stop_reason, model, input_tokens, output_tokens }` — the client owns the tool execution loop
+- `Legion::CLI::Chat::DaemonChat` adapter: drop-in replacement for the `RubyLLM::Chat` object that routes all inference through the daemon, executes tool calls locally, and loops until the LLM produces a final text response
+- `spec/legion/api/llm_inference_spec.rb`: 12 examples covering the new `/api/llm/inference` endpoint
+- `spec/legion/cli/chat/daemon_chat_spec.rb`: 25 examples covering `DaemonChat` initialization, tool registration, tool execution loop, streaming, and error handling
+
+### Changed
+- `legion chat setup_connection`: replaced `Connection.ensure_llm` (local LLM boot) with a daemon availability check via `Legion::LLM::DaemonClient.available?` — **hard fails with a descriptive error if the daemon is not running**
+- `legion chat create_chat`: now returns a `DaemonChat` instance instead of a direct `RubyLLM::Chat` object; all LLM calls route through the daemon
+
 ## [1.6.21] - 2026-03-27
 
 ### Added

--- a/lib/legion/api/llm.rb
+++ b/lib/legion/api/llm.rb
@@ -43,6 +43,8 @@ module Legion
         end
 
         def self.register_chat(app) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+          register_inference(app)
+
           app.post '/api/llm/chat' do # rubocop:disable Metrics/BlockLength
             Legion::Logging.debug "API: POST /api/llm/chat params=#{params.keys}"
             require_llm!
@@ -163,6 +165,75 @@ module Legion
           end
         end
 
+        def self.register_inference(app) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+          app.post '/api/llm/inference' do # rubocop:disable Metrics/BlockLength
+            require_llm!
+            body = parse_request_body
+            validate_required!(body, :messages)
+
+            messages = body[:messages]
+            tools    = body[:tools] || []
+            model    = body[:model]
+            provider = body[:provider]
+
+            unless messages.is_a?(Array)
+              halt 400, { 'Content-Type' => 'application/json' },
+                   Legion::JSON.dump({ error: { code: 'invalid_messages', message: 'messages must be an array' } })
+            end
+
+            session = Legion::LLM.chat(
+              model:    model,
+              provider: provider,
+              caller:   { source: 'api', path: request.path }
+            )
+
+            unless tools.empty?
+              tool_declarations = tools.map do |t|
+                ts = t.respond_to?(:transform_keys) ? t.transform_keys(&:to_sym) : t
+                tname = ts[:name].to_s
+                tdesc = ts[:description].to_s
+                tparams = ts[:parameters] || {}
+                Class.new do
+                  define_singleton_method(:tool_name) { tname }
+                  define_singleton_method(:description)  { tdesc }
+                  define_singleton_method(:parameters)   { tparams }
+                  define_method(:call) { |**_| raise NotImplementedError, "#{tname} executes client-side only" }
+                end
+              end
+              session.with_tools(*tool_declarations)
+            end
+
+            messages.each { |m| session.add_message(m) }
+
+            last_user = messages.select { |m| (m[:role] || m['role']).to_s == 'user' }.last
+            prompt    = (last_user || {})[:content] || (last_user || {})['content'] || ''
+
+            response = session.ask(prompt)
+
+            tc_list = if response.respond_to?(:tool_calls) && response.tool_calls
+                        Array(response.tool_calls).map do |tc|
+                          {
+                            id:        tc.respond_to?(:id) ? tc.id : nil,
+                            name:      tc.respond_to?(:name) ? tc.name : tc.to_s,
+                            arguments: tc.respond_to?(:arguments) ? tc.arguments : {}
+                          }
+                        end
+                      end
+
+            json_response({
+                            content:       response.content,
+                            tool_calls:    tc_list,
+                            stop_reason:   response.respond_to?(:stop_reason) ? response.stop_reason : nil,
+                            model:         session.model.to_s,
+                            input_tokens:  response.respond_to?(:input_tokens) ? response.input_tokens : nil,
+                            output_tokens: response.respond_to?(:output_tokens) ? response.output_tokens : nil
+                          }, status_code: 200)
+          rescue StandardError => e
+            Legion::Logging.error "[api/llm/inference] #{e.class}: #{e.message}" if defined?(Legion::Logging)
+            json_response({ error: { code: 'inference_error', message: e.message } }, status_code: 500)
+          end
+        end
+
         def self.register_providers(app)
           app.get '/api/llm/providers' do
             require_llm!
@@ -190,7 +261,7 @@ module Legion
         end
 
         class << self
-          private :register_chat, :register_providers
+          private :register_chat, :register_inference, :register_providers
         end
       end
     end

--- a/lib/legion/cli/chat/daemon_chat.rb
+++ b/lib/legion/cli/chat/daemon_chat.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require 'legion/cli/chat_command'
+
+begin
+  require 'legion/llm/daemon_client'
+rescue LoadError
+  # legion-llm not yet loaded; DaemonClient must be defined before DaemonChat#ask is called.
+end
+
+module Legion
+  module CLI
+    class Chat
+      # Daemon-backed chat adapter. Matches the interface that Session expects
+      # from a chat object (ask, with_tools, with_instructions, on_tool_call,
+      # on_tool_result, model, add_message, reset_messages!, with_model).
+      #
+      # All LLM inference is routed through the running daemon via
+      # POST /api/llm/inference. Tool execution runs locally on the client
+      # machine — the daemon returns tool_call requests and the client
+      # executes them and loops.
+      class DaemonChat
+        # Minimal response-like object returned from ask.
+        # Responds to the same interface Session#send_message reads.
+        Response = Struct.new(:content, :input_tokens, :output_tokens, :model)
+
+        # Minimal model object responding to .id (used by Session#model_id).
+        ModelInfo = Struct.new(:id) do
+          def to_s
+            id.to_s
+          end
+        end
+
+        attr_reader :model
+
+        def initialize(model: nil, provider: nil)
+          @model    = ModelInfo.new(id: model)
+          @provider = provider
+          @messages = []
+          @tools    = []
+          @instructions = nil
+          @on_tool_call   = nil
+          @on_tool_result = nil
+        end
+
+        # Sets the system prompt. Returns self for chaining.
+        def with_instructions(prompt)
+          @instructions = prompt
+          self
+        end
+
+        # Registers tool classes for local execution and schema forwarding.
+        # Returns self for chaining.
+        def with_tools(*tools)
+          @tools = tools.flatten
+          self
+        end
+
+        # Switches the active model. Returns self for chaining.
+        def with_model(model_id)
+          @model = ModelInfo.new(id: model_id)
+          self
+        end
+
+        # Stores a tool_call callback invoked before each local tool execution.
+        def on_tool_call(&block)
+          @on_tool_call = block
+        end
+
+        # Stores a tool_result callback invoked after each local tool execution.
+        def on_tool_result(&block)
+          @on_tool_result = block
+        end
+
+        # Appends a message to the conversation history directly (used by
+        # slash commands /fetch, /search, /agent, etc. that inject context).
+        def add_message(role:, content:)
+          @messages << { role: role.to_s, content: content }
+        end
+
+        # Clears all conversation history (used by /clear slash command).
+        def reset_messages!
+          @messages = []
+        end
+
+        # Sends a message through the daemon inference loop.
+        # Executes any tool_calls locally and loops until the LLM stops.
+        # Yields response-like chunks for streaming display (Phase 1: single chunk).
+        # Returns a Response object compatible with Session#send_message.
+        def ask(message, &on_chunk)
+          @messages << { role: 'user', content: message }
+
+          loop do
+            result = call_daemon_inference
+
+            raise CLI::Error, "Daemon inference error: #{result[:error]}" if result[:status] == :error
+            raise CLI::Error, 'Daemon is unavailable' if result[:status] == :unavailable
+
+            data = extract_data(result)
+
+            if data[:tool_calls]&.any?
+              execute_tool_calls(data[:tool_calls], data[:content])
+            else
+              on_chunk&.call(Response.new(content: data[:content]))
+              @messages << { role: 'assistant', content: data[:content] }
+              return build_response(data)
+            end
+          end
+        end
+
+        private
+
+        def call_daemon_inference
+          Legion::LLM::DaemonClient.inference(
+            messages: build_messages,
+            tools:    build_tool_schemas,
+            model:    @model.id,
+            provider: @provider
+          )
+        end
+
+        def extract_data(result)
+          # DaemonClient.inference returns { status:, data: { content:, tool_calls:, ... } }
+          data = result[:data] || result[:body] || {}
+          data.is_a?(Hash) ? data : {}
+        end
+
+        def build_messages
+          msgs = []
+          msgs << { role: 'system', content: @instructions } if @instructions
+          msgs + @messages
+        end
+
+        def build_tool_schemas
+          @tools.map do |tool|
+            {
+              name:        tool_name(tool),
+              description: tool_description(tool),
+              parameters:  tool_parameters(tool)
+            }
+          end
+        end
+
+        def tool_name(tool)
+          if tool.respond_to?(:tool_name)
+            tool.tool_name
+          else
+            tool.name.to_s.split('::').last.gsub(/([A-Z])/) do
+              "_#{::Regexp.last_match(1).downcase}"
+            end.delete_prefix('_')
+          end
+        end
+
+        def tool_description(tool)
+          tool.respond_to?(:description) ? tool.description : ''
+        end
+
+        def tool_parameters(tool)
+          tool.respond_to?(:parameters) ? tool.parameters : {}
+        end
+
+        def execute_tool_calls(tool_calls, assistant_content)
+          # Record the assistant turn with tool_calls before appending results.
+          @messages << { role: 'assistant', content: assistant_content, tool_calls: tool_calls }
+
+          tool_calls.each do |tc|
+            tc = tc.transform_keys(&:to_sym) if tc.respond_to?(:transform_keys)
+            tc_obj = build_tool_call_object(tc)
+
+            @on_tool_call&.call(tc_obj)
+
+            result_text = run_tool(tc)
+
+            result_obj = build_tool_result_object(result_text)
+            @on_tool_result&.call(result_obj)
+
+            @messages << {
+              role:         'tool',
+              tool_call_id: tc[:id] || tc[:tool_call_id],
+              content:      result_text.to_s
+            }
+          end
+        end
+
+        def build_tool_call_object(tool_call)
+          Struct.new(:name, :arguments, :id).new(
+            name:      tool_call[:name].to_s,
+            arguments: (tool_call[:arguments] || tool_call[:input] || {}).transform_keys(&:to_sym),
+            id:        tool_call[:id] || tool_call[:tool_call_id]
+          )
+        end
+
+        def build_tool_result_object(text)
+          Struct.new(:content).new(content: text.to_s)
+        end
+
+        def run_tool(tool_call)
+          name      = tool_call[:name].to_s
+          arguments = (tool_call[:arguments] || tool_call[:input] || {}).transform_keys(&:to_sym)
+
+          tool_class = @tools.find { |t| tool_name(t) == name }
+          return "Unknown tool: #{name}" unless tool_class
+
+          tool_class.call(**arguments)
+        rescue StandardError => e
+          "Tool error (#{name}): #{e.message}"
+        end
+
+        def build_response(data)
+          Response.new(
+            content:       data[:content],
+            input_tokens:  data[:input_tokens],
+            output_tokens: data[:output_tokens],
+            model:         ModelInfo.new(id: data[:model] || @model.id)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -176,7 +176,14 @@ module Legion
         def setup_connection
           Connection.config_dir = options[:config_dir] if options[:config_dir]
           Connection.log_level = options[:verbose] ? 'debug' : 'error'
-          Connection.ensure_llm
+          Connection.ensure_settings
+
+          require 'legion/llm/daemon_client'
+          return if Legion::LLM::DaemonClient.available?
+
+          raise CLI::Error,
+                "LegionIO daemon is not running. Start it with: legionio start\n  " \
+                'All LLM requests must route through the daemon.'
         end
 
         def setup_notification_bridge
@@ -237,13 +244,13 @@ module Legion
         end
 
         def create_chat
-          opts = {}
-          opts[:model]    = options[:model] || chat_setting(:model)
-          opts[:provider] = (options[:provider] || chat_setting(:provider))&.to_sym
-          opts.compact!
-
+          require 'legion/cli/chat/daemon_chat'
           require 'legion/cli/chat/tool_registry'
-          chat = Legion::LLM.chat(**opts, caller: { source: 'cli', command: 'chat' })
+
+          chat = Chat::DaemonChat.new(
+            model:    options[:model] || chat_setting(:model),
+            provider: (options[:provider] || chat_setting(:provider))&.to_sym
+          )
           chat.with_tools(*Chat::ToolRegistry.all_tools)
           chat
         end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.6.21'
+  VERSION = '1.6.22'
 end

--- a/spec/legion/api/llm_inference_spec.rb
+++ b/spec/legion/api/llm_inference_spec.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rack/test'
+require 'sinatra/base'
+require 'legion/api/helpers'
+require 'legion/api/validators'
+require 'legion/api/llm'
+
+RSpec.describe 'LLM inference API route' do
+  include Rack::Test::Methods
+
+  before(:all) do
+    Legion::Logging.setup(log_level: 'fatal', level: 'fatal', trace: false)
+    Legion::Settings.load(config_dir: File.expand_path('../../..', __dir__))
+    loader = Legion::Settings.loader
+    loader.settings[:client]    = { name: 'test-node', ready: true }
+    loader.settings[:data]      = { connected: false }
+    loader.settings[:transport] = { connected: false }
+    loader.settings[:extensions] = {}
+  end
+
+  let(:test_app) do
+    Class.new(Sinatra::Base) do
+      helpers Legion::API::Helpers
+      helpers Legion::API::Validators
+
+      set :show_exceptions, false
+      set :raise_errors, false
+      set :host_authorization, permitted: :any
+
+      register Legion::API::Routes::Llm
+    end
+  end
+
+  def app
+    test_app
+  end
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  def stub_llm_started
+    llm_mod = Module.new do
+      def self.started? = true
+    end
+    stub_const('Legion::LLM', llm_mod)
+  end
+
+  def stub_llm_chat_session(content: 'inference response', model_name: 'claude-sonnet-4-6',
+                            input_tokens: 10, output_tokens: 20)
+    fake_response = double('InferenceResponse',
+                           content:       content,
+                           input_tokens:  input_tokens,
+                           output_tokens: output_tokens)
+    # Stub all respond_to? checks the endpoint makes — pure doubles need explicit stubs
+    allow(fake_response).to receive(:respond_to?).with(:input_tokens).and_return(true)
+    allow(fake_response).to receive(:respond_to?).with(:output_tokens).and_return(true)
+    allow(fake_response).to receive(:respond_to?).with(:stop_reason).and_return(false)
+    allow(fake_response).to receive(:respond_to?).with(:tool_calls).and_return(false)
+
+    model_obj = double('ModelObj', to_s: model_name)
+
+    fake_session = double('ChatSession', model: model_obj)
+    allow(fake_session).to receive(:with_tools)
+    allow(fake_session).to receive(:add_message)
+    allow(fake_session).to receive(:ask).and_return(fake_response)
+
+    allow(Legion::LLM).to receive(:chat).and_return(fake_session)
+
+    [fake_session, fake_response]
+  end
+
+  # ── 503 when LLM not started ───────────────────────────────────────────────
+
+  describe 'POST /api/llm/inference — LLM unavailable' do
+    it 'returns 503 when Legion::LLM is not defined' do
+      post '/api/llm/inference',
+           Legion::JSON.dump({ messages: [{ role: 'user', content: 'hello' }] }),
+           'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(503)
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:error][:code]).to eq('llm_unavailable')
+    end
+
+    it 'returns 503 when Legion::LLM is defined but not started' do
+      llm_mod = Module.new { def self.started? = false }
+      stub_const('Legion::LLM', llm_mod)
+
+      post '/api/llm/inference',
+           Legion::JSON.dump({ messages: [{ role: 'user', content: 'hello' }] }),
+           'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(503)
+    end
+  end
+
+  # ── 400 when messages missing or invalid ───────────────────────────────────
+
+  describe 'POST /api/llm/inference — validation errors' do
+    before { stub_llm_started }
+
+    it 'returns 400 when messages field is absent' do
+      post '/api/llm/inference',
+           Legion::JSON.dump({ model: 'claude-sonnet-4-6' }),
+           'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:error][:code]).to eq('missing_fields')
+    end
+
+    it 'returns 400 when messages is not an array' do
+      post '/api/llm/inference',
+           Legion::JSON.dump({ messages: 'not an array' }),
+           'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(400)
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:error][:code]).to eq('invalid_messages')
+    end
+  end
+
+  # ── 200 success path ───────────────────────────────────────────────────────
+
+  describe 'POST /api/llm/inference — success' do
+    before { stub_llm_started }
+
+    it 'returns 200 with content and token counts' do
+      stub_llm_chat_session
+
+      post '/api/llm/inference',
+           Legion::JSON.dump({ messages: [{ role: 'user', content: 'hello' }] }),
+           'CONTENT_TYPE' => 'application/json'
+
+      expect(last_response.status).to eq(200)
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:data][:content]).to eq('inference response')
+      expect(body[:data][:input_tokens]).to eq(10)
+      expect(body[:data][:output_tokens]).to eq(20)
+    end
+
+    it 'forwards model and provider to Legion::LLM.chat' do
+      fake_session, = stub_llm_chat_session
+
+      expect(Legion::LLM).to receive(:chat).with(
+        hash_including(model: 'gpt-4o', provider: 'openai')
+      ).and_return(fake_session)
+
+      post '/api/llm/inference',
+           Legion::JSON.dump({
+                               messages: [{ role: 'user', content: 'test' }],
+                               model:    'gpt-4o',
+                               provider: 'openai'
+                             }),
+           'CONTENT_TYPE' => 'application/json'
+    end
+
+    it 'calls add_message for each message in the history' do
+      fake_session, = stub_llm_chat_session
+
+      messages = [
+        { role: 'user', content: 'first message' },
+        { role: 'assistant', content: 'first response' },
+        { role: 'user', content: 'follow up' }
+      ]
+
+      expect(fake_session).to receive(:add_message).exactly(3).times
+
+      post '/api/llm/inference',
+           Legion::JSON.dump({ messages: messages }),
+           'CONTENT_TYPE' => 'application/json'
+    end
+
+    it 'registers tool declarations when tools are provided' do
+      fake_session, = stub_llm_chat_session
+      tools_received = []
+      allow(fake_session).to receive(:with_tools) { |*args| tools_received.concat(args) }
+
+      tools = [{ name: 'read_file', description: 'Reads a file', parameters: { type: 'object' } }]
+
+      post '/api/llm/inference',
+           Legion::JSON.dump({
+                               messages: [{ role: 'user', content: 'read main.rb' }],
+                               tools:    tools
+                             }),
+           'CONTENT_TYPE' => 'application/json'
+
+      expect(last_response.status).to eq(200)
+      expect(tools_received.length).to eq(1)
+      expect(tools_received.first.tool_name).to eq('read_file')
+    end
+
+    it 'does not call with_tools when tools array is empty' do
+      fake_session, = stub_llm_chat_session
+      expect(fake_session).not_to receive(:with_tools)
+
+      post '/api/llm/inference',
+           Legion::JSON.dump({
+                               messages: [{ role: 'user', content: 'hello' }],
+                               tools:    []
+                             }),
+           'CONTENT_TYPE' => 'application/json'
+    end
+
+    it 'includes model string in the response' do
+      stub_llm_chat_session(model_name: 'claude-sonnet-4-6')
+
+      post '/api/llm/inference',
+           Legion::JSON.dump({ messages: [{ role: 'user', content: 'hello' }] }),
+           'CONTENT_TYPE' => 'application/json'
+
+      expect(last_response.status).to eq(200)
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:data][:model]).to eq('claude-sonnet-4-6')
+    end
+
+    it 'includes meta timestamp and node in response wrapper' do
+      stub_llm_chat_session
+
+      post '/api/llm/inference',
+           Legion::JSON.dump({ messages: [{ role: 'user', content: 'hello' }] }),
+           'CONTENT_TYPE' => 'application/json'
+
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:meta]).to have_key(:timestamp)
+      expect(body[:meta][:node]).to eq('test-node')
+    end
+  end
+
+  # ── 500 error path ─────────────────────────────────────────────────────────
+
+  describe 'POST /api/llm/inference — error handling' do
+    before { stub_llm_started }
+
+    it 'returns 500 when LLM.chat raises' do
+      allow(Legion::LLM).to receive(:chat).and_raise(StandardError, 'provider exploded')
+
+      post '/api/llm/inference',
+           Legion::JSON.dump({ messages: [{ role: 'user', content: 'boom' }] }),
+           'CONTENT_TYPE' => 'application/json'
+
+      expect(last_response.status).to eq(500)
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:data][:error][:code]).to eq('inference_error')
+      expect(body[:data][:error][:message]).to eq('provider exploded')
+    end
+  end
+end

--- a/spec/legion/cli/chat/daemon_chat_spec.rb
+++ b/spec/legion/cli/chat/daemon_chat_spec.rb
@@ -1,0 +1,363 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/cli/chat/daemon_chat'
+
+RSpec.describe Legion::CLI::Chat::DaemonChat do
+  subject(:chat) { described_class.new(model: 'claude-sonnet-4-6', provider: :bedrock) }
+
+  # Ensure the stub constant exists before each test.
+  before do
+    unless defined?(Legion::LLM::DaemonClient)
+      stub_const('Legion::LLM', Module.new) unless defined?(Legion::LLM)
+      daemon_mod = Module.new
+      stub_const('Legion::LLM::DaemonClient', daemon_mod)
+    end
+  end
+
+  # Stub DaemonClient.inference so specs never hit the network.
+  def stub_inference(content: 'hello from daemon', tool_calls: nil,
+                     input_tokens: 5, output_tokens: 10, status: :immediate)
+    result = {
+      status: status,
+      data:   {
+        content:       content,
+        tool_calls:    tool_calls,
+        input_tokens:  input_tokens,
+        output_tokens: output_tokens,
+        model:         'claude-sonnet-4-6'
+      }
+    }
+    allow(Legion::LLM::DaemonClient).to receive(:inference).and_return(result)
+    result
+  end
+
+  # ── initialization ─────────────────────────────────────────────────────────
+
+  describe '#initialize' do
+    it 'exposes a model object responding to .id' do
+      expect(chat.model.id).to eq('claude-sonnet-4-6')
+    end
+
+    it 'model.to_s returns the model id' do
+      expect(chat.model.to_s).to eq('claude-sonnet-4-6')
+    end
+
+    it 'starts with an empty message history' do
+      stub_inference
+      responses = []
+      chat.ask('test') { |chunk| responses << chunk.content }
+      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+        hash_including(messages: array_including(hash_including(role: 'user', content: 'test')))
+      )
+    end
+  end
+
+  # ── with_instructions ──────────────────────────────────────────────────────
+
+  describe '#with_instructions' do
+    it 'prepends a system message to the outgoing messages array' do
+      stub_inference
+      chat.with_instructions('You are a helpful assistant.')
+      chat.ask('test')
+
+      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+        hash_including(
+          messages: array_including(hash_including(role: 'system', content: 'You are a helpful assistant.'))
+        )
+      )
+    end
+
+    it 'returns self for chaining' do
+      expect(chat.with_instructions('prompt')).to eq(chat)
+    end
+  end
+
+  # ── with_tools ─────────────────────────────────────────────────────────────
+
+  describe '#with_tools' do
+    it 'stores tools and forwards their schemas to DaemonClient.inference' do
+      fake_tool = Class.new do
+        def self.tool_name  = 'read_file'
+        def self.description = 'Reads a file'
+        def self.parameters  = { type: 'object' }
+      end
+
+      stub_inference
+      chat.with_tools(fake_tool)
+      chat.ask('read something')
+
+      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+        hash_including(
+          tools: array_including(hash_including(name: 'read_file'))
+        )
+      )
+    end
+
+    it 'returns self for chaining' do
+      expect(chat.with_tools).to eq(chat)
+    end
+  end
+
+  # ── with_model ─────────────────────────────────────────────────────────────
+
+  describe '#with_model' do
+    it 'updates the model id' do
+      chat.with_model('gpt-4o')
+      expect(chat.model.id).to eq('gpt-4o')
+    end
+
+    it 'returns self for chaining' do
+      expect(chat.with_model('gpt-4o')).to eq(chat)
+    end
+  end
+
+  # ── add_message / reset_messages! ─────────────────────────────────────────
+
+  describe '#add_message' do
+    it 'injects a message into the history before the next ask' do
+      stub_inference
+      chat.add_message(role: :user, content: 'injected context')
+      chat.ask('follow up')
+
+      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+        hash_including(
+          messages: array_including(hash_including(role: 'user', content: 'injected context'))
+        )
+      )
+    end
+  end
+
+  describe '#reset_messages!' do
+    it 'clears accumulated message history so the next ask sends only new messages' do
+      stub_inference(content: 'first answer')
+      chat.ask('first message')
+
+      # After reset, only the new message should appear in the next inference call
+      captured_messages = nil
+      allow(Legion::LLM::DaemonClient).to receive(:inference) do |messages:, **_|
+        captured_messages = messages
+        {
+          status: :immediate,
+          data:   { content: 'fresh answer', tool_calls: nil,
+                    input_tokens: 2, output_tokens: 2, model: 'claude-sonnet-4-6' }
+        }
+      end
+
+      chat.reset_messages!
+      chat.ask('fresh start')
+
+      user_messages = captured_messages&.select { |m| m[:role] == 'user' }
+      expect(user_messages&.length).to eq(1)
+      expect(user_messages&.first&.dig(:content)).to eq('fresh start')
+    end
+  end
+
+  # ── on_tool_call / on_tool_result ─────────────────────────────────────────
+
+  describe '#on_tool_call and #on_tool_result callbacks' do
+    let(:fake_tool) do
+      Class.new do
+        def self.tool_name = 'run_command'
+        def self.description = 'Runs a shell command'
+        def self.parameters  = {}
+        def self.call(**_)   = 'command output'
+      end
+    end
+
+    it 'fires on_tool_call before executing a tool' do
+      tool_call_received = []
+
+      first_response = {
+        status: :immediate,
+        data:   {
+          content:       nil,
+          tool_calls:    [{ id: 'tc1', name: 'run_command', arguments: { cmd: 'ls' } }],
+          input_tokens:  5,
+          output_tokens: 5,
+          model:         'claude-sonnet-4-6'
+        }
+      }
+      final_response = {
+        status: :immediate,
+        data:   {
+          content:       'done',
+          tool_calls:    nil,
+          input_tokens:  10,
+          output_tokens: 10,
+          model:         'claude-sonnet-4-6'
+        }
+      }
+
+      allow(Legion::LLM::DaemonClient).to receive(:inference)
+        .and_return(first_response, final_response)
+
+      chat.with_tools(fake_tool)
+      chat.on_tool_call { |tc| tool_call_received << tc.name }
+      chat.ask('run something')
+
+      expect(tool_call_received).to eq(['run_command'])
+    end
+
+    it 'fires on_tool_result after executing a tool' do
+      tool_results_received = []
+
+      first_response = {
+        status: :immediate,
+        data:   {
+          content:       nil,
+          tool_calls:    [{ id: 'tc1', name: 'run_command', arguments: {} }],
+          input_tokens:  5,
+          output_tokens: 5,
+          model:         'claude-sonnet-4-6'
+        }
+      }
+      final_response = {
+        status: :immediate,
+        data:   {
+          content:       'done',
+          tool_calls:    nil,
+          input_tokens:  10,
+          output_tokens: 10,
+          model:         'claude-sonnet-4-6'
+        }
+      }
+
+      allow(Legion::LLM::DaemonClient).to receive(:inference)
+        .and_return(first_response, final_response)
+
+      chat.with_tools(fake_tool)
+      chat.on_tool_result { |tr| tool_results_received << tr.content }
+      chat.ask('run something')
+
+      expect(tool_results_received).to eq(['command output'])
+    end
+  end
+
+  # ── ask ────────────────────────────────────────────────────────────────────
+
+  describe '#ask' do
+    context 'with a plain text response (no tool calls)' do
+      before { stub_inference(content: 'Hello there!') }
+
+      it 'returns a Response with the content' do
+        response = chat.ask('hello')
+        expect(response.content).to eq('Hello there!')
+      end
+
+      it 'returns a Response with token counts' do
+        response = chat.ask('hello')
+        expect(response.input_tokens).to eq(5)
+        expect(response.output_tokens).to eq(10)
+      end
+
+      it 'returns a Response with a model object responding to .id' do
+        response = chat.ask('hello')
+        expect(response.model.id).to eq('claude-sonnet-4-6')
+      end
+
+      it 'yields a chunk with the full content for streaming' do
+        chunks = []
+        chat.ask('hello') { |chunk| chunks << chunk.content }
+        expect(chunks).to eq(['Hello there!'])
+      end
+
+      it 'appends the user message and assistant response to history' do
+        chat.ask('hello')
+        stub_inference(content: 'follow up answer')
+        chat.ask('follow up')
+
+        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+      end
+    end
+
+    context 'when daemon returns an error status' do
+      it 'raises CLI::Error' do
+        allow(Legion::LLM::DaemonClient).to receive(:inference)
+          .and_return({ status: :error, error: 'connection refused' })
+
+        expect { chat.ask('test') }.to raise_error(Legion::CLI::Error, /Daemon inference error/)
+      end
+    end
+
+    context 'when daemon is unavailable' do
+      it 'raises CLI::Error' do
+        allow(Legion::LLM::DaemonClient).to receive(:inference)
+          .and_return({ status: :unavailable })
+
+        expect { chat.ask('test') }.to raise_error(Legion::CLI::Error, /unavailable/)
+      end
+    end
+
+    context 'with a tool_calls response followed by a final text response' do
+      let(:fake_tool) do
+        Class.new do
+          def self.tool_name   = 'read_file'
+          def self.description = 'Reads a file'
+          def self.parameters  = {}
+          def self.call(**)    = 'file contents here'
+        end
+      end
+
+      let(:tool_call_response) do
+        {
+          status: :immediate,
+          data:   {
+            content:       nil,
+            tool_calls:    [{ id: 'tc1', name: 'read_file', arguments: { path: 'main.rb' } }],
+            input_tokens:  8,
+            output_tokens: 4,
+            model:         'claude-sonnet-4-6'
+          }
+        }
+      end
+
+      let(:final_response) do
+        {
+          status: :immediate,
+          data:   {
+            content:       'Based on the file: it looks good.',
+            tool_calls:    nil,
+            input_tokens:  20,
+            output_tokens: 15,
+            model:         'claude-sonnet-4-6'
+          }
+        }
+      end
+
+      before do
+        allow(Legion::LLM::DaemonClient).to receive(:inference)
+          .and_return(tool_call_response, final_response)
+        chat.with_tools(fake_tool)
+      end
+
+      it 'loops until a non-tool response is received' do
+        response = chat.ask('read main.rb')
+        expect(response.content).to eq('Based on the file: it looks good.')
+        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+      end
+
+      it 'appends tool result messages to the conversation' do
+        chat.ask('read main.rb')
+
+        # On the second call, messages should include the tool result
+        second_call_messages = nil
+        allow(Legion::LLM::DaemonClient).to receive(:inference) do |messages:, **|
+          second_call_messages ||= messages if second_call_messages.nil?
+          final_response
+        end
+
+        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+      end
+
+      it 'returns "Unknown tool: name" when tool is not registered' do
+        chat.with_tools # clear tools
+        allow(Legion::LLM::DaemonClient).to receive(:inference)
+          .and_return(tool_call_response, final_response)
+
+        # Should not raise — returns graceful error string as tool result
+        expect { chat.ask('read main.rb') }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `POST /api/llm/inference` endpoint: stateless, accepts a full messages array and optional tool schemas, runs a single LLM completion pass via `Legion::LLM.chat`, returns `{ content, tool_calls, stop_reason, model, input_tokens, output_tokens }`. The client owns the conversation and tool-execution loop.
- Adds `Legion::CLI::Chat::DaemonChat` adapter (`lib/legion/cli/chat/daemon_chat.rb`): implements the same interface Session expects (`ask`, `with_tools`, `with_instructions`, `on_tool_call`, `on_tool_result`, `model`, `add_message`, `reset_messages!`, `with_model`). Routes all LLM inference through the daemon and executes tool calls locally in a loop until the LLM produces a final text response.
- Rewrites `chat_command.rb#setup_connection`: drops `Connection.ensure_llm` (local LLM stack boot), checks `Legion::LLM::DaemonClient.available?` instead, and **hard fails** with a descriptive message if the daemon is not running.
- Rewrites `chat_command.rb#create_chat`: returns `Chat::DaemonChat` instead of a direct `RubyLLM::Chat` object.

Closes #48.

**Note**: `DaemonClient.inference` method (Phase 1 HTTP POST) is being added to `legion-llm` in a parallel PR. This PR stubs it in specs.

## Test plan

- [x] `bundle exec rspec` — 3827 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] 12 new specs for `POST /api/llm/inference` covering 503/400/200/500 paths
- [x] 25 new specs for `DaemonChat` covering initialization, tool schemas, tool execution loop, streaming chunks, error handling, `reset_messages!`, `add_message`, `with_model`
- [x] Existing `chat_command_spec.rb` still green (3 examples)
- [x] Version bumped to 1.6.22
- [x] CHANGELOG updated