### PR TITLE
Fleet WS-00F: fix generate_task_id namespace case sensitivity

### DIFF
--- a/lib/legion/runner/status.rb
+++ b/lib/legion/runner/status.rb
@@ -41,7 +41,7 @@ module Legion
         Legion::Logging.debug "[Status] generate_task_id: #{runner_class}##{function} status=#{status}" if defined?(Legion::Logging)
         return nil unless Legion::Settings[:data][:connected]
 
-        runner = Legion::Data::Model::Runner.where(namespace: runner_class.to_s.downcase).first
+        runner = Legion::Data::Model::Runner.where(namespace: runner_class.to_s).first
         return nil if runner.nil?
 
         function = Legion::Data::Model::Function.where(runner_id: runner.values[:id], name: function).first

--- a/spec/runner/status_spec.rb
+++ b/spec/runner/status_spec.rb
@@ -3,6 +3,16 @@
 require 'spec_helper'
 require 'legion/runner/log'
 
+module Legion
+  module Data
+    module Model
+      Runner = Class.new unless const_defined?(:Runner, false)
+      Function = Class.new unless const_defined?(:Function, false)
+      Task = Class.new unless const_defined?(:Task, false)
+    end
+  end
+end
+
 RSpec.describe Legion::Runner::Status do
   describe 'it should have things' do
     it { is_expected.to be_a Module }
@@ -10,5 +20,38 @@ RSpec.describe Legion::Runner::Status do
     it { is_expected.to respond_to :update_rmq }
     it { is_expected.to respond_to :update_db }
     it { is_expected.to respond_to :generate_task_id }
+  end
+
+  describe '.generate_task_id' do
+    context 'when data is not connected' do
+      before do
+        allow(Legion::Settings).to receive(:[]).with(:data).and_return({ connected: false })
+      end
+
+      it 'returns nil' do
+        expect(described_class.generate_task_id(runner_class: 'SomeRunner', function: 'run')).to be_nil
+      end
+    end
+
+    context 'when data is connected' do
+      let(:runner_relation) { double('runner_relation', first: nil) }
+
+      before do
+        allow(Legion::Settings).to receive(:[]).with(:data).and_return({ connected: true })
+        allow(Legion::Data::Model::Runner).to receive(:where).and_return(runner_relation)
+      end
+
+      it 'queries runner namespace without downcasing (preserves mixed case)' do
+        expect(Legion::Data::Model::Runner)
+          .to receive(:where).with(namespace: 'Legion::Extensions::MyRunner')
+          .and_return(runner_relation)
+        described_class.generate_task_id(runner_class: 'Legion::Extensions::MyRunner', function: 'run')
+      end
+
+      it 'returns nil when runner is not found' do
+        result = described_class.generate_task_id(runner_class: 'Legion::Extensions::MyRunner', function: 'run')
+        expect(result).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `Runner::Status.generate_task_id` queried `Runner.where(namespace: runner_class.to_s.downcase)`
- DB stores namespaces in mixed case (e.g. `Legion::Extensions::Tasker`) — `.downcase` never matched, always returning `nil`
- Fix: remove `.downcase`, query with exact casing

## Test plan

- [x] Added `.generate_task_id` specs to `spec/runner/status_spec.rb`
- [x] Watched test fail: expected `namespace: "Legion::Extensions::MyRunner"`, got `namespace: "legion::extensions::myrunner"`
- [x] Applied one-line fix, tests pass
- [x] Full suite: 0 new failures
- [x] Rubocop: 0 offenses