### PR TITLE
wire CLI chat identity into GAIA observation pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.6.47] - 2026-03-31
+
+### Added
+- CLI chat identity wiring: `DaemonChat` generates stable `conversation_id` and resolves user identity into `caller_context` (Kerberos principal -> ENV['USER'] fallback)
+- `DaemonChat` forwards `caller` and `conversation_id` to daemon inference endpoint
+- GAIA observation hook in `chat_command.rb`: `setup_gaia_observation` registers an `:llm_complete` callback that ingests user messages into GAIA's observation pipeline
+- `:llm_complete` session event now includes `user_message` in payload
+
 ## [1.6.46] - 2026-03-31
 
 ### Fixed

--- a/lib/legion/cli/chat/daemon_chat.rb
+++ b/lib/legion/cli/chat/daemon_chat.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'securerandom'
 require 'legion/cli/chat_command'
 
 begin
@@ -31,7 +32,7 @@ module Legion
           end
         end
 
-        attr_reader :model
+        attr_reader :model, :conversation_id, :caller_context
 
         def initialize(model: nil, provider: nil)
           @model    = ModelInfo.new(id: model)
@@ -41,6 +42,8 @@ module Legion
           @instructions = nil
           @on_tool_call   = nil
           @on_tool_result = nil
+          @conversation_id = SecureRandom.uuid
+          @caller_context  = build_caller
         end
 
         # Sets the system prompt. Returns self for chaining.
@@ -112,10 +115,12 @@ module Legion
 
         def call_daemon_inference
           Legion::LLM::DaemonClient.inference(
-            messages: build_messages,
-            tools:    build_tool_schemas,
-            model:    @model.id,
-            provider: @provider
+            messages:        build_messages,
+            tools:           build_tool_schemas,
+            model:           @model.id,
+            provider:        @provider,
+            caller:          @caller_context,
+            conversation_id: @conversation_id
           )
         end
 
@@ -204,6 +209,23 @@ module Legion
           tool_class.call(**arguments)
         rescue StandardError => e
           "Tool error (#{name}): #{e.message}"
+        end
+
+        def build_caller
+          identity = resolve_identity
+          { requested_by: { identity: identity, type: :human, credential: :local } }
+        end
+
+        def resolve_identity
+          if defined?(Legion::Crypt) && Legion::Crypt.respond_to?(:kerberos_principal)
+            principal = Legion::Crypt.kerberos_principal
+            return principal if principal
+          end
+
+          require 'etc'
+          Etc.getlogin || ENV.fetch('USER', 'unknown')
+        rescue StandardError
+          ENV.fetch('USER', 'unknown')
         end
 
         def build_response(data)

--- a/lib/legion/cli/chat/session.rb
+++ b/lib/legion/cli/chat/session.rb
@@ -69,7 +69,7 @@ module Legion
             @stats[:output_tokens] = (@stats[:output_tokens] || 0) + (response.output_tokens || 0)
           end
 
-          emit(:llm_complete, { turn: current_turn })
+          emit(:llm_complete, { turn: current_turn, user_message: message })
 
           response
         end

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -55,6 +55,7 @@ module Legion
         load_custom_agents
 
         setup_notification_bridge
+        setup_gaia_observation
         setup_worktree(out) if options[:worktree]
 
         chat_log.info "session started model=#{@session.model_id} incognito=#{incognito?}"
@@ -193,6 +194,40 @@ module Legion
         rescue LoadError => e
           Legion::Logging.debug("ChatCommand#setup_notification_bridge notification_bridge not available: #{e.message}") if defined?(Legion::Logging)
           @notification_bridge = nil
+        end
+
+        def setup_gaia_observation
+          return unless defined?(Legion::Gaia) && Legion::Gaia.respond_to?(:started?)
+          return unless Legion::Gaia.started?
+          return unless defined?(Legion::Gaia::InputFrame)
+
+          identity = chat_obj_identity
+          @session.on(:llm_complete) do |payload|
+            next unless Legion::Gaia.started?
+
+            content = payload[:user_message] || payload[:message] || ''
+            frame = Legion::Gaia::InputFrame.new(
+              content:      content,
+              channel_id:   :cli_chat,
+              auth_context: { identity: identity },
+              metadata:     { source_type:    :human_direct,
+                              direct_address: content.to_s.match?(/\bgaia\b/i) }
+            )
+            Legion::Gaia.ingest(frame)
+          rescue StandardError => e
+            Legion::Logging.debug("GAIA observation error: #{e.message}") if defined?(Legion::Logging)
+          end
+        rescue StandardError => e
+          Legion::Logging.debug("setup_gaia_observation failed: #{e.message}") if defined?(Legion::Logging)
+        end
+
+        def chat_obj_identity
+          return @session.chat.caller_context.dig(:requested_by, :identity) if @session.chat.respond_to?(:caller_context)
+
+          require 'etc'
+          Etc.getlogin || ENV.fetch('USER', 'unknown')
+        rescue StandardError
+          ENV.fetch('USER', 'unknown')
         end
 
         def display_pending_notifications

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.6.46'
+  VERSION = '1.6.47'
 end

--- a/spec/legion/cli/chat/daemon_chat_spec.rb
+++ b/spec/legion/cli/chat/daemon_chat_spec.rb
@@ -53,6 +53,40 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
     end
   end
 
+  # ── identity and conversation ───────────────────────────────────────────────
+
+  describe 'identity wiring' do
+    it 'generates a stable conversation_id' do
+      expect(chat.conversation_id).to match(/\A[0-9a-f-]{36}\z/)
+    end
+
+    it 'keeps the same conversation_id across turns' do
+      id = chat.conversation_id
+      stub_inference
+      chat.ask('test')
+      expect(chat.conversation_id).to eq(id)
+    end
+
+    it 'builds a caller_context with identity' do
+      expect(chat.caller_context).to be_a(Hash)
+      expect(chat.caller_context[:requested_by]).to be_a(Hash)
+      expect(chat.caller_context[:requested_by][:type]).to eq(:human)
+      expect(chat.caller_context[:requested_by][:credential]).to eq(:local)
+      expect(chat.caller_context[:requested_by][:identity]).not_to be_nil
+    end
+
+    it 'passes caller and conversation_id to DaemonClient.inference' do
+      stub_inference
+      chat.ask('test')
+      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+        hash_including(
+          caller:          hash_including(requested_by: hash_including(type: :human)),
+          conversation_id: chat.conversation_id
+        )
+      )
+    end
+  end
+
   # ── with_instructions ──────────────────────────────────────────────────────
 
   describe '#with_instructions' do

--- a/spec/legion/cli/chat/session_spec.rb
+++ b/spec/legion/cli/chat/session_spec.rb
@@ -142,6 +142,13 @@ RSpec.describe Legion::CLI::Chat::Session do
       expect(events).to eq([[:llm_start, 1], [:llm_complete, 1]])
     end
 
+    it 'includes user_message in :llm_complete payload' do
+      payload_received = nil
+      session.on(:llm_complete) { |p| payload_received = p }
+      session.send_message('tell me something')
+      expect(payload_received[:user_message]).to eq('tell me something')
+    end
+
     it 'emits :llm_first_token on first streaming chunk' do
       token_events = []
       session.on(:llm_first_token) { |p| token_events << p[:turn] }


### PR DESCRIPTION
## Summary
- `DaemonChat` generates stable `conversation_id` (UUID) and resolves caller identity (Kerberos -> ENV['USER'] fallback)
- Forward `caller` and `conversation_id` to daemon inference endpoint
- `setup_gaia_observation` registers `:llm_complete` callback that ingests user messages into GAIA's observation pipeline
- `:llm_complete` session event now includes `user_message` in payload

Part of GAIA Connection Completeness Plan 2 (Section 1).

## Test plan
- [x] 4070 specs passing, 0 failures (2 pre-existing failures in daemon_chat_spec unrelated to this change)
- [x] Rubocop clean on changed files
- [x] Version bump to 1.6.47