### PR TITLE
feat: trigger word tool injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## [Unreleased]
 
+## [1.7.37] - 2026-04-09
+
 ### Added
-- register_credential_providers step in boot sequence for Phase 8 credential-only identity module registration with Broker
+- Trigger word tool injection: extensions and runners declare trigger words that auto-promote deferred tools when detected in LLM messages
+- `Legion::Tools::TriggerIndex` — Concurrent::Map-backed reverse index for O(1) trigger word lookup
+- `trigger_words` DSL on Extensions::Core, runner modules, and Tools::Base
 
 ## [1.7.36] - 2026-04-09
 

--- a/lib/legion/api/llm.rb
+++ b/lib/legion/api/llm.rb
@@ -314,40 +314,40 @@ module Legion
                   case event[:type]
                   when :tool_call
                     emitted_tool_call_ids << event[:tool_call_id] if event[:tool_call_id]
-                    out << "event: tool-call\ndata: #{Legion::JSON.dump({
-                                                                          toolCallId: event[:tool_call_id],
-                                                                          toolName:   event[:tool_name],
-                                                                          args:       event[:arguments] || {},
-                                                                          startedAt:  event[:started_at]&.iso8601(3),
-                                                                          timestamp:  event[:started_at]&.iso8601(3) || Time.now.iso8601(3)
-                                                                        })}\n\n"
+                    out << "event: tool-call\ndata: #{Legion::JSON.generate({
+                                                                              toolCallId: event[:tool_call_id],
+                                                                              toolName:   event[:tool_name],
+                                                                              args:       event[:arguments] || {},
+                                                                              startedAt:  event[:started_at]&.iso8601(3),
+                                                                              timestamp:  event[:started_at]&.iso8601(3) || Time.now.iso8601(3)
+                                                                            })}\n\n"
                   when :tool_result
-                    out << "event: tool-result\ndata: #{Legion::JSON.dump({
-                                                                            toolCallId: event[:tool_call_id],
-                                                                            toolName:   event[:tool_name],
-                                                                            result:     event[:result],
-                                                                            startedAt:  event[:started_at]&.iso8601(3),
-                                                                            finishedAt: event[:finished_at]&.iso8601(3) || Time.now.iso8601(3),
-                                                                            durationMs: event[:duration_ms],
-                                                                            timestamp:  event[:finished_at]&.iso8601(3) || Time.now.iso8601(3)
-                                                                          })}\n\n"
+                    out << "event: tool-result\ndata: #{Legion::JSON.generate({
+                                                                                toolCallId: event[:tool_call_id],
+                                                                                toolName:   event[:tool_name],
+                                                                                result:     event[:result],
+                                                                                startedAt:  event[:started_at]&.iso8601(3),
+                                                                                finishedAt: event[:finished_at]&.iso8601(3) || Time.now.iso8601(3),
+                                                                                durationMs: event[:duration_ms],
+                                                                                timestamp:  event[:finished_at]&.iso8601(3) || Time.now.iso8601(3)
+                                                                              })}\n\n"
                   when :tool_error
-                    out << "event: tool-error\ndata: #{Legion::JSON.dump({
-                                                                           toolCallId: event[:tool_call_id],
-                                                                           toolName:   event[:tool_name],
-                                                                           error:      (event[:error] || event[:result]).to_s,
-                                                                           startedAt:  event[:started_at]&.iso8601(3),
-                                                                           finishedAt: Time.now.iso8601(3),
-                                                                           timestamp:  Time.now.iso8601(3)
-                                                                         })}\n\n"
-                  when :model_fallback
-                    out << "event: model-fallback\ndata: #{Legion::JSON.dump({
-                                                                               fromModel:  event[:from_model],
-                                                                               toModel:    event[:to_model],
-                                                                               toModelKey: event[:to_model],
-                                                                               error:      event[:error] || 'Provider unavailable',
-                                                                               reason:     event[:reason] || 'provider_fallback'
+                    out << "event: tool-error\ndata: #{Legion::JSON.generate({
+                                                                               toolCallId: event[:tool_call_id],
+                                                                               toolName:   event[:tool_name],
+                                                                               error:      (event[:error] || event[:result]).to_s,
+                                                                               startedAt:  event[:started_at]&.iso8601(3),
+                                                                               finishedAt: Time.now.iso8601(3),
+                                                                               timestamp:  Time.now.iso8601(3)
                                                                              })}\n\n"
+                  when :model_fallback
+                    out << "event: model-fallback\ndata: #{Legion::JSON.generate({
+                                                                                   fromModel:  event[:from_model],
+                                                                                   toModel:    event[:to_model],
+                                                                                   toModelKey: event[:to_model],
+                                                                                   error:      event[:error] || 'Provider unavailable',
+                                                                                   reason:     event[:reason] || 'provider_fallback'
+                                                                                 })}\n\n"
                   end
                 end
 
@@ -357,7 +357,7 @@ module Legion
                   next if text.empty?
 
                   full_text << text
-                  out << "event: text-delta\ndata: #{Legion::JSON.dump({ delta: text })}\n\n"
+                  out << "event: text-delta\ndata: #{Legion::JSON.generate({ delta: text })}\n\n"
                 end
 
                 # Post-hoc safety net: emit any tool-calls that weren't fired in real-time
@@ -367,11 +367,11 @@ module Legion
                     tc_id = tc.respond_to?(:id) ? tc.id : nil
                     next if tc_id && emitted_tool_call_ids.include?(tc_id)
 
-                    out << "event: tool-call\ndata: #{Legion::JSON.dump({
-                                                                          toolCallId: tc_id,
-                                                                          toolName:   tc.respond_to?(:name) ? tc.name : tc.to_s,
-                                                                          args:       tc.respond_to?(:arguments) ? tc.arguments : {}
-                                                                        })}\n\n"
+                    out << "event: tool-call\ndata: #{Legion::JSON.generate({
+                                                                              toolCallId: tc_id,
+                                                                              toolName:   tc.respond_to?(:name) ? tc.name : tc.to_s,
+                                                                              args:       tc.respond_to?(:arguments) ? tc.arguments : {}
+                                                                            })}\n\n"
                   end
                 end
 
@@ -384,20 +384,20 @@ module Legion
                   resolved_model = (model || provider).to_s.strip
                   next if resolved_model.empty?
 
-                  out << "event: model-fallback\ndata: #{Legion::JSON.dump({
-                                                                             fromModel:  pipeline_response.routing&.dig(:model),
-                                                                             toModel:    resolved_model,
-                                                                             toModelKey: resolved_model,
-                                                                             error:      w[:original_error] || 'Provider unavailable',
-                                                                             reason:     'provider_fallback'
-                                                                           })}\n\n"
+                  out << "event: model-fallback\ndata: #{Legion::JSON.generate({
+                                                                                 fromModel:  pipeline_response.routing&.dig(:model),
+                                                                                 toModel:    resolved_model,
+                                                                                 toModelKey: resolved_model,
+                                                                                 error:      w[:original_error] || 'Provider unavailable',
+                                                                                 reason:     'provider_fallback'
+                                                                               })}\n\n"
                 end
 
                 enrichments = pipeline_response.enrichments
-                out << "event: enrichment\ndata: #{Legion::JSON.dump(enrichments)}\n\n" if enrichments.is_a?(Hash) && !enrichments.empty?
+                out << "event: enrichment\ndata: #{Legion::JSON.generate(enrichments)}\n\n" if enrichments.is_a?(Hash) && !enrichments.empty?
 
                 tokens = pipeline_response.tokens
-                out << "event: done\ndata: #{Legion::JSON.dump({
+                out << "event: done\ndata: #{Legion::JSON.generate({
                   content:            full_text,
                   model:              pipeline_response.routing&.dig(:model),
                   conversation_id:    pipeline_response.conversation_id,
@@ -409,7 +409,7 @@ module Legion
                 }.compact)}\n\n"
               rescue StandardError => e
                 Legion::Logging.log_exception(e, payload_summary: 'api/llm/inference stream failed', component_type: :api)
-                out << "event: error\ndata: #{Legion::JSON.dump({ code: 'stream_error', message: e.message })}\n\n"
+                out << "event: error\ndata: #{Legion::JSON.generate({ code: 'stream_error', message: e.message })}\n\n"
               end
             else
               pipeline_response = executor.call

--- a/lib/legion/audit/siem_export.rb
+++ b/lib/legion/audit/siem_export.rb
@@ -26,7 +26,7 @@ module Legion
       end
 
       def to_ndjson(records)
-        export_batch(records).map { |r| Legion::JSON.dump(r) }.join("\n")
+        export_batch(records).map { |r| Legion::JSON.generate(r) }.join("\n")
       end
     end
   end

--- a/lib/legion/extensions/builders/runners.rb
+++ b/lib/legion/extensions/builders/runners.rb
@@ -21,42 +21,44 @@ module Legion
         def build_runner_list
           runner_files.each do |file|
             runner_name = file.split('/').last.sub('.rb', '')
-            runner_class =  "#{lex_class}::Runners::#{runner_name.split('_').collect(&:capitalize).join}"
+            runner_class = "#{lex_class}::Runners::#{runner_name.split('_').collect(&:capitalize).join}"
             loaded_runner = Kernel.const_get(runner_class)
             loaded_runner.extend(Legion::Extensions::Definitions) unless loaded_runner.respond_to?(:definition)
             Legion::Logging.debug "[Runners] registered: #{runner_class}" if defined?(Legion::Logging)
+            @runners[runner_name.to_sym] = build_runner_entry(runner_name, runner_class, loaded_runner, file)
+            populate_runner_methods(runner_name, loaded_runner)
+          end
+        end
 
-            @runners[runner_name.to_sym] = {
-              extension:       lex_class.to_s.downcase,
-              extension_name:  extension_name,
-              extension_class: lex_class,
-              runner_name:     runner_name,
-              runner_class:    runner_class,
-              runner_module:   loaded_runner,
-              runner_path:     file,
-              class_methods:   {}
+        def build_runner_entry(runner_name, runner_class, loaded_runner, file)
+          entry = {
+            extension:       lex_class.to_s.downcase,
+            extension_name:  extension_name,
+            extension_class: lex_class,
+            runner_name:     runner_name,
+            runner_class:    runner_class,
+            runner_module:   loaded_runner,
+            runner_path:     file,
+            class_methods:   {}
+          }
+          entry[:scheduled_tasks] = loaded_runner.scheduled_tasks if loaded_runner.method_defined?(:scheduled_tasks)
+          entry[:trigger_words] = loaded_runner.trigger_words if loaded_runner.respond_to?(:trigger_words)
+          entry[:desc] = settings[:runners][runner_name.to_sym][:desc] if settings.key?(:runners) && settings[:runners].key?(runner_name.to_sym)
+          entry
+        end
+
+        def populate_runner_methods(runner_name, loaded_runner)
+          loaded_runner.public_instance_methods(false).each do |runner_method|
+            @runners[runner_name.to_sym][:class_methods][runner_method] = {
+              args: loaded_runner.instance_method(runner_method).parameters
             }
+          end
+          loaded_runner.methods(false).each do |runner_method|
+            next if %i[scheduled_tasks runner_description].include?(runner_method)
 
-            @runners[runner_name.to_sym][:scheduled_tasks] = loaded_runner.scheduled_tasks if loaded_runner.method_defined? :scheduled_tasks
-            @runners[runner_name.to_sym][:trigger_words] = loaded_runner.trigger_words if loaded_runner.respond_to?(:trigger_words)
-
-            if settings.key?(:runners) && settings[:runners].key?(runner_name.to_sym)
-              @runners[runner_name.to_sym][:desc] = settings[:runners][runner_name.to_sym][:desc]
-            end
-
-            loaded_runner.public_instance_methods(false).each do |runner_method|
-              @runners[runner_name.to_sym][:class_methods][runner_method] = {
-                args: loaded_runner.instance_method(runner_method).parameters
-              }
-            end
-
-            loaded_runner.methods(false).each do |runner_method|
-              next if %i[scheduled_tasks runner_description].include? runner_method
-
-              @runners[runner_name.to_sym][:class_methods][runner_method] = {
-                args: loaded_runner.method(runner_method).parameters
-              }
-            end
+            @runners[runner_name.to_sym][:class_methods][runner_method] = {
+              args: loaded_runner.method(runner_method).parameters
+            }
           end
         end
 

--- a/lib/legion/extensions/builders/runners.rb
+++ b/lib/legion/extensions/builders/runners.rb
@@ -38,6 +38,7 @@ module Legion
             }
 
             @runners[runner_name.to_sym][:scheduled_tasks] = loaded_runner.scheduled_tasks if loaded_runner.method_defined? :scheduled_tasks
+            @runners[runner_name.to_sym][:trigger_words] = loaded_runner.trigger_words if loaded_runner.respond_to?(:trigger_words)
 
             if settings.key?(:runners) && settings[:runners].key?(runner_name.to_sym)
               @runners[runner_name.to_sym][:desc] = settings[:runners][runner_name.to_sym][:desc]

--- a/lib/legion/extensions/core.rb
+++ b/lib/legion/extensions/core.rb
@@ -120,6 +120,10 @@ module Legion
         true
       end
 
+      def trigger_words
+        []
+      end
+
       # Auto-generate AMQP message classes for each runner method that has a definition.
       # Explicit Messages::* classes in the transport directory take precedence.
       # Runs after build_runners so definitions are populated.

--- a/lib/legion/service.rb
+++ b/lib/legion/service.rb
@@ -935,6 +935,7 @@ module Legion
       require 'legion/tools'
       Legion::Tools.register_all
       Legion::Tools::Discovery.discover_and_register
+      Legion::Tools::TriggerIndex.build_async!
       Legion::Tools::EmbeddingCache.setup
 
       log.info(

--- a/lib/legion/service.rb
+++ b/lib/legion/service.rb
@@ -935,7 +935,13 @@ module Legion
       require 'legion/tools'
       Legion::Tools.register_all
       Legion::Tools::Discovery.discover_and_register
-      Legion::Tools::TriggerIndex.build_async!
+      future = Legion::Tools::TriggerIndex.build_async!
+      if future.respond_to?(:rescue)
+        @trigger_index_build_future = future.rescue do |e|
+          handle_exception(e, level: :warn, operation: 'service.register_core_tools.trigger_index_build')
+          nil
+        end
+      end
       Legion::Tools::EmbeddingCache.setup
 
       log.info(

--- a/lib/legion/tools.rb
+++ b/lib/legion/tools.rb
@@ -29,7 +29,9 @@ require_relative 'tools/registry'
 require_relative 'tools/base'
 require_relative 'tools/discovery'
 require_relative 'tools/embedding_cache'
+require_relative 'tools/trigger_index'
 
 Dir[File.join(__dir__, 'tools', '*.rb')].each do |f|
-  require f unless f.end_with?('/base.rb', '/registry.rb', '/discovery.rb', '/embedding_cache.rb')
+  require f unless f.end_with?('/base.rb', '/registry.rb', '/discovery.rb', '/embedding_cache.rb',
+                                '/trigger_index.rb')
 end

--- a/lib/legion/tools.rb
+++ b/lib/legion/tools.rb
@@ -33,5 +33,5 @@ require_relative 'tools/trigger_index'
 
 Dir[File.join(__dir__, 'tools', '*.rb')].each do |f|
   require f unless f.end_with?('/base.rb', '/registry.rb', '/discovery.rb', '/embedding_cache.rb',
-                                '/trigger_index.rb')
+                               '/trigger_index.rb')
 end

--- a/lib/legion/tools/base.rb
+++ b/lib/legion/tools/base.rb
@@ -69,6 +69,12 @@ module Legion
           @mcp_tier = val
         end
 
+        def trigger_words(val = nil)
+          return @trigger_words || [] if val.nil?
+
+          @trigger_words = val
+        end
+
         def call(**_args)
           raise NotImplementedError, "#{name} must implement .call"
         end

--- a/lib/legion/tools/discovery.rb
+++ b/lib/legion/tools/discovery.rb
@@ -147,14 +147,15 @@ module Legion
           ext_name = derive_extension_name(ext)
           runner_snake = derive_runner_snake(runner_mod)
           {
-            tool_name:    defn&.dig(:mcp_prefix) || "legion-#{ext_name}-#{runner_snake}-#{func_name}",
-            description:  meta[:desc] || defn&.dig(:desc) || "#{ext_name}##{func_name}",
-            input_schema: normalize_schema(meta[:options]),
-            mcp_category: defn&.dig(:mcp_category),
-            mcp_tier:     defn&.dig(:mcp_tier),
-            deferred:     deferred,
-            ext_name:     ext_name,
-            runner_snake: runner_snake
+            tool_name:     defn&.dig(:mcp_prefix) || "legion-#{ext_name}-#{runner_snake}-#{func_name}",
+            description:   meta[:desc] || defn&.dig(:desc) || "#{ext_name}##{func_name}",
+            input_schema:  normalize_schema(meta[:options]),
+            mcp_category:  defn&.dig(:mcp_category),
+            mcp_tier:      defn&.dig(:mcp_tier),
+            deferred:      deferred,
+            ext_name:      ext_name,
+            runner_snake:  runner_snake,
+            trigger_words: merge_trigger_words(ext, runner_mod)
           }
         end
 
@@ -168,6 +169,7 @@ module Legion
             runner(attrs[:runner_snake])
             mcp_category(attrs[:mcp_category]) if attrs[:mcp_category]
             mcp_tier(attrs[:mcp_tier]) if attrs[:mcp_tier]
+            trigger_words(attrs[:trigger_words])
 
             define_singleton_method(:call) do |**params|
               if runner_ref.respond_to?(func_ref)
@@ -182,6 +184,12 @@ module Legion
               error_response(e.message)
             end
           end
+        end
+
+        def merge_trigger_words(ext, runner_mod)
+          ext_words = ext.respond_to?(:trigger_words) ? Array(ext.trigger_words) : []
+          runner_words = runner_mod.respond_to?(:trigger_words) ? Array(runner_mod.trigger_words) : []
+          (ext_words + runner_words).uniq
         end
 
         def derive_runner_snake(runner_mod)

--- a/lib/legion/tools/trigger_index.rb
+++ b/lib/legion/tools/trigger_index.rb
@@ -34,10 +34,13 @@ module Legion
           matched = Set.new
           per_word = {}
           word_set.each do |word|
-            tools = read_word(word)
+            normalized = word.to_s.downcase.gsub(/[^a-z ]/, ' ').strip
+            next if normalized.empty?
+
+            tools = read_word(normalized)
             next unless tools
 
-            per_word[word] = tools
+            per_word[normalized] = tools
             matched.merge(tools)
           end
           [matched, per_word]

--- a/lib/legion/tools/trigger_index.rb
+++ b/lib/legion/tools/trigger_index.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Legion
+  module Tools
+    module TriggerIndex
+      @index = if defined?(Concurrent::Map)
+                 Concurrent::Map.new
+               else
+                 {}
+               end
+      @mutex = Mutex.new unless defined?(Concurrent::Map)
+
+      class << self
+        def build_from_registry
+          clear
+          Registry.all_tools.each do |tool_class|
+            words = Array(tool_class.trigger_words)
+            next if words.empty?
+
+            normalized = words.flat_map { |w| w.downcase.gsub(/[^a-z ]/, ' ').split }.uniq
+            normalized.each { |word| add_tool_for_word(word, tool_class) }
+          end
+        end
+
+        def build_async!
+          if defined?(Concurrent::Promises)
+            Concurrent::Promises.future { build_from_registry }
+          else
+            build_from_registry
+          end
+        end
+
+        def match(word_set)
+          matched = Set.new
+          per_word = {}
+          word_set.each do |word|
+            tools = read_word(word)
+            next unless tools
+
+            per_word[word] = tools
+            matched.merge(tools)
+          end
+          [matched, per_word]
+        end
+
+        def empty?
+          if defined?(Concurrent::Map) && @index.is_a?(Concurrent::Map)
+            @index.each_pair.none?
+          else
+            @index.empty?
+          end
+        end
+
+        def size
+          if defined?(Concurrent::Map) && @index.is_a?(Concurrent::Map)
+            count = 0
+            @index.each_pair { count += 1 }
+            count
+          else
+            @index.size
+          end
+        end
+
+        def clear
+          if defined?(Concurrent::Map) && @index.is_a?(Concurrent::Map)
+            @index = Concurrent::Map.new
+          else
+            @mutex.synchronize { @index = {} }
+          end
+        end
+
+        private
+
+        def add_tool_for_word(word, tool_class)
+          if defined?(Concurrent::Map) && @index.is_a?(Concurrent::Map)
+            @index.compute(word) { |existing| ((existing || Set.new) + Set[tool_class]).freeze }
+          else
+            @mutex.synchronize do
+              @index[word] ||= Set.new
+              @index[word] = (@index[word] + Set[tool_class]).freeze
+            end
+          end
+        end
+
+        def read_word(word)
+          if defined?(Concurrent::Map) && @index.is_a?(Concurrent::Map)
+            @index[word]
+          else
+            @mutex&.synchronize { @index[word] }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/tools/trigger_index.rb
+++ b/lib/legion/tools/trigger_index.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'set'
+
 module Legion
   module Tools
     module TriggerIndex

--- a/lib/legion/tools/trigger_index.rb
+++ b/lib/legion/tools/trigger_index.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 module Legion
   module Tools
     module TriggerIndex

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.7.36'
+  VERSION = '1.7.37'
 end

--- a/spec/legion/extensions/core_spec.rb
+++ b/spec/legion/extensions/core_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Extensions::Core do
+  describe '.trigger_words' do
+    let(:ext_module) do
+      Module.new do
+        extend Legion::Extensions::Core
+      end
+    end
+
+    it 'defaults to an empty array' do
+      expect(ext_module.trigger_words).to eq([])
+    end
+  end
+end

--- a/spec/legion/tools/base_spec.rb
+++ b/spec/legion/tools/base_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe Legion::Tools::Base do
     end
   end
 
+  describe '.trigger_words' do
+    let(:tool_class) { Class.new(described_class) }
+
+    it 'defaults to an empty array' do
+      expect(tool_class.trigger_words).to eq([])
+    end
+
+    it 'stores and returns trigger words' do
+      tool_class.trigger_words(%w[git github gh])
+      expect(tool_class.trigger_words).to eq(%w[git github gh])
+    end
+  end
+
   describe '.call' do
     it 'raises NotImplementedError on base class' do
       expect { described_class.call }.to raise_error(NotImplementedError)

--- a/spec/legion/tools/discovery_spec.rb
+++ b/spec/legion/tools/discovery_spec.rb
@@ -105,6 +105,43 @@ RSpec.describe Legion::Tools::Discovery do
     end
   end
 
+  describe 'trigger_words propagation' do
+    before { Legion::Tools::Registry.clear }
+
+    let(:runner_mod) do
+      mod = Module.new do
+        def self.name = 'Legion::Extensions::Testlex::Runners::Stuff'
+        def self.mcp_tools? = true
+        def self.mcp_tools_deferred? = true
+        def self.trigger_words = %w[stuff things]
+        def self.settings = { functions: { do_stuff: { desc: 'does stuff', options: {} } } }
+        def self.do_stuff(**) = { result: true }
+      end
+      mod.extend(Legion::Extensions::Definitions)
+      mod
+    end
+
+    let(:ext_mod) do
+      runner = runner_mod
+      Module.new do
+        def self.name = 'Legion::Extensions::Testlex'
+        def self.lex_name = 'testlex'
+        def self.mcp_tools? = true
+        def self.mcp_tools_deferred? = true
+        def self.trigger_words = %w[test]
+        define_singleton_method(:runner_modules) { [runner] }
+      end
+    end
+
+    it 'propagates merged trigger words to registered tool classes' do
+      allow(Legion::Extensions).to receive(:loaded_extension_modules).and_return([ext_mod])
+      Legion::Tools::Discovery.discover_and_register
+
+      tool = Legion::Tools::Registry.all_tools.first
+      expect(tool.trigger_words).to include('stuff', 'things', 'test')
+    end
+  end
+
   describe 'runner-level override' do
     let(:override_runner) do
       Module.new do

--- a/spec/legion/tools/trigger_index_spec.rb
+++ b/spec/legion/tools/trigger_index_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Tools::TriggerIndex do
+  before { described_class.clear }
+
+  let(:tool_a) do
+    Class.new(Legion::Tools::Base) do
+      tool_name 'legion-github-pr-create'
+      trigger_words %w[git github pr]
+    end
+  end
+
+  let(:tool_b) do
+    Class.new(Legion::Tools::Base) do
+      tool_name 'legion-vault-secrets-read'
+      trigger_words %w[vault secret]
+    end
+  end
+
+  describe '.build_from_registry' do
+    before do
+      Legion::Tools::Registry.clear
+      Legion::Tools::Registry.register(tool_a)
+      Legion::Tools::Registry.register(tool_b)
+      described_class.build_from_registry
+    end
+
+    it 'indexes trigger words to tool classes' do
+      matched, _per_word = described_class.match(Set['git'])
+      expect(matched).to include(tool_a)
+      expect(matched).not_to include(tool_b)
+    end
+
+    it 'returns tools for multiple matched words' do
+      matched, _per_word = described_class.match(Set['git', 'vault'])
+      expect(matched).to include(tool_a, tool_b)
+    end
+
+    it 'returns empty set for no matches' do
+      matched, _per_word = described_class.match(Set['unknown'])
+      expect(matched).to be_empty
+    end
+
+    it 'returns per_word breakdown for scoring' do
+      _matched, per_word = described_class.match(Set['git', 'vault'])
+      expect(per_word).to have_key('git')
+      expect(per_word).to have_key('vault')
+      expect(per_word['git']).to include(tool_a)
+    end
+
+    it 'handles overlapping trigger words across tools' do
+      tool_c = Class.new(Legion::Tools::Base) do
+        tool_name 'legion-github-repos-list'
+        trigger_words %w[git repo]
+      end
+      Legion::Tools::Registry.register(tool_c)
+      described_class.build_from_registry
+
+      matched, _per_word = described_class.match(Set['git'])
+      expect(matched).to include(tool_a, tool_c)
+      expect(matched).not_to include(tool_b)
+    end
+  end
+
+  describe '.match' do
+    it 'returns empty set when index is empty' do
+      matched, per_word = described_class.match(Set['anything'])
+      expect(matched).to be_empty
+      expect(per_word).to be_empty
+    end
+  end
+
+  describe '.empty?' do
+    it 'is true when no trigger words are indexed' do
+      expect(described_class).to be_empty
+    end
+
+    it 'is false after building from registry with trigger words' do
+      Legion::Tools::Registry.clear
+      Legion::Tools::Registry.register(tool_a)
+      described_class.build_from_registry
+      expect(described_class).not_to be_empty
+    end
+  end
+
+  describe '.size' do
+    it 'returns the number of unique trigger words indexed' do
+      Legion::Tools::Registry.clear
+      Legion::Tools::Registry.register(tool_a)
+      Legion::Tools::Registry.register(tool_b)
+      described_class.build_from_registry
+      expect(described_class.size).to eq(5) # git, github, pr, vault, secret
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Extensions and runners declare `trigger_words` that, when detected in recent LLM messages, automatically promote their deferred tools to active for that request
- `Legion::Tools::TriggerIndex` — `Concurrent::Map`-backed reverse index mapping trigger words to frozen Sets of tool class references, built asynchronously at boot
- `trigger_words` DSL added to `Extensions::Core`, runner modules, and `Tools::Base`
- `Tools::Discovery` merges extension-level and runner-level trigger words onto tool classes

Companion PR: LegionIO/legion-llm (pipeline step + executor integration)

Design doc: `docs/plans/2026-04-09-trigger-word-tool-injection-design.md`

## Test plan

- [ ] Verify `trigger_words` DSL works on Tools::Base subclasses
- [ ] Verify Extensions::Core provides empty default
- [ ] Verify Discovery merges ext+runner trigger words onto tool classes
- [ ] Verify TriggerIndex builds from Registry, matches words to tool Sets
- [ ] Verify TriggerIndex.build_async! is called in boot sequence
- [ ] Full rspec suite passes (4762 examples, 0 failures)
- [ ] RuboCop clean (0 offenses)