### PR TITLE
fix: CLI chat tool execution, spinner UX, and Vault secret resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/
 config/tls/
 # generated integration specs
 spec/integration/self_generate_spec.rb
+worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [1.8.15] - 2026-04-21
+
+### Fixed
+- **CLI Chat Tool Security**: `Chat::Permissions::Gate#call` now returns `RubyLLM::Tool::Halt.new('Tool execution denied by user.')` instead of a plain string to properly signal tool execution loop termination and prevent infinite retry cycles
+- **Output Truncation**: `ReadFile` and `RunCommand` tools now make `MAX_OUTPUT_CHARS` (48K) configurable via `Legion::Settings[:chat][:tools][:max_output_chars]` with fallback to constant
+- **Terminal Control Sequences**: `Chat::StatusIndicator#stop_spinner` now checks `$stderr.tty?` before printing ANSI escape sequences to avoid control characters in CI logs
+- **Vault Secret Resolution**: `Connection#ensure_llm` replaced `ensure_crypt rescue nil` with proper error logging to avoid silently swallowing vault:// resolution failures
+
+### Added
+- **Before Prompt Hook**: `Chat::Permissions.before_prompt` callback support - called before permission confirmation prompts (used to pause spinners during interactive prompts)
+- **Test Coverage**: Added comprehensive specs for `ReadFile` and `RunCommand` output truncation behavior, `StatusIndicator` TTY handling, and `Permissions` before_prompt callback functionality
+
 ## [1.8.14] - 2026-04-18
 
 ### Fixed

--- a/lib/legion/cli/chat/permissions.rb
+++ b/lib/legion/cli/chat/permissions.rb
@@ -67,7 +67,7 @@ module Legion
           def call(args)
             normalized = normalize_args(args)
             desc = permission_description(normalized)
-            return 'Tool execution denied by user.' unless Permissions.confirm?(desc)
+            return RubyLLM::Tool::Halt.new('Tool execution denied by user.') unless Permissions.confirm?(desc)
 
             super
           end

--- a/lib/legion/cli/chat/permissions.rb
+++ b/lib/legion/cli/chat/permissions.rb
@@ -23,7 +23,7 @@ module Legion
         @extension_tiers = {}
 
         class << self
-          attr_accessor :mode
+          attr_accessor :mode, :before_prompt
 
           def auto_allow?
             %i[headless auto_approve].include?(mode)
@@ -37,6 +37,7 @@ module Legion
             return false if read_only?
             return true if auto_allow?
 
+            @before_prompt&.call
             $stderr.print "\e[33m#{description}\e[0m\n  Allow? [y/n] "
             response = $stdin.gets&.strip&.downcase
             %w[y yes].include?(response)

--- a/lib/legion/cli/chat/status_indicator.rb
+++ b/lib/legion/cli/chat/status_indicator.rb
@@ -16,6 +16,10 @@ module Legion
           subscribe_events
         end
 
+        def pause
+          stop_spinner
+        end
+
         private
 
         def subscribe_events

--- a/lib/legion/cli/chat/status_indicator.rb
+++ b/lib/legion/cli/chat/status_indicator.rb
@@ -55,7 +55,7 @@ module Legion
           return unless @active_spinner
 
           @active_spinner.stop
-          $stderr.print "\r\e[2K"
+          $stderr.print "\r\e[2K" if $stderr.tty?
           @active_spinner = nil
         end
       end

--- a/lib/legion/cli/chat/status_indicator.rb
+++ b/lib/legion/cli/chat/status_indicator.rb
@@ -51,6 +51,7 @@ module Legion
           return unless @active_spinner
 
           @active_spinner.stop
+          $stderr.print "\r\e[2K"
           @active_spinner = nil
         end
       end

--- a/lib/legion/cli/chat/tools/read_file.rb
+++ b/lib/legion/cli/chat/tools/read_file.rb
@@ -30,12 +30,24 @@ module Legion
             end
 
             result = "#{expanded} (#{lines.length} lines total)\n#{numbered.join}"
-            return result if result.length <= MAX_OUTPUT_CHARS
+            max_chars = max_output_chars
+            return result if result.length <= max_chars
 
-            "#{result[0, MAX_OUTPUT_CHARS]}\n\n[... truncated at #{MAX_OUTPUT_CHARS} characters — use offset/limit params to read specific sections]"
+            "#{result[0, max_chars]}\n\n[... truncated at #{max_chars} characters — use offset/limit params to read specific sections]"
           rescue StandardError => e
             Legion::Logging.warn("ReadFile#execute failed for #{path}: #{e.message}") if defined?(Legion::Logging)
             "Error reading #{path}: #{e.message}"
+          end
+
+          private
+
+          # Returns the max output chars from settings with fallback to constant.
+          # Memory usage note: Still reads entire file before truncation - this is intentional
+          # to avoid complex streaming logic. For very large files, use offset/limit params.
+          def max_output_chars
+            Legion::Settings.dig(:chat, :tools, :max_output_chars) || MAX_OUTPUT_CHARS
+          rescue StandardError
+            MAX_OUTPUT_CHARS
           end
         end
       end

--- a/lib/legion/cli/chat/tools/read_file.rb
+++ b/lib/legion/cli/chat/tools/read_file.rb
@@ -8,6 +8,8 @@ module Legion
     class Chat
       module Tools
         class ReadFile < RubyLLM::Tool
+          MAX_OUTPUT_CHARS = 48_000
+
           description 'Read the contents of a file. Returns the file content with line numbers.'
           param :path, type: 'string', desc: 'Absolute or relative path to the file'
           param :offset, type: 'integer', desc: 'Line number to start reading from (1-based)', required: false
@@ -27,7 +29,10 @@ module Legion
               "#{(start_line + i + 1).to_s.rjust(5)} | #{line}"
             end
 
-            "#{expanded} (#{lines.length} lines total)\n#{numbered.join}"
+            result = "#{expanded} (#{lines.length} lines total)\n#{numbered.join}"
+            return result if result.length <= MAX_OUTPUT_CHARS
+
+            "#{result[0, MAX_OUTPUT_CHARS]}\n\n[... truncated at #{MAX_OUTPUT_CHARS} characters — use offset/limit params to read specific sections]"
           rescue StandardError => e
             Legion::Logging.warn("ReadFile#execute failed for #{path}: #{e.message}") if defined?(Legion::Logging)
             "Error reading #{path}: #{e.message}"

--- a/lib/legion/cli/chat/tools/run_command.rb
+++ b/lib/legion/cli/chat/tools/run_command.rb
@@ -91,9 +91,19 @@ module Legion
           end
 
           def truncate_output(text)
-            return text if text.length <= MAX_OUTPUT_CHARS
+            max_chars = max_output_chars
+            return text if text.length <= max_chars
 
-            "#{text[0, MAX_OUTPUT_CHARS]}\n\n[... truncated at #{MAX_OUTPUT_CHARS} characters (#{text.length} total)]"
+            "#{text[0, max_chars]}\n\n[... truncated at #{max_chars} characters (#{text.length} total)]"
+          end
+
+          # Returns the max output chars from settings with fallback to constant.
+          # Memory usage note: Still reads entire command output before truncation - this is intentional
+          # to avoid complex streaming logic. For verbose commands, consider output redirection.
+          def max_output_chars
+            Legion::Settings.dig(:chat, :tools, :max_output_chars) || MAX_OUTPUT_CHARS
+          rescue StandardError
+            MAX_OUTPUT_CHARS
           end
         end
       end

--- a/lib/legion/cli/chat/tools/run_command.rb
+++ b/lib/legion/cli/chat/tools/run_command.rb
@@ -10,6 +10,8 @@ module Legion
     class Chat
       module Tools
         class RunCommand < RubyLLM::Tool
+          MAX_OUTPUT_CHARS = 48_000
+
           description 'Execute a shell command and return its output. Use for running tests, builds, git commands, etc.'
           param :command, type: 'string', desc: 'The shell command to execute'
           param :timeout, type: 'integer', desc: 'Timeout in seconds (default: 120)', required: false
@@ -50,7 +52,7 @@ module Legion
             elsif result[:success] == false && result[:error]
               "Error executing command: #{result[:error]}"
             else
-              format_output(command, result[:stdout], result[:stderr], result[:exit_code])
+              truncate_output(format_output(command, result[:stdout], result[:stderr], result[:exit_code]))
             end
           rescue StandardError => e
             "Error executing command: #{e.message}"
@@ -73,13 +75,12 @@ module Legion
               [out_reader.value, err_reader.value, wait_thr.value]
             end
 
-            format_output(command, stdout, stderr, status.exitstatus)
+            truncate_output(format_output(command, stdout, stderr, status.exitstatus))
           rescue ::Timeout::Error
             "[command timed out after #{timeout}s]: #{command}"
           rescue StandardError => e
             "Error executing command: #{e.message}"
           end
-
           def format_output(command, stdout, stderr, exit_code)
             output = String.new
             output << "$ #{command}\n"
@@ -87,6 +88,12 @@ module Legion
             output << stderr.to_s unless stderr.to_s.empty?
             output << "\n[exit code: #{exit_code}]"
             output
+          end
+
+          def truncate_output(text)
+            return text if text.length <= MAX_OUTPUT_CHARS
+
+            "#{text[0, MAX_OUTPUT_CHARS]}\n\n[... truncated at #{MAX_OUTPUT_CHARS} characters (#{text.length} total)]"
           end
         end
       end

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -51,6 +51,7 @@ module Legion
           budget_usd: effective_budget
         )
         @indicator = Chat::StatusIndicator.new(@session) unless options[:json]
+        Chat::Permissions.before_prompt = -> { @indicator&.pause } if @indicator
 
         restore_session(out) if options[:continue] || options[:resume] || options[:resume_latest] || options[:fork]
         load_memory_context

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -409,11 +409,11 @@ module Legion
                 tool_index += 1
                 chat_log.debug "tool_call name=#{tc.name} args=#{tc.arguments.keys.join(',')}"
                 turn_tool_calls << { name: tc.name, args: tc.arguments, result: nil }
+                puts out.dim("  [tool] #{tc.name}(#{tc.arguments.keys.join(', ')})")
                 @session.emit(:tool_start, {
                                 name: tc.name, args: tc.arguments,
                   index: tool_index, total: tool_total
                               })
-                puts out.dim("  [tool] #{tc.name}(#{tc.arguments.keys.join(', ')})")
               },
               on_tool_result: lambda { |tr|
                 result_preview = tr.to_s.lines.first(3).join.rstrip

--- a/lib/legion/cli/connection.rb
+++ b/lib/legion/cli/connection.rb
@@ -103,6 +103,8 @@ module Legion
           return if @llm_ready
 
           ensure_settings
+          ensure_crypt rescue nil
+          Legion::Settings.resolve_secrets! if Legion::Settings.respond_to?(:resolve_secrets!)
           require 'legion/llm'
           Legion::Settings.merge_settings(:llm, Legion::LLM::Settings.default)
           Legion::LLM.start

--- a/lib/legion/cli/connection.rb
+++ b/lib/legion/cli/connection.rb
@@ -103,7 +103,11 @@ module Legion
           return if @llm_ready
 
           ensure_settings
-          ensure_crypt rescue nil
+          begin
+            ensure_crypt
+          rescue StandardError => e
+            Legion::Logging.warn("ensure_crypt failed during LLM init: #{e.message}") if defined?(Legion::Logging)
+          end
           Legion::Settings.resolve_secrets! if Legion::Settings.respond_to?(:resolve_secrets!)
           require 'legion/llm'
           Legion::Settings.merge_settings(:llm, Legion::LLM::Settings.default)

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.8.14'
+  VERSION = '1.8.15'
 end

--- a/spec/legion/cli/chat/permissions_spec.rb
+++ b/spec/legion/cli/chat/permissions_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       allow($stderr).to receive(:print)
 
       result = tool.call({ path: path, content: 'hello' })
-      expect(result).to eq('Tool execution denied by user.')
+      expect(result).to be_a(RubyLLM::Tool::Halt)
+      expect(result.message).to eq('Tool execution denied by user.')
       expect(File.exist?(path)).to be false
     end
 
@@ -109,7 +110,8 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       allow($stderr).to receive(:print)
 
       result = tool.call({ path: path, old_text: 'world', new_text: 'legion' })
-      expect(result).to eq('Tool execution denied by user.')
+      expect(result).to be_a(RubyLLM::Tool::Halt)
+      expect(result.message).to eq('Tool execution denied by user.')
       expect(File.read(path)).to eq('hello world')
     end
 
@@ -133,7 +135,8 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       allow($stderr).to receive(:print)
 
       result = tool.call({ command: 'echo hello' })
-      expect(result).to eq('Tool execution denied by user.')
+      expect(result).to be_a(RubyLLM::Tool::Halt)
+      expect(result.message).to eq('Tool execution denied by user.')
     end
 
     it 'allows when user approves' do
@@ -178,6 +181,38 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       expect($stdin).not_to receive(:gets)
       result = tool.call({ pattern: '*.rb', directory: tmpdir })
       expect(result).to include('findme.rb')
+    end
+  end
+
+  describe '.before_prompt callback' do
+    let(:tool) { Legion::CLI::Chat::Tools::WriteFile.new }
+    let(:path) { File.join(tmpdir, 'callback_test.txt') }
+    let(:callback_called) { [] }
+
+    before do
+      described_class.before_prompt = -> { callback_called << :called }
+    end
+
+    after do
+      described_class.before_prompt = nil
+    end
+
+    it 'calls the before_prompt callback before showing confirmation' do
+      described_class.mode = :interactive
+      allow($stdin).to receive(:gets).and_return("y\n")
+      allow($stderr).to receive(:print)
+
+      tool.call({ path: path, content: 'hello' })
+
+      expect(callback_called).to eq([:called])
+    end
+
+    it 'does not call the callback in auto_approve mode' do
+      described_class.mode = :auto_approve
+
+      tool.call({ path: path, content: 'hello' })
+
+      expect(callback_called).to be_empty
     end
   end
 end

--- a/spec/legion/cli/chat/status_indicator_spec.rb
+++ b/spec/legion/cli/chat/status_indicator_spec.rb
@@ -88,11 +88,34 @@ RSpec.describe Legion::CLI::Chat::StatusIndicator do
     end
   end
 
-  describe 'non-TTY output' do
-    it 'does not raise when output is not a TTY' do
+  describe 'TTY handling' do
+    it 'only prints control sequences when stderr is a TTY' do
+      allow($stderr).to receive(:tty?).and_return(true)
+      allow($stderr).to receive(:print)
+
       indicator
-      expect { session.emit(:llm_start, { turn: 1 }) }.not_to raise_error
-      expect { session.emit(:llm_complete, { turn: 1 }) }.not_to raise_error
+      session.emit(:llm_start, { turn: 1 })
+      session.emit(:llm_complete, { turn: 1 })
+
+      expect($stderr).to have_received(:print).with("\r\e[2K")
+    end
+
+    it 'skips control sequences when stderr is not a TTY' do
+      allow($stderr).to receive(:tty?).and_return(false)
+      allow($stderr).to receive(:print)
+
+      indicator
+      session.emit(:llm_start, { turn: 1 })
+      session.emit(:llm_complete, { turn: 1 })
+
+      expect($stderr).not_to have_received(:print).with("\r\e[2K")
+    end
+
+    it 'calls pause method to stop spinner' do
+      indicator
+      session.emit(:llm_start, { turn: 1 })
+
+      expect { indicator.pause }.not_to raise_error
     end
   end
 end

--- a/spec/legion/cli/chat/tools/read_file_spec.rb
+++ b/spec/legion/cli/chat/tools/read_file_spec.rb
@@ -1,0 +1,35 @@
+  describe 'output truncation' do
+    it 'truncates long content at MAX_OUTPUT_CHARS' do
+      path = File.join(tmpdir, 'large.txt')
+      large_content = 'x' * 50_000  # Exceeds 48K limit
+      File.write(path, large_content)
+
+      result = tool.execute(path: path)
+
+      expect(result).to include('truncated at 48000 characters')
+      expect(result).to include('use offset/limit params')
+      expect(result.length).to be < large_content.length
+    end
+
+    it 'respects settings-based max_output_chars override' do
+      allow(Legion::Settings).to receive(:dig).with(:chat, :tools, :max_output_chars).and_return(100)
+
+      path = File.join(tmpdir, 'medium.txt')
+      File.write(path, 'x' * 200)
+
+      result = tool.execute(path: path)
+
+      expect(result).to include('truncated at 100 characters')
+    end
+
+    it 'does not truncate short content' do
+      path = File.join(tmpdir, 'small.txt')
+      File.write(path, "line 1\nline 2\nline 3")
+
+      result = tool.execute(path: path)
+
+      expect(result).not_to include('truncated')
+      expect(result).to include('small.txt (3 lines total)')
+      expect(result).to include('1 | line 1')
+    end
+  end

--- a/spec/legion/cli/chat/tools/run_command_spec.rb
+++ b/spec/legion/cli/chat/tools/run_command_spec.rb
@@ -26,6 +26,33 @@ RSpec.describe Legion::CLI::Chat::Tools::RunCommand do
     expect(result).to include('timed out')
   end
 
+  describe 'output truncation' do
+    it 'truncates long output at MAX_OUTPUT_CHARS' do
+      # Create a large output that exceeds the default limit
+      large_text = 'A' * 25_000
+      result = tool.execute(command: "echo '#{large_text}#{large_text}'")
+
+      expect(result).to include('truncated at 48000 characters')
+      expect(result.length).to be < 50_000
+    end
+
+    it 'respects settings-based max_output_chars override' do
+      allow(Legion::Settings).to receive(:dig).with(:chat, :tools, :max_output_chars).and_return(200)
+
+      result = tool.execute(command: 'echo "this is a test output that should exceed 200 characters when combined with the command header and exit code"')
+
+      expect(result).to include('truncated at 200 characters')
+    end
+
+    it 'does not truncate short output' do
+      result = tool.execute(command: 'echo short')
+
+      expect(result).not_to include('truncated')
+      expect(result).to include('short')
+      expect(result).to include('exit code: 0')
+    end
+  end
+
   describe 'sandbox routing' do
     it 'defaults to direct execution when sandboxed_commands not enabled' do
       allow(Legion::Settings).to receive(:dig).with(:chat, :sandboxed_commands, :enabled).and_return(nil)


### PR DESCRIPTION
## Summary

- **Break infinite tool retry loop**: Return `RubyLLM::Tool::Halt` on permission denial instead of a plain string, so `handle_tool_calls` stops re-invoking the denied tool
- **Vault secret resolution**: Call `ensure_crypt` and `resolve_secrets!` before LLM start so `vault://` credential references are resolved at boot
- **Output truncation**: Cap `read_file` and `run_command` tool output at 48K characters — prevents context window overflow (was hitting 2.3M tokens on large files)
- **Spinner/prompt UX**: Stop spinner before permission prompts via `before_prompt` callback; clear terminal line on spinner stop to prevent residual text

## Files Changed

| File | Change |
|---|---|
| `lib/legion/cli/chat/permissions.rb` | `before_prompt` callback + `Tool::Halt` return |
| `lib/legion/cli/chat/status_indicator.rb` | Public `pause` method, terminal line clearing |
| `lib/legion/cli/chat/tools/read_file.rb` | 48K output truncation |
| `lib/legion/cli/chat/tools/run_command.rb` | 48K output truncation |
| `lib/legion/cli/chat_command.rb` | Wire spinner pause to permission prompt |
| `lib/legion/cli/connection.rb` | Vault secret resolution before LLM init |

## Test plan

- [ ] `legion chat` → trigger tool requiring permission → verify prompt appears cleanly, denial stops the loop
- [ ] `legion chat` with `vault://` secrets in config → verify credentials resolve before LLM connects
- [ ] `read_file` on a large file (>48K chars) → verify output truncated with marker
- [ ] `run_command` with verbose output → verify truncation