### PR TITLE
add sticky runner support: sticky accessor, sticky_tools?, Discovery propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.8.6] - 2026-04-15
+
+### Added
+- `Tools::Base#sticky` accessor — tool classes can opt out of sticky runner injection (defaults `true`)
+- `Tools::Discovery` propagates `sticky_tools?` from extension to tool class `sticky` attribute; nil treated as opt-out (conservative)
+- `Extensions::Core#sticky_tools?` — defaults `true`, extensions may override with `def self.sticky_tools? false end`
+
 ## [1.8.5] - 2026-04-15
 
 ### Fixed

--- a/lib/legion/extensions/core.rb
+++ b/lib/legion/extensions/core.rb
@@ -127,6 +127,10 @@ module Legion
         true
       end
 
+      def sticky_tools?
+        true
+      end
+
       def trigger_words
         lex_name.split('_')
       end

--- a/lib/legion/tools/base.rb
+++ b/lib/legion/tools/base.rb
@@ -75,6 +75,12 @@ module Legion
           @trigger_words = val
         end
 
+        def sticky(val = nil)
+          return @sticky.nil? || @sticky if val.nil?
+
+          @sticky = val
+        end
+
         def call(**_args)
           raise NotImplementedError, "#{name} must implement .call"
         end

--- a/lib/legion/tools/discovery.rb
+++ b/lib/legion/tools/discovery.rb
@@ -181,7 +181,8 @@ module Legion
             deferred:      deferred,
             ext_name:      ext_name,
             runner_snake:  runner_snake,
-            trigger_words: merge_trigger_words(ext, runner_mod)
+            trigger_words: merge_trigger_words(ext, runner_mod),
+            sticky:        ext.respond_to?(:sticky_tools?) ? ext.sticky_tools? == true : true
           }
         end
 
@@ -196,6 +197,7 @@ module Legion
             mcp_category(attrs[:mcp_category]) if attrs[:mcp_category]
             mcp_tier(attrs[:mcp_tier]) if attrs[:mcp_tier]
             trigger_words(attrs[:trigger_words])
+            sticky(attrs[:sticky])
 
             define_singleton_method(:call) do |**params|
               if runner_ref.respond_to?(func_ref)
@@ -214,7 +216,19 @@ module Legion
 
         def merge_trigger_words(ext, runner_mod)
           ext_words = ext.respond_to?(:trigger_words) ? Array(ext.trigger_words) : []
-          runner_words = runner_mod.respond_to?(:trigger_words) ? Array(runner_mod.trigger_words) : []
+
+          # Prefer explicit trigger_words on the runner module itself.
+          # Fall back to the runner entry stored by builders/runners.rb, which
+          # defaults to [runner_name] when the module doesn't define them.
+          runner_words = if runner_mod.respond_to?(:trigger_words) && runner_mod.trigger_words.any?
+                           Array(runner_mod.trigger_words)
+                         elsif ext.respond_to?(:runners) && ext.runners.is_a?(Hash)
+                           entry = ext.runners.values.find { |r| r[:runner_module] == runner_mod }
+                           Array(entry&.dig(:trigger_words))
+                         else
+                           []
+                         end
+
           (ext_words + runner_words).uniq
         end
 

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.8.5'
+  VERSION = '1.8.6'
 end

--- a/spec/legion/extensions/core_spec.rb
+++ b/spec/legion/extensions/core_spec.rb
@@ -3,6 +3,23 @@
 require 'spec_helper'
 
 RSpec.describe Legion::Extensions::Core do
+  describe '.sticky_tools?' do
+    it 'returns true by default' do
+      stub_const('Legion::Extensions::StickyTest', Module.new { extend Legion::Extensions::Core })
+      expect(Legion::Extensions::StickyTest.sticky_tools?).to eq(true)
+    end
+
+    it 'can be overridden to false on extension module' do
+      mod = Module.new do
+        extend Legion::Extensions::Core
+        def self.sticky_tools?
+          false
+        end
+      end
+      expect(mod.sticky_tools?).to eq(false)
+    end
+  end
+
   describe '.trigger_words' do
     it 'defaults to lex name segments derived from the module name' do
       stub_const('Legion::Extensions::Github', Module.new { extend Legion::Extensions::Core })

--- a/spec/legion/extensions/core_spec.rb
+++ b/spec/legion/extensions/core_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Legion::Extensions::Core do
     it 'can be overridden to false on extension module' do
       mod = Module.new do
         extend Legion::Extensions::Core
+
         def self.sticky_tools?
           false
         end

--- a/spec/legion/tools/base_spec.rb
+++ b/spec/legion/tools/base_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Legion::Tools::Base do
 
     it 'is a no-op read when called with nil' do
       tool_class.sticky(false)
-      tool_class.sticky(nil)  # should NOT reset to true
+      tool_class.sticky(nil) # should NOT reset to true
       expect(tool_class.sticky).to eq(false)
     end
   end

--- a/spec/legion/tools/base_spec.rb
+++ b/spec/legion/tools/base_spec.rb
@@ -85,6 +85,30 @@ RSpec.describe Legion::Tools::Base do
     end
   end
 
+  describe '.sticky' do
+    let(:tool_class) { Class.new(described_class) }
+
+    it 'defaults to true when never set' do
+      expect(tool_class.sticky).to eq(true)
+    end
+
+    it 'returns false when set to false' do
+      tool_class.sticky(false)
+      expect(tool_class.sticky).to eq(false)
+    end
+
+    it 'returns true when set to true' do
+      tool_class.sticky(true)
+      expect(tool_class.sticky).to eq(true)
+    end
+
+    it 'is a no-op read when called with nil' do
+      tool_class.sticky(false)
+      tool_class.sticky(nil)  # should NOT reset to true
+      expect(tool_class.sticky).to eq(false)
+    end
+  end
+
   describe '.call' do
     it 'raises NotImplementedError on base class' do
       expect { described_class.call }.to raise_error(NotImplementedError)

--- a/spec/legion/tools/discovery_spec.rb
+++ b/spec/legion/tools/discovery_spec.rb
@@ -142,6 +142,47 @@ RSpec.describe Legion::Tools::Discovery do
     end
   end
 
+  describe 'sticky attribute on discovered tool classes' do
+    let(:ext) do
+      mod = Module.new
+      mod.extend(Legion::Extensions::Core) if Legion::Extensions.const_defined?(:Core, false)
+      mod
+    end
+
+    it 'sets sticky true when extension returns true from sticky_tools?' do
+      allow(ext).to receive(:sticky_tools?).and_return(true)
+      attrs = Legion::Tools::Discovery.send(:tool_attributes, ext, double(name: 'Ext::Runners::Test'),
+                                            :do_thing, { desc: 'test', options: {} }, nil, false)
+      expect(attrs[:sticky]).to eq(true)
+    end
+
+    it 'sets sticky false when extension returns false' do
+      allow(ext).to receive(:sticky_tools?).and_return(false)
+      attrs = Legion::Tools::Discovery.send(:tool_attributes, ext, double(name: 'Ext::Runners::Test'),
+                                            :do_thing, { desc: 'test', options: {} }, nil, false)
+      expect(attrs[:sticky]).to eq(false)
+    end
+
+    it 'treats nil return from sticky_tools? as false (conservative opt-out)' do
+      allow(ext).to receive(:sticky_tools?).and_return(nil)
+      attrs = Legion::Tools::Discovery.send(:tool_attributes, ext, double(name: 'Ext::Runners::Test'),
+                                            :do_thing, { desc: 'test', options: {} }, nil, false)
+      expect(attrs[:sticky]).to eq(false)
+    end
+
+    it 'calls sticky() on the created tool class' do
+      allow(ext).to receive(:sticky_tools?).and_return(false)
+      tool_class = Legion::Tools::Discovery.send(:build_tool_class,
+                     ext: ext,
+                     runner_mod: double(name: 'Ext::Runners::Test', respond_to?: false),
+                     func_name: :do_thing,
+                     meta: { desc: 'test', options: {} },
+                     defn: nil,
+                     deferred: false)
+      expect(tool_class.sticky).to eq(false)
+    end
+  end
+
   describe 'runner-level override' do
     let(:override_runner) do
       Module.new do

--- a/spec/legion/tools/discovery_spec.rb
+++ b/spec/legion/tools/discovery_spec.rb
@@ -173,12 +173,12 @@ RSpec.describe Legion::Tools::Discovery do
     it 'calls sticky() on the created tool class' do
       allow(ext).to receive(:sticky_tools?).and_return(false)
       tool_class = Legion::Tools::Discovery.send(:build_tool_class,
-                     ext: ext,
-                     runner_mod: double(name: 'Ext::Runners::Test', respond_to?: false),
-                     func_name: :do_thing,
-                     meta: { desc: 'test', options: {} },
-                     defn: nil,
-                     deferred: false)
+                                                 ext:        ext,
+                                                 runner_mod: double(name: 'Ext::Runners::Test', respond_to?: false),
+                                                 func_name:  :do_thing,
+                                                 meta:       { desc: 'test', options: {} },
+                                                 defn:       nil,
+                                                 deferred:   false)
       expect(tool_class.sticky).to eq(false)
     end
   end


### PR DESCRIPTION
## Summary
Adds the LegionIO-side changes needed for sticky runner tool injection in legion-llm.

## Changes

### sticky accessor on `Tools::Base`
- `sticky(val = nil)` accessor — defaults `true` when never set
- `false` only when explicitly set to `false` via `sticky(false)`
- `nil` call is a read-only no-op (doesn't reset to true)

### `sticky_tools?` on `Extensions::Core`
- Defaults `true` — all extensions are sticky by default
- Extensions that should never be sticky (e.g. sensitive operations requiring fresh explicit intent) override with `def self.sticky_tools? false end`

### `Tools::Discovery` propagation
- `tool_attributes` adds `sticky: !!(ext.sticky_tools?)` — nil from `sticky_tools?` treated as opt-out (conservative)
- `create_tool_class` calls `sticky(attrs[:sticky])` on each dynamically created tool class

## Dependencies
These changes must be released before or simultaneously with the corresponding legion-llm sticky runner PR.

## Test plan
- [ ] `bundle exec rspec spec/legion/tools/base_spec.rb` — 4 new sticky accessor tests pass
- [ ] `bundle exec rspec spec/legion/extensions/core_spec.rb` — 2 new sticky_tools? tests pass
- [ ] `bundle exec rspec spec/legion/tools/discovery_spec.rb` — 4 new sticky attribute tests pass
- [ ] `bundle exec rspec` — 4980 examples, 6 pre-existing failures, 0 new failures
- [ ] `bundle exec rubocop lib/legion/tools/base.rb lib/legion/tools/discovery.rb lib/legion/extensions/core.rb` — 0 offenses