### PR TITLE
add config reset command and bootstrap --clean flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [1.6.39] - 2026-03-30
+
+### Added
+- `legionio config reset` subcommand to wipe all JSON config files from settings directory (#88)
+- `legionio bootstrap --clean` flag to clear settings before import (#88)
+
+### Changed
+- `legionio bootstrap` no longer runs `ConfigScaffold` when a source is provided — scaffolded empty files were conflicting with imported config (#88)
+
 ## [1.6.38] - 2026-03-30
 
 ### Removed

--- a/lib/legion/cli/bootstrap_command.rb
+++ b/lib/legion/cli/bootstrap_command.rb
@@ -21,6 +21,7 @@ module Legion
       class_option :skip_packs, type: :boolean, default: false, desc: 'Skip gem pack installation (config only)'
       class_option :start,      type: :boolean, default: false, desc: 'Start redis + legionio via brew services after bootstrap'
       class_option :force,      type: :boolean, default: false, desc: 'Overwrite existing config files'
+      class_option :clean,      type: :boolean, default: false, desc: 'Remove all existing config files before import'
 
       desc 'SOURCE', 'Bootstrap Legion from a URL or local config file (fetch config, scaffold, install packs)'
       long_desc <<~DESC
@@ -53,16 +54,19 @@ module Legion
         print_step(out, 'Pre-flight checks')
         results[:preflight] = run_preflight_checks(out, warns)
 
-        # 2. Fetch + parse config
+        # 2. Clean existing config (--clean)
+        results[:cleaned] = clean_settings(out) if options[:clean]
+
+        # 3. Fetch + parse config
         print_step(out, "Fetching config from #{source}")
         body   = ConfigImport.fetch_source(source)
         config = ConfigImport.parse_payload(body)
 
-        # 3. Extract packs before writing (bootstrap-only directive)
+        # 4. Extract packs before writing (bootstrap-only directive)
         pack_names = Array(config.delete(:packs)).map(&:to_s).reject(&:empty?)
         results[:packs_requested] = pack_names
 
-        # 4. Write config
+        # 5. Write config
         paths = ConfigImport.write_config(config, force: options[:force])
         results[:config_written] = paths
         unless options[:json]
@@ -73,18 +77,18 @@ module Legion
           end
         end
 
-        # 5. Scaffold missing subsystem files
-        results[:scaffold] = run_scaffold(out)
+        # 6. Scaffold missing subsystem files (skipped when source provided)
+        results[:scaffold] = :skipped
 
-        # 6. Install packs (unless --skip-packs)
+        # 7. Install packs (unless --skip-packs)
         results[:packs_installed] = install_packs_step(pack_names, out)
 
-        # 7. Post-bootstrap summary
+        # 8. Post-bootstrap summary
         summary = build_summary(config, results, warns)
         results[:summary] = summary
         print_summary(out, summary)
 
-        # 8. Optional --start
+        # 9. Optional --start
         if options[:start]
           print_step(out, 'Starting services')
           results[:services_started] = start_services(out)
@@ -205,6 +209,24 @@ module Legion
             print_step(out, "Installing packs: #{pack_names.join(', ')}") unless pack_names.empty?
             install_packs(pack_names, out)
           end
+        end
+
+        # -----------------------------------------------------------------------
+        # Clean settings (--clean)
+        # -----------------------------------------------------------------------
+
+        def clean_settings(out)
+          dir   = ConfigImport::SETTINGS_DIR
+          files = Dir.glob(File.join(dir, '*.json'))
+          if files.empty?
+            out.warn("No existing config files to clean in #{dir}") unless options[:json]
+            return []
+          end
+
+          print_step(out, "Cleaning #{files.size} config file(s) from #{dir}")
+          files.each { |f| FileUtils.rm_f(f) }
+          files.each { |f| out.success("Removed: #{File.basename(f)}") } unless options[:json]
+          files
         end
 
         # -----------------------------------------------------------------------

--- a/lib/legion/cli/config_command.rb
+++ b/lib/legion/cli/config_command.rb
@@ -184,6 +184,43 @@ module Legion
         raise SystemExit, exit_code if exit_code != 0
       end
 
+      desc 'reset', 'Remove all JSON config files from the settings directory'
+      long_desc <<~DESC
+        Removes all *.json files from the settings directory (~/.legionio/settings/).
+        Prompts for confirmation unless --force is passed.
+      DESC
+      option :force, type: :boolean, default: false, desc: 'Skip confirmation prompt'
+      def reset
+        require_relative 'config_import'
+        out = formatter
+        dir = options[:config_dir] || ConfigImport::SETTINGS_DIR
+
+        files = Dir.glob(File.join(dir, '*.json'))
+        if files.empty?
+          out.warn("No JSON files found in #{dir}")
+          return
+        end
+
+        unless options[:force]
+          out.warn("This will remove #{files.size} JSON file(s) from #{dir}:")
+          files.each { |f| puts "    #{File.basename(f)}" }
+          print '  Continue? [y/N] '
+          answer = $stdin.gets&.strip
+          unless answer&.match?(/\Ay(es)?\z/i)
+            out.warn('Aborted.')
+            return
+          end
+        end
+
+        files.each { |f| FileUtils.rm_f(f) }
+
+        if options[:json]
+          out.json(removed: files, directory: dir)
+        else
+          out.success("Removed #{files.size} JSON file(s) from #{dir}")
+        end
+      end
+
       desc 'import SOURCE', 'Import configuration from a URL or local file'
       option :force, type: :boolean, default: false, desc: 'Overwrite existing imported config'
       def import(source)

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.6.38'
+  VERSION = '1.6.39'
 end

--- a/spec/cli/bootstrap_command_spec.rb
+++ b/spec/cli/bootstrap_command_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe Legion::CLI::Bootstrap do
       expect(described_class.class_options).to have_key(:force)
     end
 
+    it 'declares --clean class option' do
+      expect(described_class.class_options).to have_key(:clean)
+    end
+
     it 'declares --json class option' do
       expect(described_class.class_options).to have_key(:json)
     end
@@ -270,7 +274,6 @@ RSpec.describe Legion::CLI::Bootstrap do
       .and_return(opts.fetch(:config, {}))
     allow(Legion::CLI::ConfigImport).to receive(:write_config)
       .and_return(opts.fetch(:paths, ['/tmp/bootstrapped_settings.json']))
-    allow(Legion::CLI::ConfigScaffold).to receive(:run).and_return(0)
     allow(cli).to receive(:run_preflight_checks).and_return({})
     allow(cli).to receive(:install_packs).and_return([])
     allow(cli).to receive(:print_summary)
@@ -307,7 +310,6 @@ RSpec.describe Legion::CLI::Bootstrap do
       allow(Legion::CLI::ConfigImport).to receive(:parse_payload).and_return({ llm: { enabled: true } })
       expect(Legion::CLI::ConfigImport).to receive(:write_config)
         .with({ llm: { enabled: true } }, force: true).and_return(['/tmp/llm.json'])
-      allow(Legion::CLI::ConfigScaffold).to receive(:run).and_return(0)
       allow(cli).to receive(:run_preflight_checks).and_return({})
       allow(cli).to receive(:install_packs).and_return([])
       allow(cli).to receive(:print_summary)
@@ -319,7 +321,6 @@ RSpec.describe Legion::CLI::Bootstrap do
       allow(Legion::CLI::ConfigImport).to receive(:parse_payload).and_return({})
       expect(Legion::CLI::ConfigImport).to receive(:write_config)
         .with({}, force: false).and_return([])
-      allow(Legion::CLI::ConfigScaffold).to receive(:run).and_return(0)
       allow(cli).to receive(:run_preflight_checks).and_return({})
       allow(cli).to receive(:install_packs).and_return([])
       allow(cli).to receive(:print_summary)
@@ -338,7 +339,6 @@ RSpec.describe Legion::CLI::Bootstrap do
       allow(Legion::CLI::ConfigImport).to receive(:parse_payload)
         .and_return({ packs: ['agentic'], llm: { enabled: true } })
       allow(Legion::CLI::ConfigImport).to receive(:write_config).and_return(['/tmp/llm.json'])
-      allow(Legion::CLI::ConfigScaffold).to receive(:run).and_return(0)
       allow(cli).to receive(:run_preflight_checks).and_return({})
       allow(cli).to receive(:print_summary)
     end
@@ -524,6 +524,108 @@ RSpec.describe Legion::CLI::Bootstrap do
       allow(cli).to receive(:options).and_return(default_options.merge(start: false))
       expect(cli).not_to receive(:start_services)
       cli.execute('/tmp/bootstrap.json')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # --clean flag
+  # ---------------------------------------------------------------------------
+
+  describe '--clean flag' do
+    let(:tmpdir) { Dir.mktmpdir('legion_bootstrap_clean') }
+
+    before do
+      stub_const('Legion::CLI::ConfigImport::SETTINGS_DIR', tmpdir)
+      File.write(File.join(tmpdir, 'transport.json'), '{}')
+      File.write(File.join(tmpdir, 'llm.json'), '{}')
+    end
+
+    after { FileUtils.rm_rf(tmpdir) }
+
+    context 'when --clean is set' do
+      before do
+        allow(cli).to receive(:options).and_return(default_options.merge(clean: true))
+        stub_happy_path
+      end
+
+      it 'removes existing json files before import' do
+        cli.execute('/tmp/bootstrap.json')
+        expect(Dir.glob(File.join(tmpdir, '*.json'))).to be_empty
+      end
+
+      it 'sets results[:cleaned] to the removed file list' do
+        results_captured = nil
+        allow(cli).to receive(:build_summary) do |_config, results, _warns|
+          results_captured = results
+          {}
+        end
+        cli.execute('/tmp/bootstrap.json')
+        expect(results_captured[:cleaned]).to be_an(Array)
+        expect(results_captured[:cleaned].size).to eq(2)
+      end
+    end
+
+    context 'when --clean is not set' do
+      before do
+        allow(cli).to receive(:options).and_return(default_options.merge(clean: false))
+        stub_happy_path
+      end
+
+      it 'does not remove existing files' do
+        cli.execute('/tmp/bootstrap.json')
+        expect(Dir.glob(File.join(tmpdir, '*.json')).size).to eq(2)
+      end
+
+      it 'does not set results[:cleaned]' do
+        results_captured = nil
+        allow(cli).to receive(:build_summary) do |_config, results, _warns|
+          results_captured = results
+          {}
+        end
+        cli.execute('/tmp/bootstrap.json')
+        expect(results_captured).not_to have_key(:cleaned)
+      end
+    end
+
+    context 'when --clean is set but no files exist' do
+      before do
+        FileUtils.rm_f(Dir.glob(File.join(tmpdir, '*.json')))
+        allow(cli).to receive(:options).and_return(default_options.merge(clean: true))
+        stub_happy_path
+      end
+
+      it 'returns an empty array' do
+        results_captured = nil
+        allow(cli).to receive(:build_summary) do |_config, results, _warns|
+          results_captured = results
+          {}
+        end
+        cli.execute('/tmp/bootstrap.json')
+        expect(results_captured[:cleaned]).to eq([])
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Scaffold skipping (source-provided bootstrap always skips scaffold)
+  # ---------------------------------------------------------------------------
+
+  describe 'scaffold skipping' do
+    before { stub_happy_path }
+
+    it 'does not call ConfigScaffold.run' do
+      expect(Legion::CLI::ConfigScaffold).not_to receive(:run)
+      cli.execute('/tmp/bootstrap.json')
+    end
+
+    it 'sets results[:scaffold] to :skipped' do
+      results_captured = nil
+      allow(cli).to receive(:build_summary) do |_config, results, _warns|
+        results_captured = results
+        {}
+      end
+      cli.execute('/tmp/bootstrap.json')
+      expect(results_captured[:scaffold]).to eq(:skipped)
     end
   end
 

--- a/spec/cli/config_reset_spec.rb
+++ b/spec/cli/config_reset_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/cli'
+require 'legion/cli/config_command'
+require 'legion/cli/config_import'
+
+RSpec.describe Legion::CLI::Config, '#reset' do
+  let(:out) do
+    instance_double(
+      Legion::CLI::Output::Formatter,
+      success: nil, warn: nil, error: nil,
+      header: nil, spacer: nil, json: nil
+    )
+  end
+  let(:cli) { described_class.new }
+  let(:tmpdir) { Dir.mktmpdir('legion_config_reset') }
+
+  before do
+    allow(cli).to receive(:formatter).and_return(out)
+  end
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  describe 'when files exist' do
+    before do
+      File.write(File.join(tmpdir, 'transport.json'), '{}')
+      File.write(File.join(tmpdir, 'llm.json'), '{}')
+      File.write(File.join(tmpdir, 'keep.yaml'), 'not json')
+    end
+
+    context 'with --force' do
+      before do
+        allow(cli).to receive(:options).and_return(json: false, no_color: true, force: true, config_dir: tmpdir)
+      end
+
+      it 'removes all .json files' do
+        cli.reset
+        expect(Dir.glob(File.join(tmpdir, '*.json'))).to be_empty
+      end
+
+      it 'preserves non-json files' do
+        cli.reset
+        expect(File.exist?(File.join(tmpdir, 'keep.yaml'))).to be true
+      end
+
+      it 'reports the count removed' do
+        expect(out).to receive(:success).with(a_string_matching(/removed 2 json file/i))
+        cli.reset
+      end
+    end
+
+    context 'with --json and --force' do
+      before do
+        allow(cli).to receive(:options).and_return(json: true, no_color: true, force: true, config_dir: tmpdir)
+      end
+
+      it 'outputs json with removed files' do
+        expect(out).to receive(:json).with(hash_including(:removed, :directory))
+        cli.reset
+      end
+    end
+
+    context 'without --force (interactive confirmation)' do
+      before do
+        allow(cli).to receive(:options).and_return(json: false, no_color: true, force: false, config_dir: tmpdir)
+      end
+
+      it 'removes files when user confirms with y' do
+        allow($stdin).to receive(:gets).and_return("y\n")
+        cli.reset
+        expect(Dir.glob(File.join(tmpdir, '*.json'))).to be_empty
+      end
+
+      it 'removes files when user confirms with yes' do
+        allow($stdin).to receive(:gets).and_return("yes\n")
+        cli.reset
+        expect(Dir.glob(File.join(tmpdir, '*.json'))).to be_empty
+      end
+
+      it 'aborts when user declines' do
+        allow($stdin).to receive(:gets).and_return("n\n")
+        cli.reset
+        expect(Dir.glob(File.join(tmpdir, '*.json')).size).to eq(2)
+      end
+
+      it 'aborts on empty input' do
+        allow($stdin).to receive(:gets).and_return("\n")
+        cli.reset
+        expect(Dir.glob(File.join(tmpdir, '*.json')).size).to eq(2)
+      end
+
+      it 'prints abort message when declined' do
+        allow($stdin).to receive(:gets).and_return("n\n")
+        expect(out).to receive(:warn).with('Aborted.')
+        cli.reset
+      end
+    end
+  end
+
+  describe 'when no files exist' do
+    before do
+      FileUtils.mkdir_p(tmpdir)
+      allow(cli).to receive(:options).and_return(json: false, no_color: true, force: true, config_dir: tmpdir)
+    end
+
+    it 'warns that no files were found' do
+      expect(out).to receive(:warn).with(a_string_including('No JSON files found'))
+      cli.reset
+    end
+  end
+
+  describe 'uses SETTINGS_DIR by default' do
+    before do
+      allow(cli).to receive(:options).and_return(json: false, no_color: true, force: true, config_dir: nil)
+      allow(Dir).to receive(:glob).and_return([])
+    end
+
+    it 'falls back to ConfigImport::SETTINGS_DIR' do
+      expect(Dir).to receive(:glob).with(File.join(Legion::CLI::ConfigImport::SETTINGS_DIR, '*.json'))
+      cli.reset
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `legionio config reset` subcommand to wipe all `*.json` from `~/.legionio/settings/` (prompts for confirmation unless `--force`)
- Add `--clean` flag to `legionio bootstrap` to clear settings before import
- Skip `ConfigScaffold.run` during bootstrap when a source is provided — scaffolded empty files were silently conflicting with imported config

Closes #88

## Test plan
- [ ] `bundle exec rspec spec/cli/config_reset_spec.rb` — 12 examples, 0 failures
- [ ] `bundle exec rspec spec/cli/bootstrap_command_spec.rb` — 69 examples, 0 failures
- [ ] Full suite: 4084 examples, 0 failures
- [ ] `bundle exec rubocop` on all changed files — 0 offenses