### PR TITLE
feat: split-pane TUI for legion chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ legionio_wallpaper*.svg
 legionio_overview*
 # git worktrees
 .worktrees/
+worktrees/
 # local-only directories
 docs/
 config/tls/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [1.8.15] - 2026-04-22
+
+### Added
+- Split-pane TUI is now the default for `legion chat` (disable with `--no-tui`)
+- `legion` bare command now launches chat TUI instead of legacy TTY shell
+- `legion tty` aliased to `legion chat` for backwards compatibility
+- TUI Formatter — routes slash command output to TUI panes instead of stdout
+- Full slash command support in TUI mode (all 30+ commands routed through TUI output)
+- TUI screen `refresh_size` / `mark_dirty` / `dirty?` API for efficient resize handling
+
+### Fixed
+- `setup_connection` now initializes `Legion::LLM` before checking `DaemonClient.available?` — fixes "daemon is not running" false negative when daemon is healthy
+- TUI `--tui` flag replaced with `--no-tui` (TUI on by default when `chat.tui` setting is not false)
+- TUI escape sequence reader uses `io.wait_readable` instead of `IO.select` for fiber scheduler compatibility
+- TUI screen no longer calls `detect_size` on every render frame — only on SIGWINCH
+- RuboCop compliance for all TUI modules
+
 ## [1.8.14] - 2026-04-18
 
 ### Fixed

--- a/exe/legion
+++ b/exe/legion
@@ -22,19 +22,18 @@ end
 
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
-# Bare `legion` (no args, interactive terminal) launches the TTY shell
+# Bare `legion` (no args, interactive terminal) launches the chat TUI
 # Bare `legion` (piped stdin) goes to headless chat prompt
 # `legion <subcommand>` routes to the Interactive CLI (dev-workflow commands)
+require 'legion/cli'
+
 if ARGV.empty?
   if $stdin.tty?
-    require 'legion/tty'
-    Legion::TTY::App.run
+    Legion::CLI::Chat.start(['interactive'])
   else
-    require 'legion/cli'
     ARGV.replace(['chat', 'prompt', ''])
     Legion::CLI::Main.start(ARGV)
   end
 else
-  require 'legion/cli'
   Legion::CLI::Interactive.start(ARGV)
 end

--- a/lib/legion/cli/chat/permissions.rb
+++ b/lib/legion/cli/chat/permissions.rb
@@ -67,7 +67,7 @@ module Legion
           def call(args)
             normalized = normalize_args(args)
             desc = permission_description(normalized)
-            return 'Tool execution denied by user.' unless Permissions.confirm?(desc)
+            return RubyLLM::Tool::Halt.new('Tool execution denied by user.') unless Permissions.confirm?(desc)
 
             super
           end

--- a/lib/legion/cli/chat/permissions.rb
+++ b/lib/legion/cli/chat/permissions.rb
@@ -23,7 +23,7 @@ module Legion
         @extension_tiers = {}
 
         class << self
-          attr_accessor :mode
+          attr_accessor :mode, :before_prompt
 
           def auto_allow?
             %i[headless auto_approve].include?(mode)
@@ -37,6 +37,7 @@ module Legion
             return false if read_only?
             return true if auto_allow?
 
+            @before_prompt&.call
             $stderr.print "\e[33m#{description}\e[0m\n  Allow? [y/n] "
             response = $stdin.gets&.strip&.downcase
             %w[y yes].include?(response)

--- a/lib/legion/cli/chat/status_indicator.rb
+++ b/lib/legion/cli/chat/status_indicator.rb
@@ -16,6 +16,10 @@ module Legion
           subscribe_events
         end
 
+        def pause
+          stop_spinner
+        end
+
         private
 
         def subscribe_events

--- a/lib/legion/cli/chat/status_indicator.rb
+++ b/lib/legion/cli/chat/status_indicator.rb
@@ -51,6 +51,7 @@ module Legion
           return unless @active_spinner
 
           @active_spinner.stop
+          $stderr.print "\r\e[2K"
           @active_spinner = nil
         end
       end

--- a/lib/legion/cli/chat/tools/read_file.rb
+++ b/lib/legion/cli/chat/tools/read_file.rb
@@ -8,6 +8,8 @@ module Legion
     class Chat
       module Tools
         class ReadFile < RubyLLM::Tool
+          MAX_OUTPUT_CHARS = 48_000
+
           description 'Read the contents of a file. Returns the file content with line numbers.'
           param :path, type: 'string', desc: 'Absolute or relative path to the file'
           param :offset, type: 'integer', desc: 'Line number to start reading from (1-based)', required: false
@@ -27,7 +29,10 @@ module Legion
               "#{(start_line + i + 1).to_s.rjust(5)} | #{line}"
             end
 
-            "#{expanded} (#{lines.length} lines total)\n#{numbered.join}"
+            result = "#{expanded} (#{lines.length} lines total)\n#{numbered.join}"
+            return result if result.length <= MAX_OUTPUT_CHARS
+
+            "#{result[0, MAX_OUTPUT_CHARS]}\n\n[... truncated at #{MAX_OUTPUT_CHARS} characters — use offset/limit params to read specific sections]"
           rescue StandardError => e
             Legion::Logging.warn("ReadFile#execute failed for #{path}: #{e.message}") if defined?(Legion::Logging)
             "Error reading #{path}: #{e.message}"

--- a/lib/legion/cli/chat/tools/run_command.rb
+++ b/lib/legion/cli/chat/tools/run_command.rb
@@ -10,6 +10,8 @@ module Legion
     class Chat
       module Tools
         class RunCommand < RubyLLM::Tool
+          MAX_OUTPUT_CHARS = 48_000
+
           description 'Execute a shell command and return its output. Use for running tests, builds, git commands, etc.'
           param :command, type: 'string', desc: 'The shell command to execute'
           param :timeout, type: 'integer', desc: 'Timeout in seconds (default: 120)', required: false
@@ -73,7 +75,7 @@ module Legion
               [out_reader.value, err_reader.value, wait_thr.value]
             end
 
-            format_output(command, stdout, stderr, status.exitstatus)
+            truncate_output(format_output(command, stdout, stderr, status.exitstatus))
           rescue ::Timeout::Error
             "[command timed out after #{timeout}s]: #{command}"
           rescue StandardError => e
@@ -87,6 +89,14 @@ module Legion
             output << stderr.to_s unless stderr.to_s.empty?
             output << "\n[exit code: #{exit_code}]"
             output
+          end
+
+          private
+
+          def truncate_output(text)
+            return text if text.length <= MAX_OUTPUT_CHARS
+
+            "#{text[0, MAX_OUTPUT_CHARS]}\n\n[... truncated at #{MAX_OUTPUT_CHARS} characters (#{text.length} total)]"
           end
         end
       end

--- a/lib/legion/cli/chat/tui/app.rb
+++ b/lib/legion/cli/chat/tui/app.rb
@@ -1,0 +1,370 @@
+# frozen_string_literal: true
+
+require 'io/wait'
+require_relative 'screen'
+require_relative 'output_pane'
+require_relative 'status_bar'
+require_relative 'input_bar'
+
+module Legion
+  module CLI
+    class Chat
+      module TUI
+        # The main TUI application. Replaces the old Reline-based repl_loop with a
+        # raw-mode event loop driving three non-overlapping screen regions.
+        #
+        # Usage:
+        #   app = TUI::App.new(session:, slash_handler:, completions:)
+        #   app.run
+        class App
+          # Key mapping: raw escape sequences → symbolic key names
+          KEY_MAP = {
+            "\r"      => :enter,
+            "\n"      => :enter,
+            "\x7F"    => :backspace,
+            "\b"      => :backspace,
+            "\e[A"    => :up,
+            "\e[B"    => :down,
+            "\e[C"    => :right,
+            "\e[D"    => :left,
+            "\e[H"    => :home,
+            "\e[F"    => :end,
+            "\e[1~"   => :home,
+            "\e[4~"   => :end,
+            "\e[5~"   => :page_up,
+            "\e[6~"   => :page_down,
+            "\e[3~"   => :delete,
+            "\eOA"    => :up,
+            "\eOB"    => :down,
+            "\eOC"    => :right,
+            "\eOD"    => :left,
+            "\eOH"    => :home,
+            "\eOF"    => :end,
+            "\x01"    => :ctrl_a,
+            "\x02"    => :ctrl_b,
+            "\x03"    => :ctrl_c,
+            "\x04"    => :ctrl_d,
+            "\x05"    => :ctrl_e,
+            "\x0B"    => :ctrl_k,
+            "\x0C"    => :ctrl_l,
+            "\x15"    => :ctrl_u,
+            "\x17"    => :ctrl_w,
+            "\t"      => :tab
+          }.freeze
+
+          def initialize(session:, model_id: 'unknown', permissions_mode: 'interactive',
+                         slash_handler: nil, completions: [], banner: nil)
+            @session = session
+            @screen = Screen.new
+            @output = OutputPane.new
+            @status = StatusBar.new
+            @input = InputBar.new(completions: completions)
+            @slash_handler = slash_handler
+            @running = false
+            @streaming = false
+            @render_mutex = Mutex.new
+
+            @status.update(model: model_id, permissions_mode: permissions_mode)
+
+            # Wire up session events
+            setup_session_events
+
+            # Show banner if provided
+            if banner
+              banner.to_s.lines.each { |l| @output.add_info(l.chomp) }
+              @output.add_info('')
+            end
+          end
+
+          def run
+            @running = true
+            @screen.clear
+            @screen.hide_cursor
+
+            $stdin.raw do |raw_in|
+              render_frame
+              @screen.show_cursor
+
+              while @running
+                render_frame
+
+                # 50ms timeout during streaming for animation, blocking otherwise
+                timeout = @streaming ? 0.05 : 0.1
+                raw_key = read_raw_key(raw_in, timeout: timeout)
+
+                if @streaming
+                  @status.tick
+                  next unless raw_key
+                end
+
+                next unless raw_key
+
+                key = normalize_key(raw_key)
+                dispatch_key(key)
+              end
+            end
+          rescue Interrupt
+            # Ctrl+C during raw mode
+          ensure
+            @screen.show_cursor
+            $stdout.print "\e[0m"
+            $stdout.print TTY::Cursor.move_to(0, @screen.height - 1)
+            $stdout.print TTY::Cursor.clear_screen_down
+            $stdout.flush
+          end
+
+          def stop
+            @running = false
+          end
+
+          private
+
+          def setup_session_events
+            @session.on(:llm_start) do |_payload|
+              @streaming = true
+              @status.update(thinking: true)
+            end
+
+            @session.on(:llm_first_token) do |_payload|
+              @status.update(thinking: false)
+            end
+
+            @session.on(:llm_complete) do |_payload|
+              @streaming = false
+              @status.update(thinking: false, tool_name: nil)
+            end
+
+            @session.on(:tool_start) do |payload|
+              @status.update(
+                tool_name: payload[:name],
+                tool_index: payload[:index] || 0,
+                tool_total: payload[:total] || 0
+              )
+            end
+
+            @session.on(:tool_complete) do |_payload|
+              @status.update(tool_name: nil)
+            end
+          end
+
+          def render_frame
+            @render_mutex.synchronize do
+              @screen.detect_size
+              input_lines = @input.render(@screen.width)
+              inp_h = [input_lines.length, Screen::INPUT_MIN_HEIGHT].max
+              out_h = @screen.output_height(inp_h)
+              output_lines = @output.render(@screen.width, out_h)
+              status_line = @status.render(@screen.width)
+
+              @screen.render(output_lines, status_line, input_lines)
+
+              # Position cursor in the input region
+              input_row = @screen.input_start_row(inp_h)
+              @screen.position_cursor(@input.cursor_col, input_row)
+            end
+          end
+
+          def dispatch_key(key)
+            case key
+            when :ctrl_c
+              if @streaming
+                # TODO: cancel current LLM request
+                @streaming = false
+                @status.update(thinking: false, tool_name: nil)
+                @output.add_info('(interrupted)')
+              else
+                @input.handle_key(:ctrl_c)
+              end
+            when :ctrl_d
+              if @input.empty?
+                @running = false
+                return
+              end
+            when :ctrl_l
+              @screen.clear
+              return
+            when :page_up
+              @output.scroll_up(5)
+              return
+            when :page_down
+              @output.scroll_down(5)
+              return
+            else
+              result = @input.handle_key(key)
+              case result
+              when :pass
+                handle_pass_key(key)
+              when Array
+                action, text = result
+                handle_submit(text) if action == :submit
+              end
+            end
+          end
+
+          def handle_pass_key(key)
+            case key
+            when :page_up then @output.scroll_up(5)
+            when :page_down then @output.scroll_down(5)
+            when :ctrl_d
+              @running = false if @input.empty?
+            end
+          end
+
+          def handle_submit(text)
+            # Show the user's message in the output pane
+            @output.add_message(:user, text)
+
+            # Check for slash commands
+            if text.start_with?('/')
+              if text.strip == '/quit' || text.strip == '/exit'
+                @running = false
+                return
+              end
+
+              if @slash_handler
+                handled = @slash_handler.call(text)
+                return if handled
+              end
+            end
+
+            # Check for bang commands
+            if text.start_with?('!')
+              handle_bang_command(text[1..])
+              return
+            end
+
+            # Send to LLM
+            send_to_llm(text)
+          end
+
+          def send_to_llm(message)
+            @output.begin_response
+            buffer = String.new
+            tool_index = 0
+
+            @session.send_message(
+              message,
+              on_tool_call: lambda { |tc|
+                tool_index += 1
+                @output.add_tool_call(tc.name, tc.arguments.keys.join(', '))
+                @session.emit(:tool_start, {
+                  name: tc.name, args: tc.arguments,
+                  index: tool_index, total: 0
+                })
+              },
+              on_tool_result: lambda { |tr|
+                result_preview = tr.to_s.lines.first(3).join.rstrip
+                @output.add_tool_result(result_preview)
+                @session.emit(:tool_complete, {
+                  name: 'tool', result_preview: result_preview,
+                  index: tool_index, total: 0
+                })
+              }
+            ) do |chunk|
+              if chunk.content
+                buffer << chunk.content
+                @output.append_chunk(buffer)
+              end
+            end
+
+            # Finalize with rendered response
+            rendered = render_markdown(buffer)
+            @output.end_response(rendered)
+
+            # Update stats
+            update_stats
+          rescue Chat::Session::BudgetExceeded => e
+            @output.add_error("Budget exceeded: #{e.message}")
+          rescue Interrupt
+            @output.add_info('(interrupted)')
+            @streaming = false
+          rescue StandardError => e
+            @output.add_error("LLM error: #{e.message}")
+          end
+
+          def handle_bang_command(cmd)
+            @output.add_info("$ #{cmd}")
+            output = `#{cmd} 2>&1`
+            output.lines.each { |l| @output.add_info(l.chomp) }
+            @output.add_info('')
+          end
+
+          def render_markdown(text)
+            require 'legion/cli/chat/markdown_renderer'
+            Chat::MarkdownRenderer.render(text)
+          rescue LoadError
+            text
+          end
+
+          def update_stats
+            stats = @session.stats
+            @status.update(
+              tokens_in: stats[:input_tokens] || 0,
+              tokens_out: stats[:output_tokens] || 0,
+              cost: @session.estimated_cost,
+              messages: stats[:messages_sent] || 0
+            )
+          end
+
+          # --- Raw key reading (cannibalized from legion-tty App) ---
+
+          def read_raw_key(io, timeout: nil)
+            return nil unless io.wait_readable(timeout)
+
+            ch = io.getc
+            return nil unless ch
+
+            if ch == "\e"
+              read_escape_sequence(io, ch)
+            else
+              # Check for pasted text (multiple chars available immediately)
+              buf = ch
+              while io.ready?
+                buf << io.getc
+              end
+              buf
+            end
+          rescue IOError, Errno::EIO
+            nil
+          end
+
+          def read_escape_sequence(io, ch)
+            return ch unless io.wait_readable(0.05) # 50ms to disambiguate bare Escape
+
+            seq = ch + io.getc.to_s
+
+            case seq[-1]
+            when '['
+              # CSI sequence
+              while io.wait_readable(0.05)
+                c = io.getc
+                seq << c.to_s
+                break if c && c.ord >= 0x40 && c.ord <= 0x7E
+              end
+            when 'O'
+              # SS3 sequence
+              if io.wait_readable(0.05)
+                seq << io.getc.to_s
+              end
+            end
+
+            seq
+          end
+
+          def normalize_key(raw)
+            return KEY_MAP[raw] if KEY_MAP.key?(raw)
+
+            # Single printable character
+            return raw if raw.length == 1 && raw.ord >= 32
+
+            # Multi-char paste (not an escape sequence)
+            return raw if raw.length > 1 && !raw.start_with?("\e")
+
+            # Unknown escape sequence — ignore
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/cli/chat/tui/app.rb
+++ b/lib/legion/cli/chat/tui/app.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'io/console'
 require 'io/wait'
 require_relative 'screen'
 require_relative 'output_pane'
@@ -10,49 +11,44 @@ module Legion
   module CLI
     class Chat
       module TUI
-        # The main TUI application. Replaces the old Reline-based repl_loop with a
-        # raw-mode event loop driving three non-overlapping screen regions.
-        #
-        # Usage:
-        #   app = TUI::App.new(session:, slash_handler:, completions:)
-        #   app.run
         class App
-          # Key mapping: raw escape sequences → symbolic key names
+          attr_reader :output
+
           KEY_MAP = {
-            "\r"      => :enter,
-            "\n"      => :enter,
-            "\x7F"    => :backspace,
-            "\b"      => :backspace,
-            "\e[A"    => :up,
-            "\e[B"    => :down,
-            "\e[C"    => :right,
-            "\e[D"    => :left,
-            "\e[H"    => :home,
-            "\e[F"    => :end,
-            "\e[1~"   => :home,
-            "\e[4~"   => :end,
-            "\e[5~"   => :page_up,
-            "\e[6~"   => :page_down,
-            "\e[3~"   => :delete,
-            "\eOA"    => :up,
-            "\eOB"    => :down,
-            "\eOC"    => :right,
-            "\eOD"    => :left,
-            "\eOH"    => :home,
-            "\eOF"    => :end,
-            "\x01"    => :ctrl_a,
-            "\x02"    => :ctrl_b,
-            "\x03"    => :ctrl_c,
-            "\x04"    => :ctrl_d,
-            "\x05"    => :ctrl_e,
-            "\x0B"    => :ctrl_k,
-            "\x0C"    => :ctrl_l,
-            "\x15"    => :ctrl_u,
-            "\x17"    => :ctrl_w,
-            "\t"      => :tab
+            "\r"    => :enter,
+            "\n"    => :enter,
+            "\x7F"  => :backspace,
+            "\b"    => :backspace,
+            "\e[A"  => :up,
+            "\e[B"  => :down,
+            "\e[C"  => :right,
+            "\e[D"  => :left,
+            "\e[H"  => :home,
+            "\e[F"  => :end,
+            "\e[1~" => :home,
+            "\e[4~" => :end,
+            "\e[5~" => :page_up,
+            "\e[6~" => :page_down,
+            "\e[3~" => :delete,
+            "\eOA"  => :up,
+            "\eOB"  => :down,
+            "\eOC"  => :right,
+            "\eOD"  => :left,
+            "\eOH"  => :home,
+            "\eOF"  => :end,
+            "\x01"  => :ctrl_a,
+            "\x02"  => :ctrl_b,
+            "\x03"  => :ctrl_c,
+            "\x04"  => :ctrl_d,
+            "\x05"  => :ctrl_e,
+            "\x0B"  => :ctrl_k,
+            "\x0C"  => :ctrl_l,
+            "\x15"  => :ctrl_u,
+            "\x17"  => :ctrl_w,
+            "\t"    => :tab
           }.freeze
 
-          def initialize(session:, model_id: 'unknown', permissions_mode: 'interactive',
+          def initialize(session:, model_id: 'unknown', permissions_mode: 'interactive', # rubocop:disable Metrics/ParameterLists
                          slash_handler: nil, completions: [], banner: nil)
             @session = session
             @screen = Screen.new
@@ -62,50 +58,80 @@ module Legion
             @slash_handler = slash_handler
             @running = false
             @streaming = false
-            @render_mutex = Mutex.new
+            @dirty = true
+            @llm_thread = nil
+
+            # Self-pipe: write end wakes the select() in the main loop
+            @wake_r, @wake_w = IO.pipe
 
             @status.update(model: model_id, permissions_mode: permissions_mode)
-
-            # Wire up session events
             setup_session_events
 
-            # Show banner if provided
-            if banner
-              banner.to_s.lines.each { |l| @output.add_info(l.chomp) }
-              @output.add_info('')
-            end
+            return unless banner
+
+            banner.to_s.lines.each { |l| @output.add_info(l.chomp) }
+            @output.add_info('')
           end
 
-          def run
+          def run # rubocop:disable Metrics/CyclomaticComplexity
             @running = true
             @screen.clear
             @screen.hide_cursor
+
+            prev_winch = Signal.trap('WINCH') do
+              @screen.refresh_size
+              wake!
+            end
 
             $stdin.raw do |raw_in|
               render_frame
               @screen.show_cursor
 
               while @running
-                render_frame
+                render_frame if @dirty
 
-                # 50ms timeout during streaming for animation, blocking otherwise
-                timeout = @streaming ? 0.05 : 0.1
-                raw_key = read_raw_key(raw_in, timeout: timeout)
+                # IO.select: wait for stdin data OR wake-pipe signal
+                # Short timeout during streaming (spinner), long when idle
+                timeout = @streaming ? 0.08 : 5.0
+                ready = IO.select([raw_in, @wake_r], nil, nil, timeout)
 
+                # Drain the wake pipe if it fired
+                @wake_r.read_nonblock(1024, exception: false) if ready && ready[0].include?(@wake_r)
+
+                # Tick spinner during streaming regardless of input
                 if @streaming
                   @status.tick
-                  next unless raw_key
+                  @dirty = true
                 end
 
+                # Read key if stdin is ready
+                next unless ready && ready[0].include?(raw_in)
+
+                raw_key = read_raw_key(raw_in)
                 next unless raw_key
 
                 key = normalize_key(raw_key)
-                dispatch_key(key)
+                if key
+                  @dirty = true
+                  dispatch_key(key)
+                end
               end
             end
           rescue Interrupt
             # Ctrl+C during raw mode
           ensure
+            Signal.trap('WINCH', prev_winch || 'DEFAULT')
+            @llm_thread&.join(2)
+            begin
+              @wake_r.close
+            rescue StandardError
+              nil
+            end
+            begin
+              @wake_w.close
+            rescue StandardError
+              nil
+            end
             @screen.show_cursor
             $stdout.print "\e[0m"
             $stdout.print TTY::Cursor.move_to(0, @screen.height - 1)
@@ -119,56 +145,62 @@ module Legion
 
           private
 
+          # Wake the main event loop from a background thread.
+          def wake!
+            @wake_w.write_nonblock('.', exception: false)
+          end
+
           def setup_session_events
             @session.on(:llm_start) do |_payload|
               @streaming = true
               @status.update(thinking: true)
+              wake!
             end
 
             @session.on(:llm_first_token) do |_payload|
               @status.update(thinking: false)
+              wake!
             end
 
             @session.on(:llm_complete) do |_payload|
               @streaming = false
               @status.update(thinking: false, tool_name: nil)
+              wake!
             end
 
             @session.on(:tool_start) do |payload|
               @status.update(
-                tool_name: payload[:name],
+                tool_name:  payload[:name],
                 tool_index: payload[:index] || 0,
                 tool_total: payload[:total] || 0
               )
+              wake!
             end
 
             @session.on(:tool_complete) do |_payload|
               @status.update(tool_name: nil)
+              wake!
             end
           end
 
           def render_frame
-            @render_mutex.synchronize do
-              @screen.detect_size
-              input_lines = @input.render(@screen.width)
-              inp_h = [input_lines.length, Screen::INPUT_MIN_HEIGHT].max
-              out_h = @screen.output_height(inp_h)
-              output_lines = @output.render(@screen.width, out_h)
-              status_line = @status.render(@screen.width)
+            input_lines = @input.render(@screen.width)
+            inp_h = [input_lines.length, Screen::INPUT_MIN_HEIGHT].max
+            out_h = @screen.output_height(inp_h)
+            output_lines = @output.render(@screen.width, out_h)
+            status_line = @status.render(@screen.width)
 
-              @screen.render(output_lines, status_line, input_lines)
+            @screen.render(output_lines, status_line, input_lines)
 
-              # Position cursor in the input region
-              input_row = @screen.input_start_row(inp_h)
-              @screen.position_cursor(@input.cursor_col, input_row)
-            end
+            input_row = @screen.input_start_row(inp_h)
+            @screen.position_cursor(@input.cursor_col, input_row)
+            @dirty = false
           end
 
           def dispatch_key(key)
             case key
             when :ctrl_c
               if @streaming
-                # TODO: cancel current LLM request
                 @streaming = false
                 @status.update(thinking: false, tool_name: nil)
                 @output.add_info('(interrupted)')
@@ -176,19 +208,14 @@ module Legion
                 @input.handle_key(:ctrl_c)
               end
             when :ctrl_d
-              if @input.empty?
-                @running = false
-                return
-              end
+              @running = false if @input.empty?
             when :ctrl_l
               @screen.clear
-              return
+              @dirty = true
             when :page_up
               @output.scroll_up(5)
-              return
             when :page_down
               @output.scroll_down(5)
-              return
             else
               result = @input.handle_key(key)
               case result
@@ -211,12 +238,10 @@ module Legion
           end
 
           def handle_submit(text)
-            # Show the user's message in the output pane
             @output.add_message(:user, text)
 
-            # Check for slash commands
             if text.start_with?('/')
-              if text.strip == '/quit' || text.strip == '/exit'
+              if ['/quit', '/exit'].include?(text.strip)
                 @running = false
                 return
               end
@@ -227,59 +252,63 @@ module Legion
               end
             end
 
-            # Check for bang commands
             if text.start_with?('!')
               handle_bang_command(text[1..])
               return
             end
 
-            # Send to LLM
-            send_to_llm(text)
+            # LLM call runs in background thread so event loop stays alive
+            send_to_llm_async(text)
           end
 
-          def send_to_llm(message)
+          def send_to_llm_async(message)
             @output.begin_response
-            buffer = String.new
-            tool_index = 0
+            @llm_thread = Thread.new do
+              buffer = String.new
+              tool_index = 0
 
-            @session.send_message(
-              message,
-              on_tool_call: lambda { |tc|
-                tool_index += 1
-                @output.add_tool_call(tc.name, tc.arguments.keys.join(', '))
-                @session.emit(:tool_start, {
-                  name: tc.name, args: tc.arguments,
-                  index: tool_index, total: 0
-                })
-              },
-              on_tool_result: lambda { |tr|
-                result_preview = tr.to_s.lines.first(3).join.rstrip
-                @output.add_tool_result(result_preview)
-                @session.emit(:tool_complete, {
-                  name: 'tool', result_preview: result_preview,
-                  index: tool_index, total: 0
-                })
-              }
-            ) do |chunk|
-              if chunk.content
-                buffer << chunk.content
-                @output.append_chunk(buffer)
+              @session.send_message(
+                message,
+                on_tool_call:   lambda { |tc|
+                  tool_index += 1
+                  @output.add_tool_call(tc.name, tc.arguments.keys.join(', '))
+                  @session.emit(:tool_start, {
+                                  name: tc.name, args: tc.arguments,
+                    index: tool_index, total: 0
+                                })
+                  wake!
+                },
+                on_tool_result: lambda { |tr|
+                  result_preview = tr.to_s.lines.first(3).join.rstrip
+                  @output.add_tool_result(result_preview)
+                  @session.emit(:tool_complete, {
+                                  name: 'tool', result_preview: result_preview,
+                    index: tool_index, total: 0
+                                })
+                  wake!
+                }
+              ) do |chunk|
+                if chunk.content
+                  buffer << chunk.content
+                  @output.append_chunk(chunk.content)
+                  @dirty = true
+                  wake!
+                end
               end
+
+              rendered = render_markdown(buffer)
+              @output.end_response(rendered)
+              update_stats
+              @dirty = true
+              wake!
+            rescue Chat::Session::BudgetExceeded => e
+              @output.add_error("Budget exceeded: #{e.message}")
+              wake!
+            rescue StandardError => e
+              @output.add_error("LLM error: #{e.message}")
+              @streaming = false
+              wake!
             end
-
-            # Finalize with rendered response
-            rendered = render_markdown(buffer)
-            @output.end_response(rendered)
-
-            # Update stats
-            update_stats
-          rescue Chat::Session::BudgetExceeded => e
-            @output.add_error("Budget exceeded: #{e.message}")
-          rescue Interrupt
-            @output.add_info('(interrupted)')
-            @streaming = false
-          rescue StandardError => e
-            @output.add_error("LLM error: #{e.message}")
           end
 
           def handle_bang_command(cmd)
@@ -299,28 +328,25 @@ module Legion
           def update_stats
             stats = @session.stats
             @status.update(
-              tokens_in: stats[:input_tokens] || 0,
+              tokens_in:  stats[:input_tokens] || 0,
               tokens_out: stats[:output_tokens] || 0,
-              cost: @session.estimated_cost,
-              messages: stats[:messages_sent] || 0
+              cost:       @session.estimated_cost,
+              messages:   stats[:messages_sent] || 0
             )
           end
 
-          # --- Raw key reading (cannibalized from legion-tty App) ---
+          # --- Raw key reading ---
 
-          def read_raw_key(io, timeout: nil)
-            return nil unless io.wait_readable(timeout)
-
-            ch = io.getc
-            return nil unless ch
+          def read_raw_key(io)
+            ch = io.read_nonblock(1, exception: false)
+            return nil if ch == :wait_readable || ch.nil?
 
             if ch == "\e"
               read_escape_sequence(io, ch)
             else
-              # Check for pasted text (multiple chars available immediately)
               buf = ch
-              while io.ready?
-                buf << io.getc
+              while (c = io.read_nonblock(1, exception: false)) && c != :wait_readable && c
+                buf << c
               end
               buf
             end
@@ -328,23 +354,32 @@ module Legion
             nil
           end
 
-          def read_escape_sequence(io, ch)
-            return ch unless io.wait_readable(0.05) # 50ms to disambiguate bare Escape
+          def read_escape_sequence(io, char)
+            # Brief wait for rest of escape sequence
+            return char unless io.wait_readable(0.05)
 
-            seq = ch + io.getc.to_s
+            c2 = io.read_nonblock(1, exception: false)
+            return char if c2 == :wait_readable || c2.nil?
 
-            case seq[-1]
+            seq = char + c2
+
+            case c2
             when '['
-              # CSI sequence
-              while io.wait_readable(0.05)
-                c = io.getc
-                seq << c.to_s
-                break if c && c.ord >= 0x40 && c.ord <= 0x7E
+              # CSI: read until final byte (0x40-0x7E)
+              loop do
+                break unless io.wait_readable(0.05)
+
+                c = io.read_nonblock(1, exception: false)
+                break if c == :wait_readable || c.nil?
+
+                seq << c
+                break if c.ord.between?(0x40, 0x7E)
               end
             when 'O'
-              # SS3 sequence
+              # SS3: one more byte
               if io.wait_readable(0.05)
-                seq << io.getc.to_s
+                c = io.read_nonblock(1, exception: false)
+                seq << c if c && c != :wait_readable
               end
             end
 
@@ -353,14 +388,9 @@ module Legion
 
           def normalize_key(raw)
             return KEY_MAP[raw] if KEY_MAP.key?(raw)
-
-            # Single printable character
             return raw if raw.length == 1 && raw.ord >= 32
-
-            # Multi-char paste (not an escape sequence)
             return raw if raw.length > 1 && !raw.start_with?("\e")
 
-            # Unknown escape sequence — ignore
             nil
           end
         end

--- a/lib/legion/cli/chat/tui/formatter.rb
+++ b/lib/legion/cli/chat/tui/formatter.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'legion/cli/output'
+
+module Legion
+  module CLI
+    class Chat
+      module TUI
+        # Output formatter that routes all output to the TUI OutputPane
+        # instead of $stdout. Implements the same interface as Output::Formatter
+        # so existing slash command handlers work unchanged.
+        class Formatter
+          attr_reader :json_mode, :color_enabled
+
+          def initialize(output_pane)
+            @pane = output_pane
+            @json_mode = false
+            @color_enabled = true
+          end
+
+          def colorize(text, color)
+            "#{Output::COLORS[color]}#{text}#{Output::COLORS[:reset]}"
+          end
+
+          def bold(text)
+            "#{Output::COLORS[:bold]}#{Output::COLORS[:heading]}#{text}#{Output::COLORS[:reset]}"
+          end
+
+          def dim(text)
+            "#{Output::COLORS[:gray]}#{text}#{Output::COLORS[:reset]}"
+          end
+
+          def status_color(status)
+            key = status.to_s.downcase.tr('.', '_').to_sym
+            color_name = Output::STATUS_ICONS[key] || 'disabled'
+            color_name.to_sym
+          end
+
+          def status(text)
+            colorize(text, status_color(text))
+          end
+
+          def banner(version: nil)
+            # TUI shows version info in the status bar — skip the ASCII banner
+          end
+
+          def header(text)
+            @pane.add_raw("#{Output::COLORS[:bold]}#{Output::COLORS[:heading]}#{text}#{Output::COLORS[:reset]}")
+          end
+
+          def detail(hash, indent: 0)
+            pad = ' ' * indent
+            max_key = hash.keys.map { |k| k.to_s.length }.max || 0
+
+            hash.each do |key, value|
+              label = colorize("#{key.to_s.ljust(max_key)}:", :label)
+              val = case value
+                    when true  then colorize('yes', :accent)
+                    when false then colorize('no', :muted)
+                    when nil   then colorize('(none)', :disabled)
+                    else value.to_s
+                    end
+              @pane.add_raw("#{pad}  #{label} #{val}")
+            end
+          end
+
+          def table(headers, rows, title: nil) # rubocop:disable Lint/UnusedMethodArgument
+            if rows.empty?
+              @pane.add_raw(dim('  (no results)'))
+              return
+            end
+
+            all_rows = [headers] + rows
+            widths = headers.each_index.map do |i|
+              all_rows.map { |r| strip_ansi(r[i].to_s).length }.max
+            end
+
+            header_line = headers.each_with_index.map { |h, i| colorize(h.to_s.upcase.ljust(widths[i]), :heading) }.join('  ')
+            @pane.add_raw("  #{header_line}")
+            @pane.add_raw("  #{widths.map { |w| colorize("\u2500" * w, :border) }.join('  ')}")
+
+            rows.each do |row|
+              line = row.each_with_index.map { |cell, i| cell.to_s.ljust(widths[i]) }.join('  ')
+              @pane.add_raw("  #{line}")
+            end
+          end
+
+          def success(message)
+            @pane.add_raw("  #{colorize("\u00BB", :accent)} #{message}")
+          end
+
+          def warn(message)
+            @pane.add_raw("  #{colorize("\u00BB", :caution)} #{message}")
+          end
+
+          def error(message)
+            @pane.add_raw("  #{colorize("\u00BB", :critical)} #{colorize(message, :critical)}")
+          end
+
+          def info(message)
+            @pane.add_raw(dim("  #{message}"))
+          end
+
+          def spacer
+            @pane.add_raw('')
+          end
+
+          def json(data)
+            @pane.add_raw(Output.encode_json(data))
+          end
+
+          private
+
+          def strip_ansi(str)
+            str.to_s.gsub(/\e\[[0-9;]*[A-Za-z]/, '')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/cli/chat/tui/input_bar.rb
+++ b/lib/legion/cli/chat/tui/input_bar.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+module Legion
+  module CLI
+    class Chat
+      module TUI
+        # Character-by-character input handling with history, paste support,
+        # and multi-line editing. Renders into a fixed screen region.
+        #
+        # Handles raw key events — does NOT use Reline or TTY::Reader's read_line.
+        class InputBar
+          PURPLE = "\e[38;2;127;119;221m"
+          DIM = "\e[2m"
+          RESET = "\e[0m"
+
+          attr_reader :cursor_col
+
+          def initialize(prompt_label: 'you', completions: [])
+            @prompt_label = prompt_label
+            @buffer = String.new
+            @cursor_pos = 0          # position within @buffer
+            @history = []
+            @history_index = nil
+            @history_stash = nil     # saves current buffer when browsing history
+            @completions = completions
+            @continuation = false    # true when in multi-line (backslash) mode
+            @lines = ['']            # multi-line buffer (for paste support)
+            @current_line = 0
+          end
+
+          # Process a single key event. Returns:
+          #   [:submit, text]  — user pressed Enter with complete input
+          #   :handled         — key was consumed, re-render needed
+          #   :pass            — key should be handled by the outer app (e.g., page up/down)
+          def handle_key(key)
+            case key
+            when :enter, :return
+              return handle_enter
+            when :backspace, :delete_back
+              return handle_backspace
+            when :delete
+              return handle_delete
+            when :left, :arrow_left
+              @cursor_pos = [@cursor_pos - 1, 0].max
+              return :handled
+            when :right, :arrow_right
+              @cursor_pos = [@cursor_pos + 1, @buffer.length].min
+              return :handled
+            when :up, :arrow_up
+              return handle_history_prev
+            when :down, :arrow_down
+              return handle_history_next
+            when :home, :ctrl_a
+              @cursor_pos = 0
+              return :handled
+            when :end, :ctrl_e
+              @cursor_pos = @buffer.length
+              return :handled
+            when :ctrl_u
+              @buffer = @buffer[@cursor_pos..] || ''
+              @cursor_pos = 0
+              return :handled
+            when :ctrl_k
+              @buffer = @buffer[0...@cursor_pos] || ''
+              return :handled
+            when :ctrl_w
+              return handle_delete_word
+            when :ctrl_c
+              @buffer = String.new
+              @cursor_pos = 0
+              @continuation = false
+              return :handled
+            when :tab
+              return handle_tab
+            when :page_up, :page_down, :ctrl_d
+              return :pass
+            else
+              # Printable character or paste
+              if key.is_a?(String)
+                return handle_paste(key) if key.length > 1
+                return handle_char(key)
+              end
+              :handled
+            end
+          end
+
+          def render(width, prompt_width: nil)
+            prompt = build_prompt
+            pw = prompt_width || strip_ansi(prompt).length
+            available = width - pw
+
+            # For now, single-line display with horizontal scroll
+            visible_start = if @cursor_pos >= available
+                              @cursor_pos - available + 1
+                            else
+                              0
+                            end
+            visible_text = @buffer[visible_start, available] || ''
+
+            # Build the display lines
+            lines = []
+            lines << "#{prompt}#{visible_text}"
+
+            # Continuation indicator if in multi-line mode
+            if @continuation
+              lines << "#{DIM} ...#{RESET} "
+            end
+
+            # Pad to minimum height
+            while lines.length < 3
+              lines << ''
+            end
+
+            @cursor_col = pw + (@cursor_pos - visible_start)
+            lines
+          end
+
+          def clear
+            @buffer = String.new
+            @cursor_pos = 0
+            @continuation = false
+          end
+
+          def set_prompt_label(label)
+            @prompt_label = label
+          end
+
+          def buffer_content
+            @buffer.dup
+          end
+
+          def empty?
+            @buffer.strip.empty?
+          end
+
+          private
+
+          def build_prompt
+            "#{PURPLE}#{@prompt_label}#{RESET} #{DIM}>#{RESET} "
+          end
+
+          def handle_enter
+            text = @buffer.strip
+
+            # Multi-line continuation with trailing backslash
+            if text.end_with?('\\')
+              @buffer << "\n"
+              @cursor_pos = @buffer.length
+              @continuation = true
+              return :handled
+            end
+
+            return :handled if text.empty?
+
+            # Finalize
+            result = text.gsub(/\\\n/, "\n")
+            @history << result unless result.empty? || @history.last == result
+            @history_index = nil
+            @history_stash = nil
+            @buffer = String.new
+            @cursor_pos = 0
+            @continuation = false
+            [:submit, result]
+          end
+
+          def handle_backspace
+            return :handled if @cursor_pos.zero?
+
+            @buffer = @buffer[0...(@cursor_pos - 1)] + (@buffer[@cursor_pos..] || '')
+            @cursor_pos -= 1
+            :handled
+          end
+
+          def handle_delete
+            return :handled if @cursor_pos >= @buffer.length
+
+            @buffer = @buffer[0...@cursor_pos] + (@buffer[(@cursor_pos + 1)..] || '')
+            :handled
+          end
+
+          def handle_delete_word
+            return :handled if @cursor_pos.zero?
+
+            # Delete backward to previous word boundary
+            pos = @cursor_pos - 1
+            pos -= 1 while pos.positive? && @buffer[pos] == ' '
+            pos -= 1 while pos.positive? && @buffer[pos] != ' '
+            pos += 1 if @buffer[pos] == ' '
+            @buffer = (@buffer[0...pos] || '') + (@buffer[@cursor_pos..] || '')
+            @cursor_pos = pos
+            :handled
+          end
+
+          def handle_char(ch)
+            @buffer = @buffer[0...@cursor_pos] + ch + (@buffer[@cursor_pos..] || '')
+            @cursor_pos += 1
+            :handled
+          end
+
+          def handle_paste(text)
+            # Treat pasted text as a single input block (fixes the multi-line paste bug)
+            # Replace newlines with literal newlines in buffer
+            @buffer = @buffer[0...@cursor_pos] + text + (@buffer[@cursor_pos..] || '')
+            @cursor_pos += text.length
+            :handled
+          end
+
+          def handle_history_prev
+            return :handled if @history.empty?
+
+            if @history_index.nil?
+              @history_stash = @buffer.dup
+              @history_index = @history.length - 1
+            elsif @history_index.positive?
+              @history_index -= 1
+            else
+              return :handled
+            end
+
+            @buffer = @history[@history_index].dup
+            @cursor_pos = @buffer.length
+            :handled
+          end
+
+          def handle_history_next
+            return :handled if @history_index.nil?
+
+            if @history_index < @history.length - 1
+              @history_index += 1
+              @buffer = @history[@history_index].dup
+            else
+              @buffer = @history_stash || ''
+              @history_index = nil
+              @history_stash = nil
+            end
+
+            @cursor_pos = @buffer.length
+            :handled
+          end
+
+          def handle_tab
+            return :handled if @completions.empty?
+
+            # Simple prefix completion
+            prefix = @buffer[0...@cursor_pos]
+            matches = @completions.select { |c| c.start_with?(prefix) }
+
+            if matches.length == 1
+              @buffer = matches.first + ' '
+              @cursor_pos = @buffer.length
+            end
+
+            :handled
+          end
+
+          def strip_ansi(str)
+            str.to_s.gsub(/\e\[[0-9;]*[A-Za-z]/, '').gsub(/\e\].*?\e\\/, '')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/cli/chat/tui/output_pane.rb
+++ b/lib/legion/cli/chat/tui/output_pane.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+module Legion
+  module CLI
+    class Chat
+      module TUI
+        # Scrollable output pane that accumulates messages and tool results.
+        # Renders a window of visible lines based on scroll offset and pane height.
+        class OutputPane
+          PURPLE = "\e[38;2;127;119;221m"
+          DIM = "\e[2m"
+          BOLD = "\e[1m"
+          YELLOW = "\e[33m"
+          GREEN = "\e[32m"
+          RED = "\e[31m"
+          RESET = "\e[0m"
+
+          def initialize
+            @lines = []           # All accumulated output lines (raw strings with ANSI)
+            @scroll_offset = 0    # 0 = pinned to bottom (auto-scroll), >0 = scrolled up
+            @streaming_buffer = String.new
+            @auto_scroll = true
+          end
+
+          # Add a complete message block (user or assistant)
+          def add_message(role, text)
+            case role
+            when :user
+              @lines << "#{PURPLE}#{BOLD}you#{RESET} #{DIM}>#{RESET} #{text}"
+            when :assistant
+              # Assistant messages may be multi-line; wrap each line
+              text.to_s.lines.each { |line| @lines << line.chomp }
+            when :system
+              @lines << "#{DIM}#{text}#{RESET}"
+            end
+            @lines << '' # blank line spacer
+            pin_to_bottom if @auto_scroll
+          end
+
+          # Start streaming a response — show the header
+          def begin_response
+            @lines << "#{PURPLE}#{BOLD}legion#{RESET} #{DIM}>#{RESET} "
+            @streaming_buffer = String.new
+            pin_to_bottom if @auto_scroll
+          end
+
+          # Append a streaming chunk to the current response
+          def append_chunk(text)
+            return if text.nil? || text.empty?
+
+            @streaming_buffer << text
+
+            # Replace the last line(s) of the response with the full rendered buffer
+            # Remove previous streaming lines (everything after the last "legion >" header)
+            # Find the response header
+            header_idx = @lines.rindex { |l| l.include?("legion#{RESET} #{DIM}>") }
+            if header_idx
+              @lines.slice!(header_idx + 1..)
+              # Re-add all lines from the streaming buffer
+              @streaming_buffer.lines.each { |line| @lines << line.chomp }
+            end
+
+            pin_to_bottom if @auto_scroll
+          end
+
+          # Finalize the current streaming response with the full rendered text
+          def end_response(rendered_text)
+            header_idx = @lines.rindex { |l| l.include?("legion#{RESET} #{DIM}>") }
+            if header_idx
+              @lines.slice!(header_idx + 1..)
+              rendered_text.to_s.lines.each { |line| @lines << line.chomp }
+            end
+            @lines << '' # spacer
+            @streaming_buffer = String.new
+            pin_to_bottom if @auto_scroll
+          end
+
+          # Add a tool call notification
+          def add_tool_call(name, args_summary)
+            @lines << "  #{DIM}[tool] #{name}(#{args_summary})#{RESET}"
+            pin_to_bottom if @auto_scroll
+          end
+
+          # Add a tool result
+          def add_tool_result(preview)
+            @lines << "  #{DIM}[result] #{preview}#{RESET}"
+            pin_to_bottom if @auto_scroll
+          end
+
+          # Add an error message
+          def add_error(message)
+            @lines << "#{RED}Error: #{message}#{RESET}"
+            @lines << ''
+            pin_to_bottom if @auto_scroll
+          end
+
+          # Add an info/banner line
+          def add_info(text)
+            @lines << "#{DIM}#{text}#{RESET}"
+            pin_to_bottom if @auto_scroll
+          end
+
+          def scroll_up(n = 3)
+            @auto_scroll = false
+            @scroll_offset = [@scroll_offset + n, [@lines.length - 1, 0].max].min
+          end
+
+          def scroll_down(n = 3)
+            @scroll_offset = [@scroll_offset - n, 0].max
+            @auto_scroll = true if @scroll_offset.zero?
+          end
+
+          def scroll_to_bottom
+            @scroll_offset = 0
+            @auto_scroll = true
+          end
+
+          # Render visible lines for the given pane height, truncating each to width.
+          def render(width, height)
+            return Array.new(height, '') if @lines.empty?
+
+            # Calculate the visible window
+            total = @lines.length
+            if @auto_scroll || @scroll_offset.zero?
+              # Show the last `height` lines
+              start_idx = [total - height, 0].max
+            else
+              start_idx = [total - height - @scroll_offset, 0].max
+            end
+
+            visible = @lines[start_idx, height] || []
+
+            # Pad to fill the pane and truncate long lines
+            height.times.map do |i|
+              line = visible[i] || ''
+              truncate_to_width(line, width)
+            end
+          end
+
+          def line_count
+            @lines.length
+          end
+
+          private
+
+          def pin_to_bottom
+            @scroll_offset = 0
+          end
+
+          def truncate_to_width(line, width)
+            # We need to count visible characters (excluding ANSI escapes)
+            visible_len = strip_ansi(line).length
+            return line if visible_len <= width
+
+            # Truncate by visible characters — this is approximate for ANSI strings
+            # A proper implementation would walk char-by-char tracking ANSI state
+            line[0, width + (line.length - visible_len)]
+          end
+
+          def strip_ansi(str)
+            str.to_s.gsub(/\e\[[0-9;]*[A-Za-z]/, '').gsub(/\e\].*?\e\\/, '')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/cli/chat/tui/output_pane.rb
+++ b/lib/legion/cli/chat/tui/output_pane.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
+require 'monitor'
+
 module Legion
   module CLI
     class Chat
       module TUI
         # Scrollable output pane that accumulates messages and tool results.
         # Renders a window of visible lines based on scroll offset and pane height.
+        # Thread-safe: LLM streaming thread writes, main thread reads for rendering.
         class OutputPane
+          include MonitorMixin
+
           PURPLE = "\e[38;2;127;119;221m"
           DIM = "\e[2m"
           BOLD = "\e[1m"
@@ -16,129 +21,155 @@ module Legion
           RESET = "\e[0m"
 
           def initialize
-            @lines = []           # All accumulated output lines (raw strings with ANSI)
-            @scroll_offset = 0    # 0 = pinned to bottom (auto-scroll), >0 = scrolled up
+            super # MonitorMixin
+            @lines = []
+            @scroll_offset = 0
             @streaming_buffer = String.new
             @auto_scroll = true
           end
 
-          # Add a complete message block (user or assistant)
           def add_message(role, text)
-            case role
-            when :user
-              @lines << "#{PURPLE}#{BOLD}you#{RESET} #{DIM}>#{RESET} #{text}"
-            when :assistant
-              # Assistant messages may be multi-line; wrap each line
-              text.to_s.lines.each { |line| @lines << line.chomp }
-            when :system
-              @lines << "#{DIM}#{text}#{RESET}"
+            synchronize do
+              case role
+              when :user
+                @lines << "#{PURPLE}#{BOLD}you#{RESET} #{DIM}>#{RESET} #{text}"
+              when :assistant
+                text.to_s.lines.each { |line| @lines << line.chomp }
+              when :system
+                @lines << "#{DIM}#{text}#{RESET}"
+              end
+              @lines << ''
+              pin_to_bottom if @auto_scroll
             end
-            @lines << '' # blank line spacer
-            pin_to_bottom if @auto_scroll
           end
 
-          # Start streaming a response — show the header
           def begin_response
-            @lines << "#{PURPLE}#{BOLD}legion#{RESET} #{DIM}>#{RESET} "
-            @streaming_buffer = String.new
-            pin_to_bottom if @auto_scroll
+            synchronize do
+              @lines << "#{PURPLE}#{BOLD}legion#{RESET} #{DIM}>#{RESET} "
+              @streaming_buffer = String.new
+              pin_to_bottom if @auto_scroll
+            end
           end
 
-          # Append a streaming chunk to the current response
+          # Append a streaming chunk (delta only, not cumulative)
           def append_chunk(text)
             return if text.nil? || text.empty?
 
-            @streaming_buffer << text
+            synchronize do
+              @streaming_buffer << text
 
-            # Replace the last line(s) of the response with the full rendered buffer
-            # Remove previous streaming lines (everything after the last "legion >" header)
-            # Find the response header
-            header_idx = @lines.rindex { |l| l.include?("legion#{RESET} #{DIM}>") }
-            if header_idx
-              @lines.slice!(header_idx + 1..)
-              # Re-add all lines from the streaming buffer
-              @streaming_buffer.lines.each { |line| @lines << line.chomp }
+              header_idx = @lines.rindex { |l| l.include?("legion#{RESET} #{DIM}>") }
+              if header_idx
+                @lines.slice!((header_idx + 1)..)
+                @streaming_buffer.lines.each { |line| @lines << line.chomp }
+              end
+
+              pin_to_bottom if @auto_scroll
             end
-
-            pin_to_bottom if @auto_scroll
           end
 
-          # Finalize the current streaming response with the full rendered text
           def end_response(rendered_text)
-            header_idx = @lines.rindex { |l| l.include?("legion#{RESET} #{DIM}>") }
-            if header_idx
-              @lines.slice!(header_idx + 1..)
-              rendered_text.to_s.lines.each { |line| @lines << line.chomp }
+            synchronize do
+              header_idx = @lines.rindex { |l| l.include?("legion#{RESET} #{DIM}>") }
+              if header_idx
+                @lines.slice!((header_idx + 1)..)
+                rendered_text.to_s.lines.each { |line| @lines << line.chomp }
+              end
+              @lines << ''
+              @streaming_buffer = String.new
+              pin_to_bottom if @auto_scroll
             end
-            @lines << '' # spacer
-            @streaming_buffer = String.new
-            pin_to_bottom if @auto_scroll
           end
 
-          # Add a tool call notification
           def add_tool_call(name, args_summary)
-            @lines << "  #{DIM}[tool] #{name}(#{args_summary})#{RESET}"
-            pin_to_bottom if @auto_scroll
+            synchronize do
+              @lines << "  #{DIM}[tool] #{name}(#{args_summary})#{RESET}"
+              pin_to_bottom if @auto_scroll
+            end
           end
 
-          # Add a tool result
           def add_tool_result(preview)
-            @lines << "  #{DIM}[result] #{preview}#{RESET}"
-            pin_to_bottom if @auto_scroll
+            synchronize do
+              @lines << "  #{DIM}[result] #{preview}#{RESET}"
+              pin_to_bottom if @auto_scroll
+            end
           end
 
-          # Add an error message
           def add_error(message)
-            @lines << "#{RED}Error: #{message}#{RESET}"
-            @lines << ''
-            pin_to_bottom if @auto_scroll
+            synchronize do
+              @lines << "#{RED}Error: #{message}#{RESET}"
+              @lines << ''
+              pin_to_bottom if @auto_scroll
+            end
           end
 
-          # Add an info/banner line
           def add_info(text)
-            @lines << "#{DIM}#{text}#{RESET}"
-            pin_to_bottom if @auto_scroll
+            synchronize do
+              @lines << "#{DIM}#{text}#{RESET}"
+              pin_to_bottom if @auto_scroll
+            end
           end
 
-          def scroll_up(n = 3)
-            @auto_scroll = false
-            @scroll_offset = [@scroll_offset + n, [@lines.length - 1, 0].max].min
+          # Add a pre-formatted line (no extra styling)
+          def add_raw(text)
+            synchronize do
+              @lines << text.to_s
+              pin_to_bottom if @auto_scroll
+            end
           end
 
-          def scroll_down(n = 3)
-            @scroll_offset = [@scroll_offset - n, 0].max
-            @auto_scroll = true if @scroll_offset.zero?
+          def clear
+            synchronize do
+              @lines.clear
+              @scroll_offset = 0
+              @auto_scroll = true
+              @streaming_buffer = String.new
+            end
+          end
+
+          def scroll_up(lines = 3)
+            synchronize do
+              @auto_scroll = false
+              @scroll_offset = (@scroll_offset + lines).clamp(0, [@lines.length - 1, 0].max)
+            end
+          end
+
+          def scroll_down(lines = 3)
+            synchronize do
+              @scroll_offset = (@scroll_offset - lines).clamp(0, @scroll_offset)
+              @auto_scroll = true if @scroll_offset.zero?
+            end
           end
 
           def scroll_to_bottom
-            @scroll_offset = 0
-            @auto_scroll = true
+            synchronize do
+              @scroll_offset = 0
+              @auto_scroll = true
+            end
           end
 
-          # Render visible lines for the given pane height, truncating each to width.
           def render(width, height)
-            return Array.new(height, '') if @lines.empty?
+            synchronize do
+              return Array.new(height, '') if @lines.empty?
 
-            # Calculate the visible window
-            total = @lines.length
-            if @auto_scroll || @scroll_offset.zero?
-              # Show the last `height` lines
-              start_idx = [total - height, 0].max
-            else
-              start_idx = [total - height - @scroll_offset, 0].max
-            end
+              total = @lines.length
+              start_idx = if @auto_scroll || @scroll_offset.zero?
+                            [total - height, 0].max
+                          else
+                            [total - height - @scroll_offset, 0].max
+                          end
 
-            visible = @lines[start_idx, height] || []
+              visible = @lines[start_idx, height] || []
 
-            # Pad to fill the pane and truncate long lines
-            height.times.map do |i|
-              line = visible[i] || ''
-              truncate_to_width(line, width)
+              height.times.map do |i|
+                line = visible[i] || ''
+                truncate_to_width(line, width)
+              end
             end
           end
 
           def line_count
-            @lines.length
+            synchronize { @lines.length }
           end
 
           private
@@ -147,14 +178,42 @@ module Legion
             @scroll_offset = 0
           end
 
-          def truncate_to_width(line, width)
-            # We need to count visible characters (excluding ANSI escapes)
-            visible_len = strip_ansi(line).length
-            return line if visible_len <= width
+          # ANSI-aware truncation: walks the string tracking visible character
+          # count vs. escape sequences so we never split an escape mid-sequence.
+          def truncate_to_width(line, width) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+            visible_count = 0
+            i = 0
+            result = String.new
 
-            # Truncate by visible characters — this is approximate for ANSI strings
-            # A proper implementation would walk char-by-char tracking ANSI state
-            line[0, width + (line.length - visible_len)]
+            while i < line.length
+              if line[i] == "\e"
+                # Copy the full escape sequence without counting visible chars
+                j = i + 1
+                if j < line.length && line[j] == '['
+                  j += 1
+                  j += 1 while j < line.length && line[j].ord < 0x40 # rubocop:disable Metrics/BlockNesting
+                  j += 1 if j < line.length # final byte
+                elsif j < line.length && line[j] == ']'
+                  # OSC sequence: skip to ST (\e\\)
+                  j += 1
+                  j += 1 while j < line.length && !(line[j] == "\e" && j + 1 < line.length && line[j + 1] == '\\') # rubocop:disable Metrics/BlockNesting
+                  j += 2 if j < line.length # skip \e\\
+                end
+                result << line[i...j]
+                i = j
+              else
+                break if visible_count >= width
+
+                result << line[i]
+                visible_count += 1
+                i += 1
+              end
+            end
+
+            # Append RESET if we truncated styled text
+            result << RESET if visible_count >= width && i < line.length
+
+            result
           end
 
           def strip_ansi(str)

--- a/lib/legion/cli/chat/tui/screen.rb
+++ b/lib/legion/cli/chat/tui/screen.rb
@@ -26,12 +26,22 @@ module Legion
             @cursor = TTY::Cursor
             @prev_frame = []
             @dirty = true
-            detect_size
+            refresh_size
           end
 
-          def detect_size
+          # Refresh terminal size from the OS. Call sparingly — uses ioctl/stty.
+          def refresh_size
             @height, @width = TTY::Screen.size
             @dirty = true
+          end
+
+          # Mark the screen as needing a full redraw.
+          def mark_dirty
+            @dirty = true
+          end
+
+          def dirty?
+            @dirty
           end
 
           def output_height(input_height = INPUT_MIN_HEIGHT)
@@ -51,8 +61,6 @@ module Legion
           # status_line:  String        — the status bar content
           # input_lines:  Array[String] — visible lines for the input region
           def render(output_lines, status_line, input_lines)
-            detect_size
-
             inp_h = [input_lines.length, INPUT_MIN_HEIGHT].max
             out_h = output_height(inp_h)
             s_row = status_row(inp_h)

--- a/lib/legion/cli/chat/tui/screen.rb
+++ b/lib/legion/cli/chat/tui/screen.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'tty-cursor'
+require 'tty-screen'
+
+module Legion
+  module CLI
+    class Chat
+      module TUI
+        # Manages the three-region terminal layout with differential rendering.
+        #
+        # ┌─────────────────────────────────┐
+        # │  Output pane (scrollable)       │ rows 0..(height - status_h - input_h - 1)
+        # ├─────────────────────────────────┤
+        # │  Status bar (1 row)             │ row (height - input_h - 1)
+        # ├─────────────────────────────────┤
+        # │  Input region (variable height) │ rows (height - input_h)..(height - 1)
+        # └─────────────────────────────────┘
+        class Screen
+          INPUT_MIN_HEIGHT = 3
+          STATUS_HEIGHT = 1
+
+          attr_reader :width, :height
+
+          def initialize
+            @cursor = TTY::Cursor
+            @prev_frame = []
+            @dirty = true
+            detect_size
+          end
+
+          def detect_size
+            @height, @width = TTY::Screen.size
+            @dirty = true
+          end
+
+          def output_height(input_height = INPUT_MIN_HEIGHT)
+            @height - STATUS_HEIGHT - [input_height, INPUT_MIN_HEIGHT].max
+          end
+
+          def status_row(input_height = INPUT_MIN_HEIGHT)
+            @height - [input_height, INPUT_MIN_HEIGHT].max - STATUS_HEIGHT
+          end
+
+          def input_start_row(input_height = INPUT_MIN_HEIGHT)
+            @height - [input_height, INPUT_MIN_HEIGHT].max
+          end
+
+          # Compose a full frame from pane contents and write only changed lines.
+          # output_lines: Array[String] — visible lines for the output pane
+          # status_line:  String        — the status bar content
+          # input_lines:  Array[String] — visible lines for the input region
+          def render(output_lines, status_line, input_lines)
+            detect_size
+
+            inp_h = [input_lines.length, INPUT_MIN_HEIGHT].max
+            out_h = output_height(inp_h)
+            s_row = status_row(inp_h)
+
+            # Build the full frame as an array of strings, one per terminal row
+            frame = Array.new(@height, '')
+
+            # Output pane — pad or truncate to fill its region
+            out_h.times do |i|
+              frame[i] = (output_lines[i] || '').to_s
+            end
+
+            # Status bar
+            frame[s_row] = status_line.to_s
+
+            # Input region
+            i_start = input_start_row(inp_h)
+            inp_h.times do |i|
+              frame[i_start + i] = (input_lines[i] || '').to_s
+            end
+
+            write_differential(frame)
+            @prev_frame = frame
+          end
+
+          # Position the hardware cursor at a specific location (for input editing)
+          def position_cursor(col, row)
+            $stdout.print @cursor.move_to(col, row)
+            $stdout.flush
+          end
+
+          def clear
+            $stdout.print @cursor.clear_screen
+            $stdout.print @cursor.move_to(0, 0)
+            $stdout.flush
+            @prev_frame = []
+          end
+
+          def hide_cursor
+            $stdout.print @cursor.hide
+          end
+
+          def show_cursor
+            $stdout.print @cursor.show
+          end
+
+          private
+
+          def write_differential(frame)
+            buf = String.new
+            frame.each_with_index do |line, row|
+              next if @prev_frame[row] == line
+
+              buf << @cursor.move_to(0, row)
+              buf << line
+              # Clear any remaining characters from the previous frame
+              plain_len = strip_ansi(line).length
+              buf << (' ' * (@width - plain_len)) if plain_len < @width
+            end
+            $stdout.print buf
+            $stdout.flush
+          end
+
+          def strip_ansi(str)
+            str.to_s.gsub(/\e\[[0-9;]*[A-Za-z]/, '').gsub(/\e\].*?\e\\/, '')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/cli/chat/tui/status_bar.rb
+++ b/lib/legion/cli/chat/tui/status_bar.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module Legion
+  module CLI
+    class Chat
+      module TUI
+        # Fixed single-row status bar rendered between the output pane and input region.
+        # Shows model, thinking/tool status, cost, and notifications.
+        class StatusBar
+          PURPLE = "\e[38;2;127;119;221m"
+          DIM = "\e[2m"
+          BOLD = "\e[1m"
+          YELLOW = "\e[33m"
+          GREEN = "\e[32m"
+          BG = "\e[48;2;40;40;50m"
+          RESET = "\e[0m"
+
+          SPINNER_FRAMES = %w[⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏].freeze
+
+          def initialize
+            @model = 'unknown'
+            @thinking = false
+            @tool_name = nil
+            @tool_index = 0
+            @tool_total = 0
+            @tokens_in = 0
+            @tokens_out = 0
+            @cost = 0.0
+            @messages = 0
+            @permissions_mode = 'interactive'
+            @notification = nil
+            @notification_expires = nil
+            @spinner_tick = 0
+          end
+
+          def update(**fields)
+            fields.each do |key, value|
+              case key
+              when :model then @model = value
+              when :thinking then @thinking = value; @tool_name = nil if value
+              when :tool_name then @tool_name = value; @thinking = false if value
+              when :tool_index then @tool_index = value
+              when :tool_total then @tool_total = value
+              when :tokens_in then @tokens_in = value
+              when :tokens_out then @tokens_out = value
+              when :cost then @cost = value
+              when :messages then @messages = value
+              when :permissions_mode then @permissions_mode = value
+              end
+            end
+          end
+
+          def notify(message, ttl: 5)
+            @notification = message
+            @notification_expires = Time.now + ttl
+          end
+
+          def tick
+            @spinner_tick += 1
+          end
+
+          def render(width)
+            segments = []
+
+            # Activity indicator
+            if @thinking
+              spinner = SPINNER_FRAMES[@spinner_tick % SPINNER_FRAMES.length]
+              segments << "#{PURPLE}#{spinner}#{RESET} thinking..."
+            elsif @tool_name
+              spinner = SPINNER_FRAMES[@spinner_tick % SPINNER_FRAMES.length]
+              label = if @tool_total > 1
+                        "[#{@tool_index}/#{@tool_total}] #{@tool_name}"
+                      else
+                        @tool_name
+                      end
+              segments << "#{PURPLE}#{spinner}#{RESET} #{label}"
+            else
+              segments << "#{GREEN}●#{RESET} ready"
+            end
+
+            # Model
+            segments << "#{DIM}model:#{RESET} #{@model}"
+
+            # Permissions
+            segments << "#{DIM}perms:#{RESET} #{@permissions_mode}"
+
+            # Tokens/cost
+            if @tokens_in.positive? || @tokens_out.positive?
+              segments << "#{DIM}tokens:#{RESET} #{format_tokens(@tokens_in)}/#{format_tokens(@tokens_out)}"
+              segments << "#{DIM}cost:#{RESET} $#{format('%.4f', @cost)}" if @cost.positive?
+            end
+
+            # Notification (ephemeral)
+            if @notification && @notification_expires
+              if Time.now < @notification_expires
+                segments << "#{YELLOW}#{@notification}#{RESET}"
+              else
+                @notification = nil
+                @notification_expires = nil
+              end
+            end
+
+            line = segments.join("  #{DIM}│#{RESET}  ")
+
+            # Render as a full-width bar with background
+            plain_len = strip_ansi(line).length
+            padding = [width - plain_len, 0].max
+            "#{BG}#{line}#{' ' * padding}#{RESET}"
+          end
+
+          private
+
+          def format_tokens(n)
+            if n >= 1_000_000
+              "#{format('%.1f', n / 1_000_000.0)}M"
+            elsif n >= 1_000
+              "#{format('%.1f', n / 1_000.0)}K"
+            else
+              n.to_s
+            end
+          end
+
+          def strip_ansi(str)
+            str.to_s.gsub(/\e\[[0-9;]*[A-Za-z]/, '').gsub(/\e\].*?\e\\/, '')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -24,8 +24,8 @@ module Legion
       class_option :max_budget_usd, type: :numeric, desc: 'Maximum estimated cost in USD (stops when exceeded)'
       class_option :incognito, type: :boolean, default: false,
                                desc: 'Disable automatic session history saving'
-      class_option :tui, type: :boolean, default: false, aliases: ['-t'],
-                         desc: 'Use split-pane TUI (fixed input/output/status regions)'
+      class_option :no_tui, type: :boolean, default: false,
+                           desc: 'Disable TUI, use basic REPL (for non-interactive terminals)'
       class_option :continue, type: :boolean, default: false, aliases: ['-c'],
                               desc: 'Resume the most recent session'
       class_option :resume,         type: :string, desc: 'Resume a saved session by name'
@@ -193,6 +193,8 @@ module Legion
           Connection.log_level = options[:verbose] ? 'debug' : 'error'
           Connection.ensure_settings
 
+          require 'legion/llm'
+          Legion::Settings.merge_settings(:llm, Legion::LLM::Settings.default)
           require 'legion/llm/daemon_client'
           return if Legion::LLM::DaemonClient.available?
 
@@ -337,51 +339,80 @@ module Legion
         end
 
         def use_tui?
-          options[:tui] || chat_setting(:tui) == true
+          return false if options[:no_tui]
+          return false unless $stdout.tty?
+
+          chat_setting(:tui) != false
         end
 
         def run_tui
           require 'legion/cli/chat/tui/app'
+          require 'legion/cli/chat/tui/formatter'
 
-          slash_completions = %w[/help /quit /exit /model /status /permissions /history /clear /edit /save /export]
+          slash_completions = %w[
+            /help /quit /exit /cost /status /clear /new
+            /save /load /sessions /compact /context
+            /fetch /search /diff /copy /rewind
+            /memory /agent /agents /plan /swarm
+            /review /permissions /personality
+            /model /commit /workers /dream /edit
+          ]
           banner = "Legion v#{Legion::VERSION}  |  Model: #{@session.model_id}  |  /help for commands, /quit to exit"
 
-          tui_app = Chat::TUI::App.new(
-            session: @session,
-            model_id: @session.model_id,
+          @tui_app = Chat::TUI::App.new(
+            session:          @session,
+            model_id:         @session.model_id,
             permissions_mode: Chat::Permissions.mode.to_s,
-            slash_handler: method(:handle_tui_slash),
-            completions: slash_completions,
-            banner: banner
+            slash_handler:    method(:handle_tui_slash),
+            completions:      slash_completions,
+            banner:           banner
           )
 
-          tui_app.run
+          @tui_app.run
           show_session_stats(formatter)
         end
 
         def handle_tui_slash(text)
           cmd = text.strip.split(/\s+/, 2)
+
+          # TUI-specific overrides
           case cmd[0]
-          when '/help'
-            true # TODO: show help overlay
-          when '/model'
-            true # TODO: switch model
-          when '/status'
-            true # TODO: show status
-          when '/permissions'
-            if cmd[1]
-              sym = cmd[1].strip.to_sym
-              valid = %i[interactive auto_approve read_only]
-              if valid.include?(sym)
-                Chat::Permissions.mode = sym
-              end
-            end
-            true
+          when '/quit', '/exit', '/q'
+            @tui_app.stop
+            return true
           when '/clear'
-            true # TODO: clear output
-          else
-            false # Not handled — send to LLM
+            @tui_app.output.clear
+            @session.chat.reset_messages!
+            chat_log.info 'conversation cleared'
+            return true
+          when '/edit', '/e'
+            @tui_app.output.add_info('/edit requires terminal mode — not available in TUI')
+            return true
+          when '/commit'
+            @tui_app.output.add_info('/commit requires interactive confirmation — not available in TUI yet')
+            return true
           end
+
+          tui_out = Chat::TUI::Formatter.new(@tui_app.output)
+
+          # Capture any direct puts/print calls from slash command handlers
+          require 'stringio'
+          captured = StringIO.new
+          original_stdout = $stdout
+          begin
+            $stdout = captured
+            handle_slash_command(text, tui_out)
+          rescue SystemExit
+            @tui_app.stop
+          ensure
+            $stdout = original_stdout
+          end
+
+          # Feed captured stdout output to TUI pane
+          captured.string.lines.each { |l| @tui_app.output.add_raw(l.chomp) } unless captured.string.empty?
+
+          @tui_app.output.add_raw('')
+          true
         end
 
         def create_chat

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -24,6 +24,8 @@ module Legion
       class_option :max_budget_usd, type: :numeric, desc: 'Maximum estimated cost in USD (stops when exceeded)'
       class_option :incognito, type: :boolean, default: false,
                                desc: 'Disable automatic session history saving'
+      class_option :tui, type: :boolean, default: false, aliases: ['-t'],
+                         desc: 'Use split-pane TUI (fixed input/output/status regions)'
       class_option :continue, type: :boolean, default: false, aliases: ['-c'],
                               desc: 'Resume the most recent session'
       class_option :resume,         type: :string, desc: 'Resume a saved session by name'
@@ -50,8 +52,6 @@ module Legion
           chat: chat_obj, system_prompt: system_prompt,
           budget_usd: effective_budget
         )
-        @indicator = Chat::StatusIndicator.new(@session) unless options[:json]
-
         restore_session(out) if options[:continue] || options[:resume] || options[:resume_latest] || options[:fork]
         load_memory_context
         load_custom_agents
@@ -63,14 +63,23 @@ module Legion
         @last_active_at = Time.now
 
         chat_log.info "session started model=#{@session.model_id} incognito=#{incognito?}"
-        out.banner(version: Legion::VERSION)
-        puts
-        puts out.dim("  Model: #{@session.model_id}")
-        puts out.dim('  Type /help for commands, /quit to exit. End a line with \\ for multiline.')
-        puts
 
         send_recovery_message(out) if @recovery_message
-        repl_loop(out)
+
+        if use_tui?
+          run_tui
+        else
+          @indicator = Chat::StatusIndicator.new(@session) unless options[:json]
+          Chat::Permissions.before_prompt = -> { @indicator&.pause } if @indicator
+
+          out.banner(version: Legion::VERSION)
+          puts
+          puts out.dim("  Model: #{@session.model_id}")
+          puts out.dim('  Type /help for commands, /quit to exit. End a line with \\ for multiline.')
+          puts
+
+          repl_loop(out)
+        end
       rescue Interrupt
         Legion::Logging.debug('ChatCommand#interactive interrupted by user') if defined?(Legion::Logging)
         puts
@@ -325,6 +334,54 @@ module Legion
                                    else
                                      default
                                    end
+        end
+
+        def use_tui?
+          options[:tui] || chat_setting(:tui) == true
+        end
+
+        def run_tui
+          require 'legion/cli/chat/tui/app'
+
+          slash_completions = %w[/help /quit /exit /model /status /permissions /history /clear /edit /save /export]
+          banner = "Legion v#{Legion::VERSION}  |  Model: #{@session.model_id}  |  /help for commands, /quit to exit"
+
+          tui_app = Chat::TUI::App.new(
+            session: @session,
+            model_id: @session.model_id,
+            permissions_mode: Chat::Permissions.mode.to_s,
+            slash_handler: method(:handle_tui_slash),
+            completions: slash_completions,
+            banner: banner
+          )
+
+          tui_app.run
+          show_session_stats(formatter)
+        end
+
+        def handle_tui_slash(text)
+          cmd = text.strip.split(/\s+/, 2)
+          case cmd[0]
+          when '/help'
+            true # TODO: show help overlay
+          when '/model'
+            true # TODO: switch model
+          when '/status'
+            true # TODO: show status
+          when '/permissions'
+            if cmd[1]
+              sym = cmd[1].strip.to_sym
+              valid = %i[interactive auto_approve read_only]
+              if valid.include?(sym)
+                Chat::Permissions.mode = sym
+              end
+            end
+            true
+          when '/clear'
+            true # TODO: clear output
+          else
+            false # Not handled — send to LLM
+          end
         end
 
         def create_chat

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -466,11 +466,11 @@ module Legion
                 tool_index += 1
                 chat_log.debug "tool_call name=#{tc.name} args=#{tc.arguments.keys.join(',')}"
                 turn_tool_calls << { name: tc.name, args: tc.arguments, result: nil }
+                puts out.dim("  [tool] #{tc.name}(#{tc.arguments.keys.join(', ')})")
                 @session.emit(:tool_start, {
                                 name: tc.name, args: tc.arguments,
                   index: tool_index, total: tool_total
                               })
-                puts out.dim("  [tool] #{tc.name}(#{tc.arguments.keys.join(', ')})")
               },
               on_tool_result: lambda { |tr|
                 result_preview = tr.to_s.lines.first(3).join.rstrip

--- a/lib/legion/cli/connection.rb
+++ b/lib/legion/cli/connection.rb
@@ -103,6 +103,8 @@ module Legion
           return if @llm_ready
 
           ensure_settings
+          ensure_crypt rescue nil
+          Legion::Settings.resolve_secrets! if Legion::Settings.respond_to?(:resolve_secrets!)
           require 'legion/llm'
           Legion::Settings.merge_settings(:llm, Legion::LLM::Settings.default)
           Legion::LLM.start

--- a/lib/legion/cli/interactive.rb
+++ b/lib/legion/cli/interactive.rb
@@ -43,8 +43,10 @@ module Legion
       desc 'init', 'Initialize a new Legion workspace'
       subcommand 'init', Legion::CLI::Init
 
-      desc 'tty', 'Launch the rich terminal UI'
-      subcommand 'tty', Legion::CLI::Tty
+      desc 'tty', 'Launch the rich terminal UI (alias for chat)'
+      def tty(*args)
+        Legion::CLI::Chat.start(['interactive'] + args + ARGV.select { |a| a.start_with?('--') })
+      end
 
       desc 'ask TEXT', 'Quick AI prompt (shortcut for chat prompt)'
       map %w[-p --prompt] => :ask

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.8.14'
+  VERSION = '1.8.15'
 end


### PR DESCRIPTION
## Summary

Adds a proper terminal UI for `legion chat` with three non-overlapping screen regions:

- **Output pane**: Scrollable chat history with streaming response display
- **Status bar**: Fixed row showing model, activity spinner, tokens/cost
- **Input bar**: Character-by-character input with history and paste support

Activated via `legion chat --tui` or `chat.tui: true` in settings. Falls back to the existing REPL when not enabled.

## Architecture

| File | Purpose |
|---|---|
| `lib/legion/cli/chat/tui/screen.rb` | Differential rendering engine — only redraws changed lines |
| `lib/legion/cli/chat/tui/output_pane.rb` | Scrollable message accumulator with streaming support |
| `lib/legion/cli/chat/tui/status_bar.rb` | Single-row status with inline spinner (no TTY::Spinner) |
| `lib/legion/cli/chat/tui/input_bar.rb` | Raw-mode input handler (replaces Reline.readline) |
| `lib/legion/cli/chat/tui/app.rb` | Raw-mode event loop wiring Session events to pane updates |
| `lib/legion/cli/chat_command.rb` | Integration — TUI or REPL based on settings |

**1,120+ lines** of new code. Thread-safe via `MonitorMixin`. Cannibalizes patterns from legion-tty: raw stdin event loop, differential rendering, escape sequence parsing, key normalization.

## Dependencies

This PR includes the CLI bug fixes from #159 (Tool::Halt, output truncation, Vault resolution, spinner UX).

## Test plan

- [ ] `legion chat --tui` → verify three-pane layout renders correctly
- [ ] Stream a long response → verify output pane scrolls, status bar shows spinner
- [ ] Type input with up/down arrow → verify history navigation works
- [ ] Paste a multi-line block → verify paste detection handles it
- [ ] `legion chat` (no --tui) → verify existing REPL still works
- [ ] Resize terminal window → verify layout adapts
- [ ] Ctrl-C / exit → verify clean terminal restore