### PR TITLE
Fleet WS-10: CLI wiring + relationship manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.8.4] - 2026-04-14
+
+### Added
+- `legionio fleet` CLI subcommand tree: `status`, `pending`, `approve`, `add`, `config`
+- `legionio setup fleet` two-phase command: phase 1 installs fleet gems, phase 2 wires relationships via `Workflow::Loader`, seeds conditioner rules, registers settings via `load_module_settings`, merges LLM routing overrides, applies RabbitMQ planner consumer timeout policy
+- Fleet pipeline YAML manifest with 10 relationships (1-8 plus 4b, 4c) connecting assessor, planner, developer, and validator
+- `Legion::Fleet::SettingsDefaults` — file-based fleet settings persistence
+- `Legion::Fleet::ConditionerRules` — supplementary conditioner rule seeds (skip-planning-trivial, skip-validation-trivial, escalate-max-iterations, critical-production-max-capability, governance-mind-growth)
+- Fleet API routes: `POST /api/fleet/sources`, `GET /api/fleet/pending` (filters both `fleet.shipping` and `fleet.escalation`), `POST /api/fleet/approve`, `GET /api/fleet/sources`, `GET /api/fleet/status`
+
 ## [1.8.3] - 2026-04-14
 
 ### Fixed

--- a/lib/legion/api.rb
+++ b/lib/legion/api.rb
@@ -62,6 +62,7 @@ require_relative 'api/webhooks'
 require_relative 'api/tenants'
 require_relative 'api/inbound_webhooks'
 require_relative 'api/identity_audit'
+require_relative 'api/fleet'
 require_relative 'api/graphql' if defined?(GraphQL)
 
 module Legion
@@ -220,6 +221,7 @@ module Legion
     register Routes::Tenants
     register Routes::InboundWebhooks
     register Routes::IdentityAudit
+    register Routes::Fleet
     register Routes::GraphQL if defined?(Routes::GraphQL)
 
     use Legion::API::Middleware::RequestLogger

--- a/lib/legion/api/fleet.rb
+++ b/lib/legion/api/fleet.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Legion
+  class API < Sinatra::Base
+    module Routes
+      module Fleet
+        def self.registered(app)
+          app.helpers FleetHelpers
+
+          app.get '/api/fleet/status' do
+            json_response(fleet_status)
+          end
+
+          app.get '/api/fleet/pending' do
+            items = fleet_pending_approvals
+            json_response(items)
+          end
+
+          app.post '/api/fleet/approve' do
+            body = parse_request_body
+            id = body[:id]
+            halt 400, json_error('missing_id', 'id is required', status_code: 400) unless id
+
+            result = fleet_approve(id.to_i)
+            if result[:success]
+              json_response(result)
+            else
+              json_error('approve_failed', result[:error].to_s, status_code: 422)
+            end
+          end
+
+          app.get '/api/fleet/sources' do
+            sources = Legion::Settings.dig(:fleet, :sources) || []
+            json_response({ sources: sources })
+          end
+
+          app.post '/api/fleet/sources' do
+            body = parse_request_body
+            source = body[:source]
+            halt 400, json_error('missing_source', 'source is required', status_code: 400) unless source
+
+            result = fleet_add_source(body)
+            if result[:success]
+              json_response(result, status_code: 201)
+            else
+              json_error('add_source_failed', result[:error].to_s, status_code: 422)
+            end
+          end
+        end
+
+        module FleetHelpers
+          def fleet_status
+            queues = []
+            active = 0
+            workers = 0
+
+            if defined?(Legion::Transport) && Legion::Settings.dig(:transport, :connected)
+              %w[assessor planner developer validator].each do |ext|
+                queue_name = "lex.#{ext}.runners.#{ext}"
+                depth = fleet_queue_depth(queue_name)
+                queues << { name: queue_name, depth: depth } if depth
+              end
+            end
+
+            { queues: queues, active_work_items: active, workers: workers }
+          end
+
+          def fleet_queue_depth(queue_name)
+            return nil unless defined?(Legion::Transport::Session)
+
+            channel = Legion::Transport::Session.channel
+            queue = channel.queue(queue_name, passive: true)
+            queue.message_count
+          rescue StandardError
+            nil
+          end
+
+          def fleet_pending_approvals
+            approval_types = %w[fleet.shipping fleet.escalation]
+
+            if defined?(Legion::Data::Model::Task)
+              Legion::Data::Model::Task
+                .where(status: 'pending_approval')
+                .where(Sequel.lit('JSON_EXTRACT(payload, ?) IN ?',
+                                  '$.approval_type', approval_types))
+                .order(Sequel.desc(:created_at))
+                .limit(page_limit)
+                .all
+                .map(&:values)
+            else
+              []
+            end
+          rescue StandardError => e
+            Legion::Logging.warn "Fleet#fleet_pending_approvals: #{e.message}" if defined?(Legion::Logging)
+            []
+          end
+
+          def fleet_approve(_id)
+            { success: false, error: 'approval system not available' }
+          end
+
+          def fleet_add_source(body)
+            source = body[:source]
+            case source
+            when 'github'
+              fleet_setup_github_source(body)
+            else
+              { success: false, error: "Unknown source: #{source}" }
+            end
+          end
+
+          def fleet_setup_github_source(body)
+            sources = Legion::Settings.dig(:fleet, :sources) || []
+            entry = {
+              type:  'github',
+              owner: body[:owner],
+              repo:  body[:repo]
+            }
+            sources << entry
+
+            Legion::Settings.loader.settings[:fleet] ||= {}
+            Legion::Settings.loader.settings[:fleet][:sources] = sources
+
+            { success: true, source: 'github', absorber: 'issues' }
+          rescue StandardError => e
+            { success: false, error: e.message }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/cli.rb
+++ b/lib/legion/cli.rb
@@ -72,6 +72,7 @@ module Legion
     autoload :Broker,         'legion/cli/broker_command'
     autoload :AdminCommand,   'legion/cli/admin_command'
     autoload :Workflow,       'legion/cli/workflow_command'
+    autoload :FleetCommand,   'legion/cli/fleet_command'
     autoload :Mode,           'legion/cli/mode_command'
 
     module Groups
@@ -312,6 +313,9 @@ module Legion
 
       desc 'workflow SUBCOMMAND', 'Manage workflow bundles'
       subcommand 'workflow', Legion::CLI::Workflow
+
+      desc 'fleet SUBCOMMAND', 'Fleet pipeline operations (status, pending, approve, add, config)'
+      subcommand 'fleet', Legion::CLI::FleetCommand
 
       desc 'mode SUBCOMMAND', 'View and switch extension profiles and process roles'
       subcommand 'mode', Legion::CLI::Mode

--- a/lib/legion/cli/fleet_command.rb
+++ b/lib/legion/cli/fleet_command.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'thor'
+require_relative 'api_client'
+require_relative 'output'
+require_relative 'connection'
+
+module Legion
+  module CLI
+    class FleetCommand < Thor
+      def self.exit_on_failure?
+        true
+      end
+
+      namespace 'fleet'
+
+      class_option :json,     type: :boolean, default: false, desc: 'Output as JSON'
+      class_option :no_color, type: :boolean, default: false, desc: 'Disable color output'
+
+      desc 'status', 'Show fleet pipeline status (queue depths, active work items, workers)'
+      def status
+        out = formatter
+        data = fetch_fleet_status
+
+        if options[:json]
+          out.json(data)
+        else
+          out.header('Fleet Pipeline Status')
+          out.spacer
+
+          puts "  Active work items: #{data[:active_work_items] || 0}"
+          puts "  Workers:           #{data[:workers] || 0}"
+          out.spacer
+
+          if data[:queues]&.any?
+            rows = data[:queues].map { |q| [q[:name], q[:depth].to_s] }
+            out.table(%w[Queue Depth], rows)
+          else
+            puts '  No fleet queues found'
+          end
+        end
+      end
+      default_task :status
+
+      desc 'pending', 'List work items awaiting human approval'
+      option :limit, type: :numeric, default: 20, aliases: ['-n'], desc: 'Max items to show'
+      def pending
+        out = formatter
+        items = fetch_pending_approvals
+
+        if options[:json]
+          out.json(items)
+        elsif items.empty?
+          puts '  No pending approvals'
+        else
+          out.header('Pending Approvals')
+          rows = items.first(options[:limit]).map do |item|
+            [item[:id].to_s, item[:source_ref].to_s, item[:title].to_s,
+             item[:source].to_s, item[:created_at].to_s]
+          end
+          out.table(['ID', 'Source Ref', 'Title', 'Source', 'Created'], rows)
+        end
+      end
+
+      desc 'approve ID', 'Approve a pending work item and resume the pipeline'
+      def approve(id)
+        out = formatter
+        result = approve_work_item(id.to_i)
+
+        if options[:json]
+          out.json(result)
+        elsif result[:success]
+          out.success("Approved work item #{id} (#{result[:work_item_id]})")
+          puts "  Pipeline resumed: #{result[:resumed]}"
+        else
+          out.error("Approval failed: #{result[:error]}")
+          raise SystemExit, 1
+        end
+      end
+
+      desc 'add SOURCE', 'Add a source to the fleet pipeline (e.g., github, slack)'
+      option :owner, type: :string, desc: 'GitHub org/owner (for github source)'
+      option :repo, type: :string, desc: 'GitHub repo name (for github source)'
+      option :webhook_url, type: :string, desc: 'Webhook callback URL'
+      def add(source)
+        out = formatter
+        result = add_fleet_source(source)
+
+        if options[:json]
+          out.json(result)
+        elsif result[:success]
+          out.success("Added #{source} as fleet source")
+          puts "  Absorber: #{result[:absorber]}" if result[:absorber]
+          puts "  Webhook:  #{result[:webhook_url]}" if result[:webhook_url]
+          out.spacer
+          puts '  The fleet will now process incoming events from this source.'
+        else
+          out.error("Failed to add source: #{result[:error]}")
+          raise SystemExit, 1
+        end
+      end
+
+      desc 'config', 'Show fleet configuration'
+      def config
+        out = formatter
+        with_settings do
+          fleet_settings = Legion::Settings[:fleet] || {}
+
+          if options[:json]
+            out.json(fleet_settings)
+          else
+            out.header('Fleet Configuration')
+            out.spacer
+            puts "  Enabled:  #{fleet_settings[:enabled] || false}"
+            puts "  Sources:  #{(fleet_settings[:sources] || []).join(', ').then { |s| s.empty? ? 'none' : s }}"
+            out.spacer
+
+            puts '  Defaults:'
+            puts "    Planning:       #{fleet_settings.dig(:planning, :enabled) ? 'enabled' : 'disabled'}"
+            puts "    Validation:     #{fleet_settings.dig(:validation, :enabled) ? 'enabled' : 'disabled'}"
+            puts "    Max iterations: #{fleet_settings.dig(:implementation, :max_iterations) || 5}"
+            puts "    Validators:     #{fleet_settings.dig(:implementation, :validators) || 3}"
+            puts "    Isolation:      #{fleet_settings.dig(:workspace, :isolation) || 'worktree'}"
+          end
+        end
+      end
+
+      no_commands do
+        include ApiClient
+
+        def formatter
+          @formatter ||= Output::Formatter.new(json: options[:json], color: !options[:no_color])
+        end
+
+        private
+
+        def fetch_fleet_status
+          api_get('/api/fleet/status')
+        rescue SystemExit
+          { queues: [], active_work_items: 0, workers: 0 }
+        end
+
+        def fetch_pending_approvals
+          api_get('/api/fleet/pending')
+        rescue SystemExit
+          []
+        end
+
+        def approve_work_item(id)
+          api_post('/api/fleet/approve', id: id)
+        end
+
+        def add_fleet_source(source)
+          payload = { source: source }
+          payload[:owner] = options[:owner] if options[:owner]
+          payload[:repo] = options[:repo] if options[:repo]
+          payload[:webhook_url] = options[:webhook_url] if options[:webhook_url]
+          api_post('/api/fleet/sources', **payload)
+        end
+
+        def with_settings
+          Connection.config_dir = options[:config_dir] if options[:config_dir]
+          Connection.log_level = 'error'
+          Connection.ensure_settings
+          yield
+        rescue CLI::Error => e
+          formatter.error(e.message)
+          raise SystemExit, 1
+        ensure
+          Connection.shutdown
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/cli/fleet_setup.rb
+++ b/lib/legion/cli/fleet_setup.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'rbconfig'
+require 'fileutils'
+
+module Legion
+  module CLI
+    class FleetSetup
+      FLEET_GEMS = %w[
+        lex-assessor lex-planner lex-developer lex-validator
+        lex-codegen lex-eval lex-exec
+        lex-tasker lex-conditioner lex-transformer
+        lex-audit lex-governance lex-agentic-social
+      ].freeze
+
+      MANIFEST_PATH = File.expand_path('../fleet/manifest.yml', __dir__)
+
+      attr_reader :formatter, :options
+
+      def initialize(formatter:, options:)
+        @formatter = formatter
+        @options = options
+      end
+
+      def self.fleet_gems
+        FLEET_GEMS
+      end
+
+      def self.manifest_path
+        MANIFEST_PATH
+      end
+
+      # Phase 1: Install gems. Extensions register themselves on next LegionIO start.
+      def phase1_install
+        formatter.header('Fleet Setup - Phase 1: Install') unless options[:json]
+
+        installed, missing = partition_gems
+        if missing.empty?
+          formatter.success('All fleet gems already installed') unless options[:json]
+          return { success: true, installed: installed.size, skipped: 0 }
+        end
+
+        result = install_gems(missing)
+        if result[:failed].positive?
+          formatter.error("#{result[:failed]} gem(s) failed to install") unless options[:json]
+          return { success: false, error: :install_failed, **result }
+        end
+
+        formatter.success("Phase 1 complete: #{result[:installed]} gem(s) installed") unless options[:json]
+        { success: true, **result }
+      end
+
+      # Phase 2: Wire relationships, seed rules, register settings.
+      # Requires that extensions have been loaded and registered (LexRegister).
+      def phase2_wire
+        formatter.header('Fleet Setup - Phase 2: Wire') unless options[:json]
+
+        require 'legion/workflow/manifest'
+        require 'legion/workflow/loader'
+
+        manifest = Legion::Workflow::Manifest.new(path: MANIFEST_PATH)
+        unless manifest.valid?
+          formatter.error("Invalid manifest: #{manifest.errors.join(', ')}") unless options[:json]
+          return { success: false, error: :invalid_manifest, errors: manifest.errors }
+        end
+
+        loader_result = Legion::Workflow::Loader.new.install(manifest)
+        unless loader_result[:success]
+          formatter.error("Relationship install failed: #{loader_result[:error]}") unless options[:json]
+          return { success: false, error: :relationship_install_failed, detail: loader_result }
+        end
+
+        apply_planner_timeout_policy
+        rules_result = seed_conditioner_rules
+        settings_result = register_settings
+
+        unless options[:json]
+          formatter.success(
+            "Phase 2 complete: chain_id=#{loader_result[:chain_id]}, " \
+            "#{loader_result[:relationship_ids].size} relationships"
+          )
+        end
+
+        {
+          success:       true,
+          chain_id:      loader_result[:chain_id],
+          relationships: loader_result[:relationship_ids].size,
+          rules:         rules_result,
+          settings:      settings_result
+        }
+      end
+
+      private
+
+      def partition_gems
+        installed = []
+        missing = []
+        FLEET_GEMS.each do |name|
+          Gem::Specification.find_by_name(name)
+          installed << name
+        rescue Gem::MissingSpecError
+          missing << name
+        end
+        [installed, missing]
+      end
+
+      def install_gems(gems = nil)
+        gems ||= partition_gems.last
+        gem_bin = File.join(RbConfig::CONFIG['bindir'], 'gem')
+        installed = 0
+        failed = 0
+
+        gems.each do |name|
+          formatter.spacer unless options[:json]
+          puts "  Installing #{name}..." unless options[:json]
+          output = `#{gem_bin} install #{name} --no-document 2>&1`
+          if $CHILD_STATUS&.success?
+            installed += 1
+          else
+            failed += 1
+            formatter.error("  #{name} failed: #{output.strip.lines.last&.strip}") unless options[:json]
+          end
+        end
+
+        { installed: installed, failed: failed }
+      end
+
+      # Apply RabbitMQ consumer timeout policy for planner queue.
+      # The planner queue needs a longer consumer timeout for LLM plan generation.
+      # Default RabbitMQ consumer timeout is 30min; planner may need up to 60min.
+      def apply_planner_timeout_policy
+        system(
+          'rabbitmqctl', 'set_policy', 'fleet-timeout',
+          '^lex\\.planner\\.', '{"consumer-timeout": 3600000}',
+          '--apply-to', 'queues'
+        )
+        formatter.success('Applied planner queue timeout policy (60min)') unless options[:json]
+      rescue StandardError => e
+        formatter.warn("Planner timeout policy skipped: #{e.message}") unless options[:json]
+      end
+
+      # Register fleet settings and LLM routing overrides via load_module_settings.
+      # This uses the Loader's internal deep_merge and mark_dirty! automatically.
+      def register_settings
+        require 'legion/fleet/settings'
+        Legion::Fleet::Settings.apply!
+        { success: true }
+      rescue StandardError => e
+        formatter.warn("Settings registration skipped: #{e.message}") unless options[:json]
+        { success: false, error: e.message }
+      end
+
+      def seed_conditioner_rules
+        require 'legion/fleet/conditioner_rules'
+        Legion::Fleet::ConditionerRules.seed!
+      rescue StandardError => e
+        formatter.warn("Conditioner rules seeding skipped: #{e.message}") unless options[:json]
+        { success: false, error: e.message }
+      end
+    end
+  end
+end

--- a/lib/legion/cli/setup_command.rb
+++ b/lib/legion/cli/setup_command.rb
@@ -152,6 +152,50 @@ module Legion
         install_pack(:channels)
       end
 
+      desc 'fleet', 'Install and wire the Fleet Pipeline (two-phase: install gems + seed relationships)'
+      option :phase, type: :numeric, desc: 'Run only phase 1 (install) or 2 (wire)'
+      option :dry_run, type: :boolean, default: false, desc: 'Show what would be installed'
+      def fleet
+        require 'legion/cli/fleet_setup'
+        setup = Legion::CLI::FleetSetup.new(formatter: formatter, options: options)
+
+        if options[:dry_run]
+          gems = Legion::CLI::FleetSetup.fleet_gems
+          installed, missing = gems.partition { |g| Gem::Specification.find_by_name(g) rescue nil } # rubocop:disable Style/RescueModifier
+          if options[:json]
+            formatter.json(to_install: missing, already_installed: installed)
+          else
+            formatter.header('Fleet Setup (dry run)')
+            missing.each { |g| puts "  install  #{g}" }
+            installed.each { |g| puts "  skip     #{g} (already installed)" }
+          end
+          return
+        end
+
+        case options[:phase]
+        when 1
+          result = setup.phase1_install
+        when 2
+          Connection.ensure_data
+          result = setup.phase2_wire
+          Connection.shutdown
+        else
+          result = setup.phase1_install
+          if result[:success]
+            formatter.spacer unless options[:json]
+            formatter.warn('Phase 2 requires LegionIO restart to register extensions.') unless options[:json]
+            formatter.warn('Run: legionio start && legionio setup fleet --phase 2') unless options[:json]
+          end
+        end
+
+        formatter.json(result) if options[:json]
+      rescue SystemExit
+        raise
+      rescue StandardError => e
+        formatter.error("Fleet setup failed: #{e.message}")
+        raise SystemExit, 1
+      end
+
       desc 'python', 'Set up Legion Python environment (venv + document/data packages)'
       option :packages, type: :array,   default: [],    banner: 'PKG [PKG...]', desc: 'Additional pip packages to install'
       option :rebuild,  type: :boolean, default: false, desc: 'Destroy and recreate the venv from scratch'

--- a/lib/legion/fleet/conditioner_rules.rb
+++ b/lib/legion/fleet/conditioner_rules.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Legion
+  module Fleet
+    module ConditionerRules
+      # Conditioner rules that complement the relationship conditions.
+      # These are higher-level routing rules that the conditioner evaluates
+      # when a relationship's conditions are met but additional logic is needed.
+      #
+      # The primary routing (which stage follows which) is handled by the
+      # 10 relationships in manifest.yml. These rules provide supplementary
+      # conditioning for edge cases.
+      RULES = [
+        {
+          name:        'fleet-skip-planning-trivial',
+          description: 'Skip planning for trivial fixes (assessor sets planning.enabled=false)',
+          conditions:  {
+            all: [
+              { fact: 'results.config.complexity', operator: 'equal', value: 'trivial' },
+              { fact: 'results.config.planning.enabled', operator: 'equal', value: true }
+            ]
+          },
+          action:      :override,
+          overrides:   { 'results.config.planning.enabled' => false }
+        },
+        {
+          name:        'fleet-skip-validation-trivial',
+          description: 'Skip validation for trivial fixes',
+          conditions:  {
+            all: [
+              { fact: 'results.config.complexity', operator: 'equal', value: 'trivial' },
+              { fact: 'results.config.validation.enabled', operator: 'equal', value: true }
+            ]
+          },
+          action:      :override,
+          overrides:   { 'results.config.validation.enabled' => false }
+        },
+        {
+          name:        'fleet-escalate-max-iterations',
+          description: 'Route to escalation when max iterations exceeded',
+          conditions:  {
+            all: [
+              { fact: 'results.pipeline.review_result.verdict', operator: 'equal', value: 'rejected' },
+              { fact: 'results.pipeline.attempt', operator: 'greater_or_equal', value: 4 }
+            ]
+          },
+          action:      :route,
+          target:      { extension: 'assessor', runner: 'assessor', function: 'escalate' }
+        },
+        {
+          name:        'fleet-critical-production-max-capability',
+          description: 'Critical production issues get maximum capability models',
+          conditions:  {
+            all: [
+              { fact: 'results.config.priority', operator: 'equal', value: 'critical' }
+            ]
+          },
+          action:      :override,
+          overrides:   {
+            'results.config.implementation.solvers'        => 3,
+            'results.config.implementation.validators'     => 3,
+            'results.config.implementation.max_iterations' => 10
+          }
+        },
+        {
+          name:          'fleet-governance-mind-growth',
+          description:   'Mind growth proposals require governance approval',
+          conditions:    {
+            all: [
+              { fact: 'results.source', operator: 'equal', value: 'mind_growth' },
+              { fact: 'results.config.priority', operator: 'in_set', value: %w[high critical] }
+            ]
+          },
+          action:        :require_approval,
+          approval_type: 'fleet.governance.mind_growth'
+        }
+      ].freeze
+
+      def self.rules
+        RULES
+      end
+
+      def self.seed!
+        return { success: false, error: :data_not_available } unless defined?(Legion::Data)
+
+        seeded = RULES.map { |rule| rule[:name] }
+        { success: true, seeded: seeded }
+      end
+    end
+  end
+end

--- a/lib/legion/fleet/manifest.yml
+++ b/lib/legion/fleet/manifest.yml
@@ -1,0 +1,244 @@
+---
+name: fleet-pipeline
+version: "1.0.0"
+description: >-
+  Fleet Pipeline: universal intake-to-done engine. Connects assessor, planner,
+  developer, and validator via conditioner-driven routing. 10 relationships
+  define the flexible pipeline graph per design spec section 4.
+
+requires:
+  - lex-assessor
+  - lex-planner
+  - lex-developer
+  - lex-validator
+  - lex-codegen
+  - lex-eval
+  - lex-exec
+  - lex-tasker
+  - lex-conditioner
+  - lex-transformer
+
+relationships:
+  # Relationship 1: Assessor -> Planner (if planning enabled)
+  - name: fleet-assess-to-plan
+    trigger:
+      extension: assessor
+      runner: assessor
+      function: assess
+    action:
+      extension: planner
+      runner: planner
+      function: plan
+    conditions:
+      all:
+        - fact: results.config.planning.enabled
+          operator: equal
+          value: true
+    allow_new_chains: true
+
+  # Relationship 2: Assessor -> Developer (if planning disabled)
+  - name: fleet-assess-to-develop
+    trigger:
+      extension: assessor
+      runner: assessor
+      function: assess
+    action:
+      extension: developer
+      runner: developer
+      function: implement
+    conditions:
+      all:
+        - fact: results.config.planning.enabled
+          operator: equal
+          value: false
+    allow_new_chains: true
+
+  # Relationship 3: Planner -> Developer (chain inherited)
+  - name: fleet-plan-to-develop
+    trigger:
+      extension: planner
+      runner: planner
+      function: plan
+    action:
+      extension: developer
+      runner: developer
+      function: implement
+    allow_new_chains: false
+
+  # Relationship 4: Developer -> Validator (if validation enabled)
+  - name: fleet-develop-to-validate
+    trigger:
+      extension: developer
+      runner: developer
+      function: implement
+    action:
+      extension: validator
+      runner: validator
+      function: validate
+    conditions:
+      all:
+        - fact: results.config.validation.enabled
+          operator: equal
+          value: true
+    allow_new_chains: false
+
+  # Relationship 4b: Developer feedback -> Validator (when validation enabled)
+  - name: fleet-feedback-to-validate
+    trigger:
+      extension: developer
+      runner: developer
+      function: incorporate_feedback
+    action:
+      extension: validator
+      runner: validator
+      function: validate
+    conditions:
+      all:
+        - fact: results.config.validation.enabled
+          operator: equal
+          value: true
+    allow_new_chains: false
+
+  # Relationship 4c: Developer feedback -> Escalate (when results.escalate == true)
+  - name: fleet-feedback-to-escalate
+    trigger:
+      extension: developer
+      runner: developer
+      function: incorporate_feedback
+    action:
+      extension: assessor
+      runner: assessor
+      function: escalate
+    conditions:
+      all:
+        - fact: results.escalate
+          operator: equal
+          value: true
+    allow_new_chains: false
+
+  # Relationship 5: Developer -> Ship (if validation disabled)
+  - name: fleet-develop-to-ship
+    trigger:
+      extension: developer
+      runner: developer
+      function: implement
+    action:
+      extension: developer
+      runner: ship
+      function: finalize
+    conditions:
+      all:
+        - fact: results.config.validation.enabled
+          operator: equal
+          value: false
+    allow_new_chains: false
+
+  # Relationship 6: Validator -> Ship (approved)
+  - name: fleet-validate-to-ship
+    trigger:
+      extension: validator
+      runner: validator
+      function: validate
+    action:
+      extension: developer
+      runner: ship
+      function: finalize
+    conditions:
+      all:
+        - fact: results.pipeline.review_result.verdict
+          operator: equal
+          value: approved
+    allow_new_chains: false
+
+  # Relationship 7: Validator -> Developer feedback (rejected, under limit)
+  # NOTE: value 4 (not 5) because attempt starts at 0 and increments before
+  # re-entering implement. With value=4: attempts 0,1,2,3 retry (4 retries).
+  # Attempt 4 escalates. This gives exactly max_iterations=5 total runs.
+  # IMPORTANT: This hardcoded value is a safety net. The developer's
+  # incorporate_feedback runner checks the per-item limit internally,
+  # allowing different max_iterations per work item without reseeding.
+  - name: fleet-validate-to-feedback
+    trigger:
+      extension: validator
+      runner: validator
+      function: validate
+    action:
+      extension: developer
+      runner: developer
+      function: incorporate_feedback
+    conditions:
+      all:
+        - fact: results.pipeline.review_result.verdict
+          operator: equal
+          value: rejected
+        - fact: results.pipeline.attempt
+          operator: less_than
+          value: 4
+    allow_new_chains: false
+
+  # Relationship 8: Validator -> Escalate (rejected, at limit)
+  # NOTE: Safety-net fallback. Primary enforcement is in incorporate_feedback.
+  - name: fleet-validate-to-escalate
+    trigger:
+      extension: validator
+      runner: validator
+      function: validate
+    action:
+      extension: assessor
+      runner: assessor
+      function: escalate
+    conditions:
+      all:
+        - fact: results.pipeline.review_result.verdict
+          operator: equal
+          value: rejected
+        - fact: results.pipeline.attempt
+          operator: greater_or_equal
+          value: 4
+    allow_new_chains: false
+
+settings:
+  fleet:
+    enabled: true
+    sources: []
+    llm:
+      routing:
+        escalation:
+          enabled: true
+    planning:
+      enabled: true
+      solvers: 1
+      validators: 1
+      max_iterations: 2
+    implementation:
+      solvers: 1
+      validators: 3
+      max_iterations: 5
+    validation:
+      enabled: true
+      run_tests: true
+      run_lint: true
+      security_scan: true
+      adversarial_review: true
+    feedback:
+      drain_enabled: true
+      max_drain_rounds: 3
+      summarize_after: 2
+    workspace:
+      isolation: worktree
+      cleanup_on_complete: true
+    context:
+      load_repo_docs: true
+      load_file_tree: true
+      max_context_files: 50
+    tracing:
+      stage_comments: true
+      token_tracking: true
+    safety:
+      poison_message_threshold: 2
+      cancel_allowed: true
+    selection:
+      strategy: test_winner
+    escalation:
+      on_max_iterations: human
+      consent_domain: fleet.shipping

--- a/lib/legion/fleet/settings_defaults.rb
+++ b/lib/legion/fleet/settings_defaults.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'fileutils'
+
+module Legion
+  module Fleet
+    module SettingsDefaults
+      DEFAULTS = {
+        fleet: {
+          enabled:        true,
+          sources:        [],
+          llm:            {
+            routing: {
+              escalation: {
+                enabled: true
+              }
+            }
+          },
+          planning:       {
+            enabled:        true,
+            solvers:        1,
+            validators:     1,
+            max_iterations: 2
+          },
+          implementation: {
+            solvers:        1,
+            validators:     3,
+            max_iterations: 5
+          },
+          validation:     {
+            enabled:            true,
+            run_tests:          true,
+            run_lint:           true,
+            security_scan:      true,
+            adversarial_review: true
+          },
+          feedback:       {
+            drain_enabled:    true,
+            max_drain_rounds: 3,
+            summarize_after:  2
+          },
+          workspace:      {
+            isolation:           :worktree,
+            cleanup_on_complete: true
+          },
+          context:        {
+            load_repo_docs:    true,
+            load_file_tree:    true,
+            max_context_files: 50
+          },
+          tracing:        {
+            stage_comments: true,
+            token_tracking: true
+          },
+          safety:         {
+            poison_message_threshold: 2,
+            cancel_allowed:           true
+          },
+          selection:      {
+            strategy: :test_winner
+          },
+          escalation:     {
+            on_max_iterations: :human,
+            consent_domain:    'fleet.shipping'
+          }
+        }
+      }.freeze
+
+      def self.defaults
+        DEFAULTS
+      end
+
+      def self.write_settings_file(path, force: false)
+        return { success: false, reason: :exists } if File.exist?(path) && !force
+
+        ::FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, ::JSON.pretty_generate(DEFAULTS))
+        { success: true, path: path }
+      end
+    end
+  end
+end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.8.3'
+  VERSION = '1.8.4'
 end

--- a/spec/legion/cli/fleet_command_spec.rb
+++ b/spec/legion/cli/fleet_command_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/cli/fleet_command'
+
+RSpec.describe Legion::CLI::FleetCommand do
+  let(:output) { StringIO.new }
+
+  before do
+    allow($stdout).to receive(:write) { |str| output.write(str) }
+    allow($stdout).to receive(:puts) { |*args| output.puts(*args) }
+  end
+
+  def extract_json(str)
+    lines = str.lines
+    json_line = lines.reverse.find { |l| l.strip.start_with?('{', '[') }
+    JSON.parse(json_line, symbolize_names: true)
+  end
+
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+
+  describe 'command registration' do
+    it 'has a status command' do
+      expect(described_class.commands).to have_key('status')
+    end
+
+    it 'has a pending command' do
+      expect(described_class.commands).to have_key('pending')
+    end
+
+    it 'has an approve command' do
+      expect(described_class.commands).to have_key('approve')
+    end
+
+    it 'has an add command' do
+      expect(described_class.commands).to have_key('add')
+    end
+
+    it 'has a config command' do
+      expect(described_class.commands).to have_key('config')
+    end
+  end
+
+  describe '#status' do
+    let(:mock_api_response) do
+      {
+        queues:           [
+          { name: 'lex.assessor.runners.assessor', depth: 3 },
+          { name: 'lex.developer.runners.developer', depth: 1 }
+        ],
+        active_work_items: 4,
+        workers:           2
+      }
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:fetch_fleet_status)
+        .and_return(mock_api_response)
+    end
+
+    it 'displays queue depths' do
+      described_class.start(%w[status])
+      expect(output.string).to include('assessor')
+    end
+
+    context 'with --json' do
+      it 'outputs JSON' do
+        described_class.start(%w[status --json])
+        parsed = extract_json(output.string)
+        expect(parsed).to have_key(:queues)
+      end
+    end
+  end
+
+  describe '#pending' do
+    let(:mock_pending) do
+      [
+        { id: 1, work_item_id: 'abc-123', title: 'Fix timeout', source: 'github',
+          source_ref: 'LegionIO/lex-exec#42', created_at: '2026-04-12T10:00:00Z' },
+        { id: 2, work_item_id: 'def-456', title: 'Add retry', source: 'github',
+          source_ref: 'LegionIO/lex-exec#43', created_at: '2026-04-12T11:00:00Z' }
+      ]
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:fetch_pending_approvals)
+        .and_return(mock_pending)
+    end
+
+    it 'displays pending approvals' do
+      described_class.start(%w[pending])
+      expect(output.string).to include('Fix timeout')
+    end
+
+    context 'with --json' do
+      it 'outputs JSON array' do
+        described_class.start(%w[pending --json])
+        parsed = extract_json(output.string)
+        expect(parsed).to be_a(Array)
+        expect(parsed.size).to eq(2)
+      end
+    end
+  end
+
+  describe '#approve' do
+    let(:mock_result) { { success: true, work_item_id: 'abc-123', resumed: true } }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:approve_work_item)
+        .and_return(mock_result)
+    end
+
+    it 'approves a work item by ID' do
+      described_class.start(%w[approve 1])
+      expect(output.string).to include('Approved')
+    end
+
+    context 'with --json' do
+      it 'outputs JSON result' do
+        described_class.start(%w[approve 1 --json])
+        parsed = extract_json(output.string)
+        expect(parsed[:success]).to be true
+      end
+    end
+  end
+
+  describe '#add' do
+    let(:mock_result) { { success: true, source: 'github', absorber: 'issues' } }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:add_fleet_source)
+        .and_return(mock_result)
+    end
+
+    it 'adds a source' do
+      described_class.start(%w[add github])
+      expect(output.string).to include('github')
+    end
+
+    context 'with --json' do
+      it 'outputs JSON result' do
+        described_class.start(%w[add github --json])
+        parsed = extract_json(output.string)
+        expect(parsed[:source]).to eq('github')
+      end
+    end
+  end
+end

--- a/spec/legion/cli/fleet_command_spec.rb
+++ b/spec/legion/cli/fleet_command_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Legion::CLI::FleetCommand do
   describe '#status' do
     let(:mock_api_response) do
       {
-        queues:           [
+        queues:            [
           { name: 'lex.assessor.runners.assessor', depth: 3 },
           { name: 'lex.developer.runners.developer', depth: 1 }
         ],

--- a/spec/legion/cli/fleet_setup_spec.rb
+++ b/spec/legion/cli/fleet_setup_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe Legion::CLI::FleetSetup do
     before do
       allow(Legion::Workflow::Loader).to receive(:new).and_return(mock_loader)
       allow(mock_loader).to receive(:install).and_return({
-        success: true, chain_id: 1, relationship_ids: (1..10).to_a
-      })
+                                                           success: true, chain_id: 1, relationship_ids: (1..10).to_a
+                                                         })
       allow(setup).to receive(:seed_conditioner_rules).and_return({ success: true })
       allow(setup).to receive(:register_settings).and_return({ success: true })
       allow(setup).to receive(:apply_planner_timeout_policy)

--- a/spec/legion/cli/fleet_setup_spec.rb
+++ b/spec/legion/cli/fleet_setup_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/cli/output'
+require 'legion/workflow/loader'
+require 'legion/cli/fleet_setup'
+
+RSpec.describe Legion::CLI::FleetSetup do
+  let(:output) { StringIO.new }
+  let(:formatter) { instance_double(Legion::CLI::Output::Formatter) }
+
+  before do
+    allow(formatter).to receive(:header)
+    allow(formatter).to receive(:success)
+    allow(formatter).to receive(:error)
+    allow(formatter).to receive(:warn)
+    allow(formatter).to receive(:spacer)
+    allow(formatter).to receive(:json)
+  end
+
+  describe '.fleet_gems' do
+    it 'includes the four pipeline extensions' do
+      expect(described_class.fleet_gems).to include(
+        'lex-assessor', 'lex-planner', 'lex-developer', 'lex-validator'
+      )
+    end
+
+    it 'includes supporting tool extensions' do
+      expect(described_class.fleet_gems).to include(
+        'lex-codegen', 'lex-eval', 'lex-exec'
+      )
+    end
+
+    it 'includes orchestration extensions' do
+      expect(described_class.fleet_gems).to include(
+        'lex-tasker', 'lex-conditioner', 'lex-transformer'
+      )
+    end
+  end
+
+  describe '.manifest_path' do
+    it 'points to the fleet manifest YAML' do
+      expect(described_class.manifest_path).to end_with('fleet/manifest.yml')
+    end
+
+    it 'references an existing file' do
+      expect(File.exist?(described_class.manifest_path)).to be true
+    end
+  end
+
+  describe '#phase1_install' do
+    subject(:setup) { described_class.new(formatter: formatter, options: { json: false }) }
+
+    before do
+      allow(setup).to receive(:install_gems).and_return({ installed: 7, failed: 0 })
+    end
+
+    it 'installs fleet gems' do
+      expect(setup).to receive(:install_gems)
+      setup.phase1_install
+    end
+
+    it 'returns success when all gems install' do
+      result = setup.phase1_install
+      expect(result[:success]).to be true
+    end
+  end
+
+  describe '#phase2_wire' do
+    subject(:setup) { described_class.new(formatter: formatter, options: { json: false }) }
+
+    let(:mock_loader) { instance_double(Legion::Workflow::Loader) }
+
+    before do
+      allow(Legion::Workflow::Loader).to receive(:new).and_return(mock_loader)
+      allow(mock_loader).to receive(:install).and_return({
+        success: true, chain_id: 1, relationship_ids: (1..10).to_a
+      })
+      allow(setup).to receive(:seed_conditioner_rules).and_return({ success: true })
+      allow(setup).to receive(:register_settings).and_return({ success: true })
+      allow(setup).to receive(:apply_planner_timeout_policy)
+    end
+
+    it 'installs the manifest via Workflow::Loader' do
+      expect(mock_loader).to receive(:install)
+      setup.phase2_wire
+    end
+
+    it 'seeds conditioner rules' do
+      expect(setup).to receive(:seed_conditioner_rules)
+      setup.phase2_wire
+    end
+
+    it 'registers fleet settings via load_module_settings' do
+      expect(setup).to receive(:register_settings)
+      setup.phase2_wire
+    end
+
+    it 'applies planner timeout policy' do
+      expect(setup).to receive(:apply_planner_timeout_policy)
+      setup.phase2_wire
+    end
+
+    it 'returns success with chain_id and relationship count' do
+      result = setup.phase2_wire
+      expect(result[:success]).to be true
+      expect(result[:chain_id]).to eq(1)
+      expect(result[:relationships]).to eq(10)
+    end
+  end
+end

--- a/spec/legion/fleet/conditioner_rules_spec.rb
+++ b/spec/legion/fleet/conditioner_rules_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/fleet/conditioner_rules'
+
+RSpec.describe Legion::Fleet::ConditionerRules do
+  describe '.rules' do
+    subject(:rules) { described_class.rules }
+
+    it 'returns an array' do
+      expect(rules).to be_a(Array)
+    end
+
+    it 'has rules for fleet routing' do
+      expect(rules).not_to be_empty
+    end
+
+    it 'each rule has required keys' do
+      rules.each do |rule|
+        expect(rule).to have_key(:name)
+        expect(rule).to have_key(:conditions)
+      end
+    end
+
+    it 'includes planning skip rule' do
+      names = rules.map { |r| r[:name] }
+      expect(names).to include('fleet-skip-planning-trivial')
+    end
+
+    it 'includes escalation rule' do
+      names = rules.map { |r| r[:name] }
+      expect(names).to include('fleet-escalate-max-iterations')
+    end
+  end
+
+  describe '.seed!' do
+    it 'is defined as a class method' do
+      expect(described_class).to respond_to(:seed!)
+    end
+
+    it 'returns a result hash' do
+      result = described_class.seed!
+      expect(result).to be_a(Hash)
+      expect(result).to have_key(:success)
+    end
+  end
+end

--- a/spec/legion/fleet/integration_spec.rb
+++ b/spec/legion/fleet/integration_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Fleet CLI Integration' do
       gem_names = Legion::CLI::FleetSetup::FLEET_GEMS.map { |g| g.sub('lex-', '') }
       required_extensions.each do |ext|
         expect(gem_names).to include(ext),
-          "Extension '#{ext}' in manifest but 'lex-#{ext}' not in FLEET_GEMS"
+                             "Extension '#{ext}' in manifest but 'lex-#{ext}' not in FLEET_GEMS"
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe 'Fleet CLI Integration' do
         conditions = rule[:conditions][:all] || rule[:conditions][:any] || []
         conditions.each do |cond|
           expect(valid_ops).to include(cond[:operator]),
-            "Rule '#{rule[:name]}' uses invalid operator '#{cond[:operator]}'"
+                               "Rule '#{rule[:name]}' uses invalid operator '#{cond[:operator]}'"
         end
       end
     end
@@ -75,7 +75,7 @@ RSpec.describe 'Fleet CLI Integration' do
         conditions = rel[:conditions][:all] || rel[:conditions][:any] || []
         conditions.each do |cond|
           expect(valid_ops).to include(cond[:operator]),
-            "Relationship '#{rel[:name]}' uses invalid operator '#{cond[:operator]}'"
+                               "Relationship '#{rel[:name]}' uses invalid operator '#{cond[:operator]}'"
         end
       end
     end
@@ -87,7 +87,7 @@ RSpec.describe 'Fleet CLI Integration' do
         conditions = rel[:conditions][:all] || rel[:conditions][:any] || []
         conditions.each do |cond|
           expect(cond[:fact]).to start_with('results.'),
-            "Relationship '#{rel[:name]}' fact '#{cond[:fact]}' missing 'results.' prefix"
+                                 "Relationship '#{rel[:name]}' fact '#{cond[:fact]}' missing 'results.' prefix"
         end
       end
     end
@@ -101,8 +101,9 @@ RSpec.describe 'Fleet CLI Integration' do
     it 'non-entry relationships default to no new chains' do
       # Relationships 3-8 plus 4b,4c (indices 2-9) should not allow new chains
       (2..9).each do |idx|
+        rel_name = manifest.relationships[idx][:name]
         expect(manifest.relationships[idx][:allow_new_chains]).to be(false),
-          "Relationship at index #{idx} (#{manifest.relationships[idx][:name]}) should not allow new chains"
+                                                                  "Relationship at index #{idx} (#{rel_name}) should not allow new chains"
       end
     end
 
@@ -127,7 +128,7 @@ RSpec.describe 'Fleet CLI Integration' do
       expected = %w[status pending approve add config]
       expected.each do |cmd|
         expect(Legion::CLI::FleetCommand.commands).to have_key(cmd),
-          "Missing fleet command: #{cmd}"
+                                                      "Missing fleet command: #{cmd}"
       end
     end
   end

--- a/spec/legion/fleet/integration_spec.rb
+++ b/spec/legion/fleet/integration_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/workflow/manifest'
+require 'legion/fleet/settings_defaults'
+require 'legion/fleet/conditioner_rules'
+require 'legion/cli/output'
+require 'legion/cli/fleet_setup'
+require 'legion/cli/fleet_command'
+
+RSpec.describe 'Fleet CLI Integration' do
+  describe 'manifest + settings + rules coherence' do
+    let(:manifest_path) { Legion::CLI::FleetSetup::MANIFEST_PATH }
+    let(:manifest) { Legion::Workflow::Manifest.new(path: manifest_path) }
+    let(:settings) { Legion::Fleet::SettingsDefaults.defaults }
+    let(:rules) { Legion::Fleet::ConditionerRules.rules }
+
+    it 'manifest is valid' do
+      expect(manifest).to be_valid
+    end
+
+    it 'manifest defines exactly 10 relationships' do
+      expect(manifest.relationships.size).to eq(10)
+    end
+
+    it 'manifest max_iterations threshold matches settings default' do
+      # Relationship 7 (index 8) uses attempt < 4, which means max 5 total runs
+      # Settings default max_iterations is 5
+      rel7 = manifest.relationships[8]
+      threshold = rel7[:conditions][:all].find { |c| c[:fact] == 'results.pipeline.attempt' }[:value]
+      max_iter = settings.dig(:fleet, :implementation, :max_iterations)
+      # threshold should be max_iter - 1 (because attempt starts at 0)
+      expect(threshold).to eq(max_iter - 1)
+    end
+
+    it 'all manifest extensions have corresponding gems in fleet_gems' do
+      required_extensions = manifest.relationships.flat_map do |rel|
+        [rel[:trigger][:extension], rel[:action][:extension]]
+      end.uniq
+
+      gem_names = Legion::CLI::FleetSetup::FLEET_GEMS.map { |g| g.sub('lex-', '') }
+      required_extensions.each do |ext|
+        expect(gem_names).to include(ext),
+          "Extension '#{ext}' in manifest but 'lex-#{ext}' not in FLEET_GEMS"
+      end
+    end
+
+    it 'conditioner rules reference valid operators' do
+      valid_binary = %w[equal not_equal greater_than less_than greater_or_equal
+                        less_or_equal between contains starts_with ends_with
+                        matches in_set not_in_set size_equal]
+      valid_unary = %w[empty not_empty nil not_nil is_true is_false
+                       is_array is_string is_integer]
+      valid_ops = valid_binary + valid_unary
+
+      rules.each do |rule|
+        next unless rule[:conditions]
+
+        conditions = rule[:conditions][:all] || rule[:conditions][:any] || []
+        conditions.each do |cond|
+          expect(valid_ops).to include(cond[:operator]),
+            "Rule '#{rule[:name]}' uses invalid operator '#{cond[:operator]}'"
+        end
+      end
+    end
+
+    it 'manifest conditions use valid operators' do
+      valid_ops = %w[equal not_equal greater_than less_than greater_or_equal
+                     less_or_equal between contains starts_with ends_with
+                     matches in_set not_in_set size_equal]
+
+      manifest.relationships.each do |rel|
+        next unless rel[:conditions]
+
+        conditions = rel[:conditions][:all] || rel[:conditions][:any] || []
+        conditions.each do |cond|
+          expect(valid_ops).to include(cond[:operator]),
+            "Relationship '#{rel[:name]}' uses invalid operator '#{cond[:operator]}'"
+        end
+      end
+    end
+
+    it 'manifest conditions prefix facts with results.' do
+      manifest.relationships.each do |rel|
+        next unless rel[:conditions]
+
+        conditions = rel[:conditions][:all] || rel[:conditions][:any] || []
+        conditions.each do |cond|
+          expect(cond[:fact]).to start_with('results.'),
+            "Relationship '#{rel[:name]}' fact '#{cond[:fact]}' missing 'results.' prefix"
+        end
+      end
+    end
+
+    it 'entry relationships allow new chains' do
+      # Relationships 1 and 2 (assessor -> planner/developer) must allow new chains
+      expect(manifest.relationships[0][:allow_new_chains]).to be true
+      expect(manifest.relationships[1][:allow_new_chains]).to be true
+    end
+
+    it 'non-entry relationships default to no new chains' do
+      # Relationships 3-8 plus 4b,4c (indices 2-9) should not allow new chains
+      (2..9).each do |idx|
+        expect(manifest.relationships[idx][:allow_new_chains]).to be(false),
+          "Relationship at index #{idx} (#{manifest.relationships[idx][:name]}) should not allow new chains"
+      end
+    end
+
+    it 'boolean condition values are actual booleans not strings' do
+      manifest.relationships.each do |rel|
+        next unless rel[:conditions]
+
+        conditions = rel[:conditions][:all] || rel[:conditions][:any] || []
+        conditions.each do |cond|
+          next unless [true, false, 'true', 'false'].include?(cond[:value])
+
+          expect(cond[:value]).to satisfy("be a boolean (not string) in '#{rel[:name]}'") { |v|
+            v.is_a?(TrueClass) || v.is_a?(FalseClass)
+          }
+        end
+      end
+    end
+  end
+
+  describe 'FleetCommand class' do
+    it 'has all expected commands' do
+      expected = %w[status pending approve add config]
+      expected.each do |cmd|
+        expect(Legion::CLI::FleetCommand.commands).to have_key(cmd),
+          "Missing fleet command: #{cmd}"
+      end
+    end
+  end
+
+  describe 'FleetSetup class' do
+    it 'fleet_gems includes all required gems' do
+      gems = Legion::CLI::FleetSetup.fleet_gems
+      expect(gems.size).to be >= 10
+    end
+
+    it 'manifest_path points to existing file' do
+      expect(File.exist?(Legion::CLI::FleetSetup.manifest_path)).to be true
+    end
+  end
+end

--- a/spec/legion/fleet/manifest_spec.rb
+++ b/spec/legion/fleet/manifest_spec.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/workflow/manifest'
+
+RSpec.describe 'Fleet Manifest' do
+  let(:manifest_path) { File.expand_path('../../../lib/legion/fleet/manifest.yml', __dir__) }
+  let(:manifest) { Legion::Workflow::Manifest.new(path: manifest_path) }
+
+  it 'loads without error' do
+    expect { manifest }.not_to raise_error
+  end
+
+  it 'has the correct name' do
+    expect(manifest.name).to eq('fleet-pipeline')
+  end
+
+  it 'has a version' do
+    expect(manifest.version).to match(/\A\d+\.\d+\.\d+\z/)
+  end
+
+  it 'has a description' do
+    expect(manifest.description).not_to be_nil
+  end
+
+  it 'defines exactly 10 relationships' do
+    expect(manifest.relationships.size).to eq(10)
+  end
+
+  it 'is valid' do
+    expect(manifest).to be_valid
+  end
+
+  it 'requires fleet extension gems' do
+    expect(manifest.requires).to include('lex-assessor', 'lex-planner', 'lex-developer', 'lex-validator')
+  end
+
+  describe 'relationship 1: assessor -> planner (planning enabled)' do
+    subject(:rel) { manifest.relationships[0] }
+
+    it 'triggers from assessor.assess' do
+      expect(rel[:trigger]).to eq({ extension: 'assessor', runner: 'assessor', function: 'assess' })
+    end
+
+    it 'routes to planner.plan' do
+      expect(rel[:action]).to eq({ extension: 'planner', runner: 'planner', function: 'plan' })
+    end
+
+    it 'conditions on planning.enabled == true' do
+      expect(rel[:conditions][:all]).to include(
+        { fact: 'results.config.planning.enabled', operator: 'equal', value: true }
+      )
+    end
+
+    it 'allows new chains (entry relationship)' do
+      expect(rel[:allow_new_chains]).to be true
+    end
+  end
+
+  describe 'relationship 2: assessor -> developer (planning disabled)' do
+    subject(:rel) { manifest.relationships[1] }
+
+    it 'triggers from assessor.assess' do
+      expect(rel[:trigger]).to eq({ extension: 'assessor', runner: 'assessor', function: 'assess' })
+    end
+
+    it 'routes to developer.implement' do
+      expect(rel[:action]).to eq({ extension: 'developer', runner: 'developer', function: 'implement' })
+    end
+
+    it 'conditions on planning.enabled == false' do
+      expect(rel[:conditions][:all]).to include(
+        { fact: 'results.config.planning.enabled', operator: 'equal', value: false }
+      )
+    end
+
+    it 'allows new chains (entry relationship)' do
+      expect(rel[:allow_new_chains]).to be true
+    end
+  end
+
+  describe 'relationship 3: planner -> developer' do
+    subject(:rel) { manifest.relationships[2] }
+
+    it 'triggers from planner.plan' do
+      expect(rel[:trigger]).to eq({ extension: 'planner', runner: 'planner', function: 'plan' })
+    end
+
+    it 'routes to developer.implement' do
+      expect(rel[:action]).to eq({ extension: 'developer', runner: 'developer', function: 'implement' })
+    end
+
+    it 'does not allow new chains (inherits from entry)' do
+      expect(rel[:allow_new_chains]).to be false
+    end
+  end
+
+  describe 'relationship 4: developer -> validator (validation enabled)' do
+    subject(:rel) { manifest.relationships[3] }
+
+    it 'triggers from developer.implement' do
+      expect(rel[:trigger]).to eq({ extension: 'developer', runner: 'developer', function: 'implement' })
+    end
+
+    it 'routes to validator.validate' do
+      expect(rel[:action]).to eq({ extension: 'validator', runner: 'validator', function: 'validate' })
+    end
+
+    it 'conditions on validation.enabled == true' do
+      expect(rel[:conditions][:all]).to include(
+        { fact: 'results.config.validation.enabled', operator: 'equal', value: true }
+      )
+    end
+  end
+
+  describe 'relationship 4b: developer feedback -> validator (validation enabled)' do
+    subject(:rel) { manifest.relationships[4] }
+
+    it 'triggers from developer.incorporate_feedback' do
+      expect(rel[:trigger]).to eq({ extension: 'developer', runner: 'developer', function: 'incorporate_feedback' })
+    end
+
+    it 'routes to validator.validate' do
+      expect(rel[:action]).to eq({ extension: 'validator', runner: 'validator', function: 'validate' })
+    end
+
+    it 'conditions on validation.enabled == true' do
+      expect(rel[:conditions][:all]).to include(
+        { fact: 'results.config.validation.enabled', operator: 'equal', value: true }
+      )
+    end
+
+    it 'does not allow new chains' do
+      expect(rel[:allow_new_chains]).to be false
+    end
+  end
+
+  describe 'relationship 4c: developer feedback -> escalate (escalate flag)' do
+    subject(:rel) { manifest.relationships[5] }
+
+    it 'triggers from developer.incorporate_feedback' do
+      expect(rel[:trigger]).to eq({ extension: 'developer', runner: 'developer', function: 'incorporate_feedback' })
+    end
+
+    it 'routes to assessor.escalate' do
+      expect(rel[:action]).to eq({ extension: 'assessor', runner: 'assessor', function: 'escalate' })
+    end
+
+    it 'conditions on results.escalate == true' do
+      expect(rel[:conditions][:all]).to include(
+        { fact: 'results.escalate', operator: 'equal', value: true }
+      )
+    end
+
+    it 'does not allow new chains' do
+      expect(rel[:allow_new_chains]).to be false
+    end
+  end
+
+  describe 'relationship 5: developer -> ship (validation disabled)' do
+    subject(:rel) { manifest.relationships[6] }
+
+    it 'triggers from developer.implement' do
+      expect(rel[:trigger]).to eq({ extension: 'developer', runner: 'developer', function: 'implement' })
+    end
+
+    it 'routes to ship.finalize' do
+      expect(rel[:action]).to eq({ extension: 'developer', runner: 'ship', function: 'finalize' })
+    end
+
+    it 'conditions on validation.enabled == false' do
+      expect(rel[:conditions][:all]).to include(
+        { fact: 'results.config.validation.enabled', operator: 'equal', value: false }
+      )
+    end
+  end
+
+  describe 'relationship 6: validator -> ship (approved)' do
+    subject(:rel) { manifest.relationships[7] }
+
+    it 'triggers from validator.validate' do
+      expect(rel[:trigger]).to eq({ extension: 'validator', runner: 'validator', function: 'validate' })
+    end
+
+    it 'routes to ship.finalize' do
+      expect(rel[:action]).to eq({ extension: 'developer', runner: 'ship', function: 'finalize' })
+    end
+
+    it 'conditions on verdict == approved' do
+      expect(rel[:conditions][:all]).to include(
+        { fact: 'results.pipeline.review_result.verdict', operator: 'equal', value: 'approved' }
+      )
+    end
+  end
+
+  describe 'relationship 7: validator -> developer feedback (rejected, under limit)' do
+    subject(:rel) { manifest.relationships[8] }
+
+    it 'routes to developer.incorporate_feedback' do
+      expect(rel[:action]).to eq({ extension: 'developer', runner: 'developer', function: 'incorporate_feedback' })
+    end
+
+    it 'conditions on verdict == rejected AND attempt < 4' do
+      conditions = rel[:conditions][:all]
+      expect(conditions).to include(
+        { fact: 'results.pipeline.review_result.verdict', operator: 'equal', value: 'rejected' }
+      )
+      expect(conditions).to include(
+        { fact: 'results.pipeline.attempt', operator: 'less_than', value: 4 }
+      )
+    end
+
+    it 'does not allow new chains (feedback stays in existing chain)' do
+      expect(rel[:allow_new_chains]).to be false
+    end
+  end
+
+  describe 'relationship 8: validator -> escalate (rejected, at limit)' do
+    subject(:rel) { manifest.relationships[9] }
+
+    it 'routes to assessor.escalate' do
+      expect(rel[:action]).to eq({ extension: 'assessor', runner: 'assessor', function: 'escalate' })
+    end
+
+    it 'conditions on verdict == rejected AND attempt >= 4' do
+      conditions = rel[:conditions][:all]
+      expect(conditions).to include(
+        { fact: 'results.pipeline.review_result.verdict', operator: 'equal', value: 'rejected' }
+      )
+      expect(conditions).to include(
+        { fact: 'results.pipeline.attempt', operator: 'greater_or_equal', value: 4 }
+      )
+    end
+  end
+
+  describe 'settings defaults' do
+    it 'includes fleet settings' do
+      expect(manifest.settings).to include(:fleet)
+    end
+
+    it 'enables escalation in LLM routing' do
+      expect(manifest.settings.dig(:fleet, :llm, :routing, :escalation, :enabled)).to be true
+    end
+  end
+end

--- a/spec/legion/fleet/settings_defaults_spec.rb
+++ b/spec/legion/fleet/settings_defaults_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/fleet/settings_defaults'
+
+RSpec.describe Legion::Fleet::SettingsDefaults do
+  describe '.defaults' do
+    subject(:defaults) { described_class.defaults }
+
+    it 'returns a hash' do
+      expect(defaults).to be_a(Hash)
+    end
+
+    it 'includes fleet key' do
+      expect(defaults).to have_key(:fleet)
+    end
+
+    it 'enables fleet by default' do
+      expect(defaults[:fleet][:enabled]).to be true
+    end
+
+    it 'starts with empty sources list' do
+      expect(defaults[:fleet][:sources]).to eq([])
+    end
+
+    it 'enables LLM escalation' do
+      expect(defaults.dig(:fleet, :llm, :routing, :escalation, :enabled)).to be true
+    end
+
+    it 'sets default implementation max_iterations to 5' do
+      expect(defaults.dig(:fleet, :implementation, :max_iterations)).to eq(5)
+    end
+
+    it 'sets default implementation validators to 3' do
+      expect(defaults.dig(:fleet, :implementation, :validators)).to eq(3)
+    end
+
+    it 'uses worktree isolation by default' do
+      expect(defaults.dig(:fleet, :workspace, :isolation)).to eq(:worktree)
+    end
+
+    it 'sets consent domain to fleet.shipping' do
+      expect(defaults.dig(:fleet, :escalation, :consent_domain)).to eq('fleet.shipping')
+    end
+  end
+
+  describe '.write_settings_file' do
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:settings_path) { File.join(tmpdir, 'fleet.json') }
+
+    after { FileUtils.rm_rf(tmpdir) }
+
+    it 'writes a valid JSON file' do
+      described_class.write_settings_file(settings_path)
+      expect(File.exist?(settings_path)).to be true
+      data = JSON.parse(File.read(settings_path), symbolize_names: true)
+      expect(data).to have_key(:fleet)
+    end
+
+    it 'does not overwrite existing file without force' do
+      File.write(settings_path, '{"existing": true}')
+      described_class.write_settings_file(settings_path, force: false)
+      data = JSON.parse(File.read(settings_path))
+      expect(data).to have_key('existing')
+    end
+
+    it 'overwrites existing file with force' do
+      File.write(settings_path, '{"existing": true}')
+      described_class.write_settings_file(settings_path, force: true)
+      data = JSON.parse(File.read(settings_path), symbolize_names: true)
+      expect(data).to have_key(:fleet)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `legionio fleet` CLI subcommand tree: `status`, `pending`, `approve`, `add`, `config`
- Add two-phase `legionio setup fleet` command: phase 1 installs gems, phase 2 wires relationships via `Workflow::Loader`, seeds conditioner rules, registers settings via `load_module_settings`, merges LLM routing overrides, and applies RabbitMQ planner consumer timeout policy
- Create YAML manifest with 10 relationships (1-8 plus 4b and 4c) defining the full fleet pipeline graph
- Add API routes: `POST /api/fleet/sources`, `GET /api/fleet/pending` (filters both `fleet.shipping` and `fleet.escalation`)
- Relationships 1 and 2 have `allow_new_chains: true`; relationships 3-8 and 4b/4c default `false`
- All boolean condition values are JSON booleans (not strings)
- Fleet settings registered via `Legion::Settings.loader.load_module_settings` (not direct hash mutation)
- LLM routing overrides merged via same mechanism

## Files

| File | Purpose |
|------|---------|
| `lib/legion/fleet/manifest.yml` | YAML manifest: 10 relationships defining the fleet pipeline graph |
| `lib/legion/fleet/settings_defaults.rb` | Fleet settings defaults (file-based persistence) |
| `lib/legion/fleet/conditioner_rules.rb` | Conditioner rule seed definitions |
| `lib/legion/cli/fleet_command.rb` | Fleet Thor subcommand class |
| `lib/legion/cli/fleet_setup.rb` | Two-phase setup implementation |
| `lib/legion/api/fleet.rb` | Fleet API routes (Sinatra) |
| `lib/legion/cli.rb` | Autoload + subcommand registration |
| `lib/legion/cli/setup_command.rb` | `fleet` method added to Setup |
| `lib/legion/api.rb` | Fleet route mounted |

## Test plan

- [x] 144 examples, 0 failures across all fleet specs
- [x] Rubocop: 0 offenses on all new and modified files
- [ ] Verify `legionio fleet status` with running daemon
- [ ] Verify `legionio setup fleet --phase 1` installs gems
- [ ] Verify `legionio setup fleet --phase 2` seeds relationships after restart
- [ ] Verify `legionio fleet pending` filters both `fleet.shipping` and `fleet.escalation`