### PR TITLE
include all core helpers in Helpers::Lex and Absorbers::Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.6.40] - 2026-03-30
+
+### Fixed
+- `Helpers::Lex` now includes Cache, Transport, Task, and Data helpers so all actors, runners, absorbers, and hooks automatically get `cache_connected?`, `transport_connected?`, `data_connected?`, `generate_task_id`, and related methods
+- `Absorbers::Base` now includes `Helpers::Lex` (previously included zero helpers, causing `NoMethodError` for `log`, `cache_connected?`, etc.)
+
 ## [1.6.39] - 2026-03-30
 
 ### Added

--- a/lib/legion/extensions/absorbers/base.rb
+++ b/lib/legion/extensions/absorbers/base.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require_relative '../definitions'
+require_relative '../helpers/lex'
 
 module Legion
   module Extensions
     module Absorbers
       class Base
         extend Legion::Extensions::Definitions
+        include Legion::Extensions::Helpers::Lex
 
         class TokenRevocationError < StandardError
         end

--- a/lib/legion/extensions/helpers/lex.rb
+++ b/lib/legion/extensions/helpers/lex.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
 require 'legion/json/helper'
+require_relative 'core'
+require_relative 'logger'
 require_relative 'secret'
+require_relative 'cache'
+require_relative 'transport'
+require_relative 'task'
+
+begin
+  require_relative 'data'
+rescue LoadError
+  nil
+end
 
 module Legion
   module Extensions
@@ -11,6 +22,10 @@ module Legion
         include Legion::Extensions::Helpers::Logger
         include Legion::JSON::Helper
         include Legion::Extensions::Helpers::Secret
+        include Legion::Extensions::Helpers::Cache
+        include Legion::Extensions::Helpers::Transport
+        include Legion::Extensions::Helpers::Task
+        include Legion::Extensions::Helpers::Data if defined?(Legion::Extensions::Helpers::Data)
 
         def runner_desc(desc)
           settings[:runners] = {} if settings[:runners].nil?
@@ -19,8 +34,12 @@ module Legion
         end
 
         def self.included(base)
-          base.send :extend, Legion::Extensions::Helpers::Core if base.instance_of?(Class)
-          base.send :extend, Legion::Extensions::Helpers::Logger if base.instance_of?(Class)
+          if base.instance_of?(Class)
+            base.send :extend, Legion::Extensions::Helpers::Core
+            base.send :extend, Legion::Extensions::Helpers::Logger
+            base.send :extend, Legion::Extensions::Helpers::Cache
+            base.send :extend, Legion::Extensions::Helpers::Transport
+          end
           base.extend base if base.instance_of?(Module)
         end
 

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.6.39'
+  VERSION = '1.6.40'
 end


### PR DESCRIPTION
## Summary
- `Helpers::Lex` now includes Cache, Transport, Task, and (guarded) Data helpers — any component that includes `Helpers::Lex` automatically gets `cache_connected?`, `transport_connected?`, `data_connected?`, `generate_task_id`, etc.
- `Absorbers::Base` now includes `Helpers::Lex` (previously included zero helper modules)
- Fixes `NoMethodError` for `cache_connected?` on actors and `log` on absorbers at runtime

## Test plan
- [x] 4084 specs pass, 0 failures
- [x] rubocop clean (764 files, 0 offenses)