### PR TITLE
fix: resolve #55 - swarm automated fix

### DIFF
--- a/extensions-agentic/lex-consent/db/migrations/001_create_consent_maps.rb
+++ b/extensions-agentic/lex-consent/db/migrations/001_create_consent_maps.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:consent_maps) do
+      primary_key :id
+      String  :worker_id,    null: false
+      String  :from_tier,    null: false
+      String  :to_tier,      null: false
+      String  :requested_by, null: false
+      String  :state,        null: false, default: 'pending_approval'
+      String  :resolved_by
+      Time    :resolved_at
+      String  :notes,        text: true
+      String  :context,      text: true
+      Time    :created_at
+      Time    :updated_at
+
+      index :worker_id
+      index :state
+      index [:worker_id, :state]
+    end
+  end
+end

--- a/extensions-agentic/lex-consent/lex-consent.gemspec
+++ b/extensions-agentic/lex-consent/lex-consent.gemspec
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'lib/legion/extensions/agentic/consent/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'lex-consent'
+  spec.version       = Legion::Extensions::Agentic::Consent::VERSION
+  spec.authors       = ['Esity']
+  spec.email         = ['matthewdiverson@gmail.com']
+  spec.summary       = 'LegionIO HITL consent gate for autonomous tier promotion'
+  spec.description   = 'A LegionIO Extension (LEX) that gates agent autonomous tier promotion by human approval'
+  spec.homepage      = 'https://github.com/LegionIO/lex-consent'
+  spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 3.4'
+
+  spec.metadata = {
+    'homepage_uri'          => spec.homepage,
+    'source_code_uri'       => spec.homepage,
+    'rubygems_mfa_required' => 'true'
+  }
+
+  spec.files = Dir['lib/**/*', 'LICENSE', 'README.md']
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'legionio', '>= 1.2'
+end

--- a/extensions-agentic/lex-consent/lib/legion/extensions/agentic/consent.rb
+++ b/extensions-agentic/lex-consent/lib/legion/extensions/agentic/consent.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'consent/version'
+require_relative 'consent/models/consent_map'
+require_relative 'consent/runners/consent'
+require_relative 'consent/actors/tier_evaluation'
+
+module Legion
+  module Extensions
+    module Agentic
+      module Consent
+      end
+    end
+  end
+end

--- a/extensions-agentic/lex-consent/lib/legion/extensions/agentic/consent/actors/tier_evaluation.rb
+++ b/extensions-agentic/lex-consent/lib/legion/extensions/agentic/consent/actors/tier_evaluation.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+return unless defined?(Legion::Extensions::Actors::Every)
+
+module Legion
+  module Extensions
+    module Agentic
+      module Consent
+        module Actor
+          class TierEvaluation < Legion::Extensions::Actors::Every
+            # Run tier evaluation and pending approval expiry every hour
+            INTERVAL = 3600
+
+            def perform
+              expire_stale_approvals
+              evaluate_pending_workers
+            rescue StandardError => e
+              Legion::Logging.error "[TierEvaluation] perform failed: #{e.message}" if defined?(Legion::Logging)
+            end
+
+            private
+
+            def expire_stale_approvals
+              return unless runner_available?
+
+              runner = runner_instance
+              ttl_hours = Legion::Settings.dig(:consent, :pending_ttl_hours) || 72
+              result = runner.expire_pending_approvals(ttl_hours: ttl_hours)
+              return unless result[:expired].to_i.positive? && defined?(Legion::Logging)
+
+              Legion::Logging.info "[TierEvaluation] expired #{result[:expired]} stale consent requests"
+            rescue StandardError => e
+              Legion::Logging.warn "[TierEvaluation] expire_stale_approvals failed: #{e.message}" if defined?(Legion::Logging)
+            end
+
+            def evaluate_pending_workers
+              return unless defined?(Legion::Data::Model::DigitalWorker)
+              return unless defined?(Legion::Extensions::Agentic::Consent::Models::ConsentMap)
+
+              # Find active workers that may be eligible for autonomous tier promotion
+              # but do not yet have a pending approval request.
+              active_workers = Legion::Data::Model::DigitalWorker
+                               .where(lifecycle_state: 'active')
+                               .exclude(consent_tier: 'autonomous')
+                               .all
+
+              active_workers.each do |worker|
+                evaluate_worker_for_promotion(worker)
+              rescue StandardError => e
+                Legion::Logging.warn "[TierEvaluation] evaluate failed for worker=#{worker.worker_id}: #{e.message}" if defined?(Legion::Logging)
+              end
+            rescue StandardError => e
+              Legion::Logging.warn "[TierEvaluation] evaluate_pending_workers failed: #{e.message}" if defined?(Legion::Logging)
+            end
+
+            def evaluate_worker_for_promotion(worker)
+              return unless promotion_eligible?(worker)
+              return if pending_request_exists?(worker.worker_id)
+
+              from_tier = worker.consent_tier
+              to_tier   = next_tier(from_tier)
+              return unless to_tier
+
+              runner = runner_instance
+              runner.request_promotion(
+                worker_id:    worker.worker_id,
+                from_tier:    from_tier,
+                to_tier:      to_tier,
+                requested_by: 'system:tier_evaluation'
+              )
+            end
+
+            def promotion_eligible?(worker)
+              return false unless worker.trust_score.to_f >= trust_threshold
+              return false unless (worker.risk_tier || 'low') == 'low'
+
+              true
+            end
+
+            def trust_threshold
+              Legion::Settings.dig(:consent, :promotion_trust_threshold) || 0.85
+            rescue StandardError
+              0.85
+            end
+
+            def next_tier(current_tier)
+              hierarchy = %w[supervised inform consult autonomous]
+              idx = hierarchy.index(current_tier)
+              return nil unless idx
+              return nil if idx >= hierarchy.length - 1
+
+              hierarchy[idx + 1]
+            end
+
+            def pending_request_exists?(worker_id)
+              Legion::Extensions::Agentic::Consent::Models::ConsentMap
+                .pending_for_worker(worker_id).count.positive?
+            end
+
+            def runner_available?
+              defined?(Legion::Extensions::Agentic::Consent::Runners::Consent)
+            end
+
+            def runner_instance
+              Object.new.extend(Legion::Extensions::Agentic::Consent::Runners::Consent)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/extensions-agentic/lex-consent/lib/legion/extensions/agentic/consent/models/consent_map.rb
+++ b/extensions-agentic/lex-consent/lib/legion/extensions/agentic/consent/models/consent_map.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+return unless defined?(Legion::Data)
+
+module Legion
+  module Extensions
+    module Agentic
+      module Consent
+        module Models
+          class ConsentMap < Legion::Data::Model::Base
+            set_dataset :consent_maps
+
+            STATES = %w[pending_approval approved rejected expired].freeze
+
+            def self.pending
+              where(state: 'pending_approval')
+            end
+
+            def self.for_worker(worker_id)
+              where(worker_id: worker_id)
+            end
+
+            def self.pending_for_worker(worker_id)
+              where(worker_id: worker_id, state: 'pending_approval')
+            end
+
+            def approve!(approver:, notes: nil)
+              update(
+                state:          'approved',
+                resolved_by:    approver,
+                resolved_at:    Time.now.utc,
+                notes:          notes,
+                updated_at:     Time.now.utc
+              )
+            end
+
+            def reject!(approver:, reason: nil)
+              update(
+                state:          'rejected',
+                resolved_by:    approver,
+                resolved_at:    Time.now.utc,
+                notes:          reason,
+                updated_at:     Time.now.utc
+              )
+            end
+
+            def expire!
+              update(
+                state:      'expired',
+                updated_at: Time.now.utc
+              )
+            end
+
+            def pending?
+              state == 'pending_approval'
+            end
+
+            def approved?
+              state == 'approved'
+            end
+
+            def rejected?
+              state == 'rejected'
+            end
+
+            def expired?
+              state == 'expired'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/extensions-agentic/lex-consent/lib/legion/extensions/agentic/consent/runners/consent.rb
+++ b/extensions-agentic/lex-consent/lib/legion/extensions/agentic/consent/runners/consent.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+module Legion
+  module Extensions
+    module Agentic
+      module Consent
+        module Runners
+          module Consent
+            # Request human approval for a worker's autonomous tier promotion.
+            # Creates a ConsentMap record in pending_approval state.
+            #
+            # @param worker_id [String] the worker requesting promotion
+            # @param from_tier [String] current consent tier
+            # @param to_tier [String] requested consent tier
+            # @param requested_by [String] identity requesting the promotion
+            # @param context [Hash] optional metadata about why promotion is requested
+            # @return [Hash]
+            def request_promotion(worker_id:, from_tier:, to_tier:, requested_by: 'system', context: {}, **)
+              unless defined?(Legion::Extensions::Agentic::Consent::Models::ConsentMap)
+                return { success: false, reason: :model_unavailable }
+              end
+
+              existing = Legion::Extensions::Agentic::Consent::Models::ConsentMap
+                         .pending_for_worker(worker_id).first
+
+              if existing
+                Legion::Logging.info "[lex-consent] promotion already pending for worker=#{worker_id}" if defined?(Legion::Logging)
+                return { success: false, reason: :already_pending, consent_map_id: existing.id }
+              end
+
+              record = Legion::Extensions::Agentic::Consent::Models::ConsentMap.create(
+                worker_id:    worker_id,
+                from_tier:    from_tier,
+                to_tier:      to_tier,
+                requested_by: requested_by,
+                state:        'pending_approval',
+                context:      defined?(Legion::JSON) ? Legion::JSON.dump(context) : context.to_json,
+                created_at:   Time.now.utc,
+                updated_at:   Time.now.utc
+              )
+
+              Legion::Events.emit('consent.promotion_requested', {
+                                    worker_id:      worker_id,
+                                    from_tier:      from_tier,
+                                    to_tier:        to_tier,
+                                    requested_by:   requested_by,
+                                    consent_map_id: record.id,
+                                    at:             Time.now.utc
+                                  }) if defined?(Legion::Events)
+
+              Legion::Logging.info "[lex-consent] promotion requested worker=#{worker_id} #{from_tier}->#{to_tier} id=#{record.id}" if defined?(Legion::Logging)
+
+              { success: true, consent_map_id: record.id, state: 'pending_approval' }
+            rescue StandardError => e
+              Legion::Logging.error "[lex-consent] request_promotion failed: #{e.message}" if defined?(Legion::Logging)
+              { success: false, reason: e.message }
+            end
+
+            # Approve a pending tier promotion request.
+            #
+            # @param consent_map_id [Integer] the ConsentMap record to approve
+            # @param approver [String] identity of the approver
+            # @param notes [String] optional approval notes
+            # @return [Hash]
+            def approve_promotion(consent_map_id:, approver:, notes: nil, **)
+              unless defined?(Legion::Extensions::Agentic::Consent::Models::ConsentMap)
+                return { success: false, reason: :model_unavailable }
+              end
+
+              record = Legion::Extensions::Agentic::Consent::Models::ConsentMap[consent_map_id.to_i]
+              return { success: false, reason: :not_found } unless record
+              return { success: false, reason: :not_pending, state: record.state } unless record.pending?
+
+              record.approve!(approver: approver, notes: notes)
+
+              apply_promotion(record)
+
+              Legion::Events.emit('consent.promotion_approved', {
+                                    consent_map_id: record.id,
+                                    worker_id:      record.worker_id,
+                                    from_tier:      record.from_tier,
+                                    to_tier:        record.to_tier,
+                                    approver:       approver,
+                                    at:             Time.now.utc
+                                  }) if defined?(Legion::Events)
+
+              Legion::Logging.info "[lex-consent] approved consent_map_id=#{record.id} worker=#{record.worker_id} by=#{approver}" if defined?(Legion::Logging)
+
+              { success: true, consent_map_id: record.id, worker_id: record.worker_id, state: 'approved', to_tier: record.to_tier }
+            rescue StandardError => e
+              Legion::Logging.error "[lex-consent] approve_promotion failed: #{e.message}" if defined?(Legion::Logging)
+              { success: false, reason: e.message }
+            end
+
+            # Reject a pending tier promotion request.
+            #
+            # @param consent_map_id [Integer] the ConsentMap record to reject
+            # @param approver [String] identity of the approver
+            # @param reason [String] rejection reason (required)
+            # @return [Hash]
+            def reject_promotion(consent_map_id:, approver:, reason:, **)
+              unless defined?(Legion::Extensions::Agentic::Consent::Models::ConsentMap)
+                return { success: false, reason: :model_unavailable }
+              end
+
+              return { success: false, reason: :missing_reason } if reason.nil? || reason.to_s.strip.empty?
+
+              record = Legion::Extensions::Agentic::Consent::Models::ConsentMap[consent_map_id.to_i]
+              return { success: false, reason: :not_found } unless record
+              return { success: false, reason: :not_pending, state: record.state } unless record.pending?
+
+              record.reject!(approver: approver, reason: reason)
+
+              Legion::Events.emit('consent.promotion_rejected', {
+                                    consent_map_id: record.id,
+                                    worker_id:      record.worker_id,
+                                    from_tier:      record.from_tier,
+                                    to_tier:        record.to_tier,
+                                    approver:       approver,
+                                    reason:         reason,
+                                    at:             Time.now.utc
+                                  }) if defined?(Legion::Events)
+
+              Legion::Logging.info "[lex-consent] rejected consent_map_id=#{record.id} worker=#{record.worker_id} by=#{approver}" if defined?(Legion::Logging)
+
+              { success: true, consent_map_id: record.id, worker_id: record.worker_id, state: 'rejected' }
+            rescue StandardError => e
+              Legion::Logging.error "[lex-consent] reject_promotion failed: #{e.message}" if defined?(Legion::Logging)
+              { success: false, reason: e.message }
+            end
+
+            # Expire all pending promotion requests older than ttl_hours.
+            # Intended to be run on a schedule (e.g. every hour).
+            #
+            # @param ttl_hours [Integer] how many hours before a pending request expires (default 72)
+            # @return [Hash]
+            def expire_pending_approvals(ttl_hours: 72, **)
+              unless defined?(Legion::Extensions::Agentic::Consent::Models::ConsentMap)
+                return { success: false, reason: :model_unavailable }
+              end
+
+              cutoff = Time.now.utc - (ttl_hours * 3600)
+              expired_count = 0
+
+              Legion::Extensions::Agentic::Consent::Models::ConsentMap
+                .pending
+                .where { created_at < cutoff }
+                .each do |record|
+                  record.expire!
+                  expired_count += 1
+
+                  Legion::Events.emit('consent.promotion_expired', {
+                                        consent_map_id: record.id,
+                                        worker_id:      record.worker_id,
+                                        from_tier:      record.from_tier,
+                                        to_tier:        record.to_tier,
+                                        at:             Time.now.utc
+                                      }) if defined?(Legion::Events)
+                rescue StandardError => e
+                  Legion::Logging.warn "[lex-consent] expire failed for id=#{record.id}: #{e.message}" if defined?(Legion::Logging)
+                end
+
+              Legion::Logging.info "[lex-consent] expired #{expired_count} pending approvals (ttl=#{ttl_hours}h)" if defined?(Legion::Logging)
+
+              { success: true, expired: expired_count, ttl_hours: ttl_hours }
+            rescue StandardError => e
+              Legion::Logging.error "[lex-consent] expire_pending_approvals failed: #{e.message}" if defined?(Legion::Logging)
+              { success: false, reason: e.message }
+            end
+
+            # List pending promotion requests.
+            #
+            # @param worker_id [String] optional filter by worker
+            # @return [Hash]
+            def list_pending(worker_id: nil, **)
+              unless defined?(Legion::Extensions::Agentic::Consent::Models::ConsentMap)
+                return { success: false, reason: :model_unavailable }
+              end
+
+              ds = Legion::Extensions::Agentic::Consent::Models::ConsentMap.pending
+              ds = ds.where(worker_id: worker_id) if worker_id
+              records = ds.all
+
+              { success: true, count: records.size, pending: records.map(&:values) }
+            rescue StandardError => e
+              Legion::Logging.error "[lex-consent] list_pending failed: #{e.message}" if defined?(Legion::Logging)
+              { success: false, reason: e.message }
+            end
+
+            private
+
+            def apply_promotion(record)
+              return unless defined?(Legion::Data::Model::DigitalWorker)
+
+              worker = Legion::Data::Model::DigitalWorker.first(worker_id: record.worker_id)
+              return unless worker
+
+              worker.update(consent_tier: record.to_tier, updated_at: Time.now.utc)
+
+              Legion::Logging.info "[lex-consent] applied tier promotion worker=#{record.worker_id} tier=#{record.to_tier}" if defined?(Legion::Logging)
+            rescue StandardError => e
+              Legion::Logging.warn "[lex-consent] apply_promotion failed for worker=#{record.worker_id}: #{e.message}" if defined?(Legion::Logging)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/extensions-agentic/lex-consent/lib/legion/extensions/agentic/consent/version.rb
+++ b/extensions-agentic/lex-consent/lib/legion/extensions/agentic/consent/version.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Legion
+  module Extensions
+    module Agentic
+      module Consent
+        VERSION = '0.1.0'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Automated fix for #55, generated by the GitHub Swarm pipeline.

## Approach

Create the missing lex-consent extension gem under extensions-agentic/ with ConsentMap model, migration, approve_promotion/reject_promotion/expire_pending_approvals runner methods, and TierEvaluation actor — matching the design doc's HITL gate specification.

## Pipeline Details

- **Attempt:** 1
- **Fixer model:** `us.anthropic.claude-sonnet-4-6`
- **Generated at:** 2026-03-29T06:34:41Z

## Token Usage

| Call | Model | Input | Output | Thinking | Max Tokens |
|------|-------|-------|--------|----------|------------|
| 1 | `us.anthropic.claude-sonnet-4-6` | 99090 | 6610 | 2092/8000 | 6610/32000 |
| 2 | `us.anthropic.claude-sonnet-4-6` | 6106 | 1682 | - | 1682/128000 |
| **Total** | | **105196** | **8292** | | |

## Review Checklist

- [ ] Changes are correct and fix the issue
- [ ] No unintended side effects
- [ ] Tests pass (if applicable)
- [ ] Code style is consistent with the repository

---

> This PR was generated by the UHG Grid GitHub Swarm.
> The swarm never merges. Final approval and merge is your responsibility.
> Closes #55
