### PR TITLE
Fleet WS-00H: forward task_id/master_id explicitly to CheckSubtask.new

### DIFF
--- a/lib/legion/runner.rb
+++ b/lib/legion/runner.rb
@@ -76,6 +76,8 @@ module Legion
                                                       function:      function,
                                                       result:        result,
                                                       original_args: args,
+                                                      task_id:       task_id,
+                                                      master_id:     master_id,
                                                       **opts).publish
       end
       if defined?(Legion::Audit)

--- a/spec/legion/runner_check_subtask_spec.rb
+++ b/spec/legion/runner_check_subtask_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/runner'
+
+module TestRunners
+  module CheckSubtaskTest
+    def self.do_work(**_args)
+      { result: 'done' }
+    end
+  end
+end
+
+RSpec.describe 'Runner.run CheckSubtask forwarding' do
+  before do
+    stub_const('Legion::Exception::HandledTask', Class.new(StandardError)) unless defined?(Legion::Exception::HandledTask)
+    allow(Legion::Events).to receive(:emit)
+    allow(Legion::Runner::Status).to receive(:generate_task_id).and_return({ task_id: 42 })
+    allow(Legion::Runner::Status).to receive(:update)
+  end
+
+  # When args: is provided explicitly, args != opts (no aliasing), so task_id/master_id
+  # must be forwarded explicitly to CheckSubtask.new — they won't appear via **opts.
+  describe 'explicit args: path — task_id and master_id must be forwarded' do
+    let(:check_subtask_dbl) { double('check_subtask', publish: nil) }
+
+    before do
+      allow(Legion::Transport::Messages::CheckSubtask).to receive(:new).and_return(check_subtask_dbl)
+    end
+
+    it 'forwards task_id explicitly when args: is provided' do
+      Legion::Runner.run(
+        runner_class:  TestRunners::CheckSubtaskTest,
+        function:      :do_work,
+        task_id:       99,
+        args:          { some_param: 'value' },
+        check_subtask: true
+      )
+      expect(Legion::Transport::Messages::CheckSubtask).to have_received(:new).with(
+        hash_including(task_id: 99)
+      )
+    end
+
+    it 'forwards master_id explicitly when args: is provided' do
+      Legion::Runner.run(
+        runner_class:  TestRunners::CheckSubtaskTest,
+        function:      :do_work,
+        task_id:       99,
+        master_id:     7,
+        args:          { some_param: 'value' },
+        check_subtask: true
+      )
+      expect(Legion::Transport::Messages::CheckSubtask).to have_received(:new).with(
+        hash_including(master_id: 7)
+      )
+    end
+
+    it 'forwards both task_id and master_id when args: is provided' do
+      Legion::Runner.run(
+        runner_class:  TestRunners::CheckSubtaskTest,
+        function:      :do_work,
+        task_id:       55,
+        master_id:     3,
+        args:          { payload: 'data' },
+        check_subtask: true
+      )
+      expect(Legion::Transport::Messages::CheckSubtask).to have_received(:new).with(
+        hash_including(task_id: 55, master_id: 3)
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Bug:** When `Runner.run` is called with an explicit `args:` hash, `args` and `opts` are separate objects. Mutating `args[:task_id]` does not populate `opts`, so the `**opts` spread in the `CheckSubtask.new(...)` ensure block omitted `task_id` and `master_id`. Downstream subtask check messages were missing these IDs.
- **Fix:** Explicitly pass `task_id: task_id, master_id: master_id` as keyword args to `CheckSubtask.new`.
- **Test:** New `spec/legion/runner_check_subtask_spec.rb` exercises the explicit-`args:` path that surfaces the bug.

## Test plan

- [ ] `bundle exec rspec spec/legion/runner_check_subtask_spec.rb spec/legion/runner_audit_spec.rb` — 9 examples, 0 failures
- [ ] `bundle exec rubocop lib/legion/runner.rb spec/legion/runner_check_subtask_spec.rb` — 0 offenses