### PR TITLE
fix add no-op pattern class method to Actors::Subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.8.7] - 2026-04-17
+### Fixed
+- Add no-op `pattern(*) ` class method to `Actors::Subscription` — subscription actors that call `pattern` for routing hint documentation raised `NoMethodError` on class load, causing absorber build failures
+
 ## [1.8.6] - 2026-04-15
 
 ### Added

--- a/lib/legion/extensions/actors/subscription.rb
+++ b/lib/legion/extensions/actors/subscription.rb
@@ -15,6 +15,12 @@ module Legion
         include Legion::Extensions::Actors::Base
         include Legion::Extensions::Helpers::Transport
 
+        # Absorber-style routing pattern hint. Subscription actors may call
+        # `pattern` to declare their routing key for documentation and tooling.
+        # This is a no-op at the Subscription level — actual routing is handled
+        # by the queue binding — but its absence raises NoMethodError on load.
+        def self.pattern(*); end
+
         define_dsl_accessor :consumers, default: 1
         define_dsl_accessor :manual_ack, default: true
         define_dsl_accessor :delay_start, default: 0

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.8.6'
+  VERSION = '1.8.7'
 end


### PR DESCRIPTION
Closes #148

## Change

Adds a no-op `def self.pattern(*); end` to `Actors::Subscription`.

`Actors::Subscription` subclasses may call `pattern 'routing.key'` as a documentation hint. The method did not exist on the base class, causing `NoMethodError` on class load for any extension that uses this pattern (e.g. `lex-github` `IssuesActor`).

The splat `*` accepts any argument form. Actual queue routing is unaffected.