### PR TITLE
fix tool injection: auto-derive trigger words and build real input schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.8.5] - 2026-04-15
+
+### Fixed
+- `Legion::Extensions::Core#trigger_words` now defaults to `lex_name.split('_')` (e.g. `['github']` for lex-github) instead of `[]`, ensuring extensions auto-surface in TriggerIndex without requiring explicit declaration. Closes #139
+- `Legion::Extensions::Builder::Runners#build_runner_entry` now always populates `trigger_words`, defaulting to `[runner_name]` when the runner module does not define them explicitly. Closes #139
+- `Legion::Tools::Discovery#synthesize_functions` now builds a real JSON Schema from Ruby method reflection data (`Method#parameters`) — required kwargs become required schema properties, optional kwargs become optional properties — so the LLM receives accurate parameter information instead of an empty schema. Closes #140
+- `Legion::Tools::Discovery#synthesize_functions` now uses `definition[:desc]` for tool description when a `definition` DSL entry exists, falling back to the method name rather than `"method_name function"`. Closes #140
+- `Legion::Tools::Discovery#tool_attributes` now reads `definition[:inputs]` when present and non-empty, using it as the input schema in preference to `meta[:options]`. Closes #140
+- `Legion::Tools::Discovery#register_function` fixed asymmetric default: `resolve_exposed` now defaults to `true` when the extension does not respond to `mcp_tools?`, matching the behaviour of `resolve_mcp_tools_enabled`. Closes #140
+
 ## [1.8.4] - 2026-04-14
 
 ### Added

--- a/lib/legion/extensions/builders/runners.rb
+++ b/lib/legion/extensions/builders/runners.rb
@@ -42,7 +42,11 @@ module Legion
             class_methods:   {}
           }
           entry[:scheduled_tasks] = loaded_runner.scheduled_tasks if loaded_runner.method_defined?(:scheduled_tasks)
-          entry[:trigger_words] = loaded_runner.trigger_words if loaded_runner.respond_to?(:trigger_words)
+          entry[:trigger_words] = if loaded_runner.respond_to?(:trigger_words) && loaded_runner.trigger_words.any?
+                                    loaded_runner.trigger_words
+                                  else
+                                    [runner_name]
+                                  end
           entry[:desc] = settings[:runners][runner_name.to_sym][:desc] if settings.key?(:runners) && settings[:runners].key?(runner_name.to_sym)
           entry
         end

--- a/lib/legion/extensions/core.rb
+++ b/lib/legion/extensions/core.rb
@@ -128,7 +128,7 @@ module Legion
       end
 
       def trigger_words
-        []
+        lex_name.split('_')
       end
 
       # Auto-generate AMQP message classes for each runner method that has a definition.

--- a/lib/legion/tools/discovery.rb
+++ b/lib/legion/tools/discovery.rb
@@ -80,14 +80,40 @@ module Legion
           return {} unless runner_entry&.dig(:class_methods).is_a?(Hash)
 
           runner_entry[:class_methods].each_with_object({}) do |(method_name, method_info), funcs|
-            funcs[method_name] = { desc: "#{method_name} function", options: {}, args: method_info[:args] }
+            defn = runner_mod.respond_to?(:definition_for) ? runner_mod.definition_for(method_name) : nil
+            funcs[method_name] = {
+              desc:    defn&.dig(:desc) || method_name.to_s,
+              options: build_schema_from_args(method_info[:args]),
+              args:    method_info[:args]
+            }
           end
+        end
+
+        def build_schema_from_args(args)
+          return {} if args.nil? || args.empty?
+
+          properties = {}
+          required = []
+
+          args.each do |type, name|
+            next if name.nil? || %i[** * block].include?(name)
+
+            param_name = name.to_s
+            properties[param_name] = { type: 'string' }
+            required << param_name if type == :req
+          end
+
+          return {} if properties.empty?
+
+          schema = { properties: properties }
+          schema[:required] = required unless required.empty?
+          schema
         end
 
         def register_function(ext, runner_mod, func_name, meta, is_deferred)
           defn = runner_mod.respond_to?(:definition_for) ? runner_mod.definition_for(func_name) : nil
 
-          ext_default = ext.respond_to?(:mcp_tools?) ? ext.mcp_tools? : false
+          ext_default = ext.respond_to?(:mcp_tools?) ? ext.mcp_tools? : true
           return unless resolve_exposed(defn, meta, ext_default)
 
           requires = defn&.dig(:requires)&.map(&:to_s) || meta[:requires]
@@ -149,7 +175,7 @@ module Legion
           {
             tool_name:     defn&.dig(:mcp_prefix) || "legion-#{ext_name}-#{runner_snake}-#{func_name}",
             description:   meta[:desc] || defn&.dig(:desc) || "#{ext_name}##{func_name}",
-            input_schema:  normalize_schema(meta[:options]),
+            input_schema:  normalize_schema(defn&.dig(:inputs)&.any? ? defn[:inputs] : meta[:options]),
             mcp_category:  defn&.dig(:mcp_category),
             mcp_tier:      defn&.dig(:mcp_tier),
             deferred:      deferred,

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.8.4'
+  VERSION = '1.8.5'
 end

--- a/spec/legion/extensions/core_spec.rb
+++ b/spec/legion/extensions/core_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe Legion::Extensions::Core do
 
     it 'splits compound lex names into individual words' do
       stub_const('Legion::Extensions::IdentityLdap', Module.new { extend Legion::Extensions::Core })
-      expect(Legion::Extensions::IdentityLdap.trigger_words).to eq(['identity', 'ldap'])
+      expect(Legion::Extensions::IdentityLdap.trigger_words).to eq(%w[identity ldap])
     end
 
     it 'returns explicit trigger_words unchanged when overridden' do
       mod = Module.new do
         extend Legion::Extensions::Core
+
         def self.trigger_words
           %w[custom words]
         end

--- a/spec/legion/extensions/core_spec.rb
+++ b/spec/legion/extensions/core_spec.rb
@@ -4,14 +4,24 @@ require 'spec_helper'
 
 RSpec.describe Legion::Extensions::Core do
   describe '.trigger_words' do
-    let(:ext_module) do
-      Module.new do
-        extend Legion::Extensions::Core
-      end
+    it 'defaults to lex name segments derived from the module name' do
+      stub_const('Legion::Extensions::Github', Module.new { extend Legion::Extensions::Core })
+      expect(Legion::Extensions::Github.trigger_words).to eq(['github'])
     end
 
-    it 'defaults to an empty array' do
-      expect(ext_module.trigger_words).to eq([])
+    it 'splits compound lex names into individual words' do
+      stub_const('Legion::Extensions::IdentityLdap', Module.new { extend Legion::Extensions::Core })
+      expect(Legion::Extensions::IdentityLdap.trigger_words).to eq(['identity', 'ldap'])
+    end
+
+    it 'returns explicit trigger_words unchanged when overridden' do
+      mod = Module.new do
+        extend Legion::Extensions::Core
+        def self.trigger_words
+          %w[custom words]
+        end
+      end
+      expect(mod.trigger_words).to eq(%w[custom words])
     end
   end
 end


### PR DESCRIPTION
## Summary
- Extensions and runners no longer need to manually declare trigger words — they're auto-derived from the lex/runner name
- Auto-discovered tools now receive real JSON Schema parameter definitions instead of empty schemas

## Changes

### Commit 1: trigger words (Fixes #139)
- `lib/legion/extensions/core.rb` — `trigger_words` defaults to `lex_name.split('_')` instead of `[]`
- `lib/legion/extensions/builders/runners.rb` — runner entries always populate `trigger_words`, defaulting to `[runner_name]`
- `spec/legion/extensions/core_spec.rb` — updated tests for new default behaviour

### Commit 2: schema quality (Fixes #140)
- `lib/legion/tools/discovery.rb` — `synthesize_functions` converts `Method#parameters` into JSON Schema required/optional properties; uses `definition[:desc]` and `definition[:inputs]` when present; fixes `resolve_exposed` default asymmetry (`false` → `true`)
- `CHANGELOG.md` + `lib/legion/version.rb` — bump to 1.8.5

## Test plan
- [ ] `bundle exec rspec spec/legion/extensions/core_spec.rb` — 3 examples, 0 failures
- [ ] `bundle exec rspec spec/legion/tools/discovery_spec.rb` — 0 failures
- [ ] `bundle exec rspec` — 4970 examples, 6 pre-existing failures (fleet_command, embedding_cache), 0 new failures
- [ ] `bundle exec rubocop lib/legion/extensions/core.rb lib/legion/extensions/builders/runners.rb lib/legion/tools/discovery.rb` — 0 offenses