### PR TITLE
fix(cli): stop sending dry_run kwarg on every knowledge ingest call

### DIFF
--- a/lib/legion/cli/knowledge_command.rb
+++ b/lib/legion/cli/knowledge_command.rb
@@ -320,8 +320,9 @@ module Legion
       option :force,   type: :boolean, default: false, desc: 'Re-ingest even unchanged files'
       option :dry_run, type: :boolean, default: false, desc: 'Preview without writing'
       def ingest(path)
-        result = api_post('/api/knowledge/ingest',
-                          path: ::File.expand_path(path), force: options[:force], dry_run: options[:dry_run])
+        payload = { path: ::File.expand_path(path), force: options[:force] }
+        payload[:dry_run] = options[:dry_run] if options[:dry_run]
+        result = api_post('/api/knowledge/ingest', **payload)
         out = formatter
         if options[:json]
           out.json(result)


### PR DESCRIPTION
fix(cli): stop sending dry_run kwarg on every knowledge ingest call

## Problem

`legionio knowledge ingest <file>` always sends `dry_run: <boolean>` in the JSON body
to `/api/knowledge/ingest`, regardless of whether `--dry-run` was passed. When the
server routes the request to `Legion::Extensions::Knowledge::Runners::Ingest.ingest_file`
(which accepts only `file_path:` and `force:`), Ruby raises:

```
ArgumentError: unknown keyword: :dry_run
```

and the CLI sees `API 500 for /api/knowledge/ingest`. This blocks all single-file
ingestion via the CLI.

## Repro

```bash
legionio knowledge ingest /some/file.txt
# >  »   » API returned 500 for /api/knowledge/ingest
```

Daemon log confirms:
```
ArgumentError - unknown keyword: :dry_run (ArgumentError)
/.../gems/legionio-1.8.14/lib/legion/api/knowledge.rb → ingest_file(file_path:, force:, dry_run:)
/.../gems/lex-knowledge-0.6.7/lib/legion/extensions/knowledge/runners/ingest.rb:126  (ingest_file signature: (file_path:, force: false))
```

## Fix

Only include `dry_run` in the payload when the user actually passed `--dry-run`.
Paired with the server-side fix in PR 02 (removes `dry_run:` forwarding to `ingest_file`).

```ruby
# BEFORE
result = api_post('/api/knowledge/ingest',
                  path: ::File.expand_path(path), force: options[:force], dry_run: options[:dry_run])

# AFTER
payload = { path: ::File.expand_path(path), force: options[:force] }
payload[:dry_run] = options[:dry_run] if options[:dry_run]
result = api_post('/api/knowledge/ingest', **payload)
```

## Test plan

- `legionio knowledge ingest /tmp/test.txt` → `chunks_created: 1`, exit 0
- `legionio knowledge ingest /tmp/test.txt --dry-run` → still sends `dry_run: true` and no writes happen (server must also accept it for directory ingests, which it already does)
- `legionio knowledge ingest /tmp/some-dir/` → unchanged behavior

## Related

- See https://github.com/LegionIO/LegionIO/pull/163 for the companion server-side fix. Both are needed for `ingest` to work.
