### PR TITLE
fix(api): don't forward dry_run kwarg to Ingest.ingest_file

### DIFF
--- a/lib/legion/api/knowledge.rb
+++ b/lib/legion/api/knowledge.rb
@@ -55,8 +55,7 @@ module Legion
                        else
                          Legion::Extensions::Knowledge::Runners::Ingest.ingest_file(
                            file_path: body[:path],
-                           force:     body[:force] || false,
-                           dry_run:   body[:dry_run] || false
+                           force:     body[:force] || false
                          )
                        end
                      else


### PR DESCRIPTION
fix(api): don't forward dry_run kwarg to Ingest.ingest_file

## Problem

`/api/knowledge/ingest` dispatches single-file requests to
`Legion::Extensions::Knowledge::Runners::Ingest.ingest_file`, forwarding both `force:`
and `dry_run:` from the request body:

```ruby
# lib/legion/api/knowledge.rb
Legion::Extensions::Knowledge::Runners::Ingest.ingest_file(
  file_path: body[:path],
  force:     body[:force] || false,
  dry_run:   body[:dry_run] || false   # <-- not accepted
)
```

But the runner in `lex-knowledge 0.6.7` has signature:

```ruby
# lib/legion/extensions/knowledge/runners/ingest.rb:126
def ingest_file(file_path:, force: false)
  ...
end
```

Ruby raises `ArgumentError: unknown keyword: :dry_run` and the HTTP handler returns 500.

## Why the asymmetry

`ingest_corpus` does accept `dry_run:` (it's meaningful for the corpus scan/diff path —
you might want to preview what a directory ingest would add/change/remove without writing).
`ingest_file` writes a single file's chunks unconditionally and there's no "diff" to preview,
so the kwarg was never added to the runner.

## Fix

Drop `dry_run:` from the single-file branch. Keep it on the `ingest_corpus` branch where
it's actually supported.

```ruby
# BEFORE (inside the File.directory? conditional — single-file branch)
Legion::Extensions::Knowledge::Runners::Ingest.ingest_file(
  file_path: body[:path],
  force:     body[:force] || false,
  dry_run:   body[:dry_run] || false
)

# AFTER
Legion::Extensions::Knowledge::Runners::Ingest.ingest_file(
  file_path: body[:path],
  force:     body[:force] || false
)
```

## Alternative considered

Add a no-op `dry_run:` kwarg to `ingest_file` in `lex-knowledge`. Rejected because:
1. It's misleading — `dry_run: true` would still write chunks, contradicting user intent
2. Callers that genuinely want dry-run behavior should use a directory path (wrapping the file in a dir) — the directory branch already supports `dry_run` properly
3. Smaller diff, fewer moving parts

If maintainers prefer the alternative, PR 01 (CLI side) should also be reverted.

## Test plan

```bash
# Before: 500
legionio knowledge ingest /tmp/file.txt  # API 500

# After: 200
legionio knowledge ingest /tmp/file.txt  # chunks_created: 1

# Unchanged: directory ingest still supports dry_run
legionio knowledge ingest /tmp/some-dir --dry-run
```

## Related

Paired with https://github.com/LegionIO/LegionIO/pull/162 (CLI stops sending `dry_run:` for single-file ingests). Either PR
alone fixes the 500, but both together make the contract consistent.
