### PR TITLE
fix: runner_class resolution for Actor:: nested actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-04-14
+
+### Fixed
+- `runner_class` resolution for actors nested under `Actor::` namespace — `sub(/Actor$/, 'Runners')` only matched `Actor` at end-of-string, failing for `Extension::Actor::ClassName` patterns (e.g., `Health::Actor::Watchdog`, `Node::Actor::Beat`). Changed to `sub(/::Actor::/, '::Runners::')` which matches the path segment. Affects 9+ actors across lex-health, lex-node, lex-tasker, lex-conditioner, lex-transformer.
+- Added defensive guard in `manual` method — raises descriptive `NoMethodError` when `runner_class` resolves to the actor itself and the function is not defined, instead of a generic undefined method error.
+
 ## [1.8.2] - 2026-04-13
 
 ### Added

--- a/lib/legion/extensions/actors/base.rb
+++ b/lib/legion/extensions/actors/base.rb
@@ -29,6 +29,11 @@ module Legion
           klass = Kernel.const_get(klass) if klass.is_a?(String)
           func = respond_to?(:runner_function) ? runner_function : :action
           if klass == self.class
+            unless respond_to?(func)
+              raise NoMethodError,
+                    "#{self.class} resolved runner_class to itself but does not define '#{func}'. " \
+                    'Override runner_class or define the method on the actor.'
+            end
             send(func, **args)
           else
             klass.send(func, **args)

--- a/lib/legion/extensions/helpers/base.rb
+++ b/lib/legion/extensions/helpers/base.rb
@@ -83,7 +83,7 @@ module Legion
         end
 
         def runner_class
-          @runner_class ||= Kernel.const_get(actor_class.to_s.sub(/Actor$/, 'Runners'))
+          @runner_class ||= Kernel.const_get(actor_class.to_s.sub('::Actor::', '::Runners::'))
         end
 
         def runner_name

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.8.2'
+  VERSION = '1.8.3'
 end


### PR DESCRIPTION
## Summary
- Fix `runner_class` in `helpers/base.rb` — `sub(/Actor$/, 'Runners')` didn't match `Extension::Actor::ClassName` patterns. Changed to `sub('::Actor::', '::Runners::')`.
- Add defensive guard in `manual` — raises descriptive error when runner_class resolves to actor itself.
- Bump version to 1.8.3.

## Root Cause
Commit b544772 (Apr 12) changed `sub('Actor', 'Runners')` to `sub(/Actor$/, 'Runners')` to prevent a double-s bug. The `$` anchor over-corrected — it only matches `Actor` at end-of-string, but actor class names end with `Watchdog`, `Beat`, etc.

## Affected
9+ actors across lex-health, lex-node, lex-tasker, lex-conditioner, lex-transformer.

Fixes #135

## Test plan
- 4829 examples, 0 failures related to this change (2 pre-existing test-ordering failures in embedding_cache_spec unrelated)
- 860 files inspected, 0 rubocop offenses