### PR TITLE
remove deprecated lex-cortex from agentic setup pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.6.38] - 2026-03-30
+
+### Removed
+- Remove deprecated `lex-cortex` from agentic setup pack (replaced by legion-gaia)
+
 ## [1.6.37] - 2026-03-30
 
 ### Added

--- a/lib/legion/cli/setup_command.rb
+++ b/lib/legion/cli/setup_command.rb
@@ -36,7 +36,7 @@ module Legion
             lex-agentic-language lex-agentic-learning lex-agentic-memory
             lex-agentic-self lex-agentic-social lex-apollo lex-audit lex-autofix
             lex-azure-ai lex-bedrock lex-claude lex-codegen lex-coldstart
-            lex-conditioner lex-cortex lex-cost-scanner lex-dataset lex-detect
+            lex-conditioner lex-cost-scanner lex-dataset lex-detect
             lex-eval lex-exec lex-extinction lex-factory lex-finops lex-foundry
             lex-gemini lex-governance lex-kerberos lex-knowledge lex-llm-gateway
             lex-metering lex-mesh lex-microsoft_teams lex-mind-growth lex-node

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.6.37'
+  VERSION = '1.6.38'
 end


### PR DESCRIPTION
## Summary
- Remove `lex-cortex` from the `agentic` pack gem list in `setup_command.rb`
- `lex-cortex` is fully replaced by `legion-gaia` and emits a deprecation warning on every boot tick when GAIA is running
- Bump version to 1.6.38

## Test plan
- [x] `bundle exec rspec` — 4065 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses