### PR TITLE
fix(knowledge-ingest): drop unsupported dry_run from single-file path (CLI + API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- `legionio knowledge ingest <file>` no longer returns `API 500 for /api/knowledge/ingest`. Two halves of the same contract mismatch: (a) the CLI previously forwarded `dry_run:` on every call (now only when `--dry-run` is passed), and (b) the `/api/knowledge/ingest` route forwarded `dry_run:` to `Legion::Extensions::Knowledge::Runners::Ingest.ingest_file`, whose signature in `lex-knowledge` 0.6.7 is `ingest_file(file_path:, force:)` — causing `ArgumentError: unknown keyword: :dry_run`. The kwarg remains honored for directory (corpus) ingests, which support preview scans. Adds regression coverage in `spec/legion/cli/knowledge_command_spec.rb` (negative-case for file ingest) and a new `spec/api/knowledge_spec.rb` covering the file/directory/dry_run branches of the route.
+
 ## [1.8.14] - 2026-04-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.8.15] - 2026-04-22
+
 ### Fixed
 - `legionio knowledge ingest <file>` no longer returns `API 500 for /api/knowledge/ingest`. Two halves of the same contract mismatch: (a) the CLI previously forwarded `dry_run:` on every call (now only when `--dry-run` is passed), and (b) the `/api/knowledge/ingest` route forwarded `dry_run:` to `Legion::Extensions::Knowledge::Runners::Ingest.ingest_file`, whose signature in `lex-knowledge` 0.6.7 is `ingest_file(file_path:, force:)` — causing `ArgumentError: unknown keyword: :dry_run`. The kwarg remains honored for directory (corpus) ingests, which support preview scans. Adds regression coverage in `spec/legion/cli/knowledge_command_spec.rb` (negative-case for file ingest) and a new `spec/api/knowledge_spec.rb` covering the file/directory/dry_run branches of the route.
 

--- a/lib/legion/api/knowledge.rb
+++ b/lib/legion/api/knowledge.rb
@@ -55,8 +55,7 @@ module Legion
                        else
                          Legion::Extensions::Knowledge::Runners::Ingest.ingest_file(
                            file_path: body[:path],
-                           force:     body[:force] || false,
-                           dry_run:   body[:dry_run] || false
+                           force:     body[:force] || false
                          )
                        end
                      else

--- a/lib/legion/cli/knowledge_command.rb
+++ b/lib/legion/cli/knowledge_command.rb
@@ -320,8 +320,9 @@ module Legion
       option :force,   type: :boolean, default: false, desc: 'Re-ingest even unchanged files'
       option :dry_run, type: :boolean, default: false, desc: 'Preview without writing'
       def ingest(path)
-        result = api_post('/api/knowledge/ingest',
-                          path: ::File.expand_path(path), force: options[:force], dry_run: options[:dry_run])
+        payload = { path: ::File.expand_path(path), force: options[:force] }
+        payload[:dry_run] = options[:dry_run] if options[:dry_run]
+        result = api_post('/api/knowledge/ingest', **payload)
         out = formatter
         if options[:json]
           out.json(result)

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.8.14'
+  VERSION = '1.8.15'
 end

--- a/spec/api/knowledge_spec.rb
+++ b/spec/api/knowledge_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require_relative 'api_spec_helper'
+
+RSpec.describe 'Knowledge API' do
+  include Rack::Test::Methods
+
+  def app = Legion::API
+
+  before(:all) { ApiSpecSetup.configure_settings }
+
+  # Stub the Knowledge runners module tree so require_knowledge_ingest! succeeds
+  before do
+    stub_const('Legion::Extensions::Knowledge', Module.new) unless defined?(Legion::Extensions::Knowledge)
+    stub_const('Legion::Extensions::Knowledge::Runners', Module.new) unless defined?(Legion::Extensions::Knowledge::Runners)
+    stub_const('Legion::Extensions::Knowledge::Runners::Ingest', Module.new) unless defined?(Legion::Extensions::Knowledge::Runners::Ingest)
+  end
+
+  describe 'POST /api/knowledge/ingest' do
+    let(:tmpfile) do
+      path = File.join(Dir.mktmpdir, 'test.md')
+      File.write(path, '# Test content')
+      path
+    end
+    let(:tmpdir) { Dir.mktmpdir('knowledge-test') }
+
+    after do
+      FileUtils.rm_rf(File.dirname(tmpfile)) if File.exist?(tmpfile)
+      FileUtils.rm_rf(tmpdir) if File.directory?(tmpdir)
+    end
+
+    it 'dispatches a file path to ingest_file with only :file_path and :force' do
+      expect(Legion::Extensions::Knowledge::Runners::Ingest)
+        .to receive(:ingest_file)
+        .with(file_path: tmpfile, force: false)
+        .and_return(success: true, chunks_created: 1)
+
+      post '/api/knowledge/ingest',
+           Legion::JSON.dump({ path: tmpfile, force: false }),
+           { 'CONTENT_TYPE' => 'application/json' }
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'does not forward :dry_run to ingest_file even when present in the body' do
+      expect(Legion::Extensions::Knowledge::Runners::Ingest)
+        .to receive(:ingest_file)
+        .with(hash_excluding(:dry_run))
+        .and_return(success: true, chunks_created: 1)
+
+      post '/api/knowledge/ingest',
+           Legion::JSON.dump({ path: tmpfile, force: false, dry_run: true }),
+           { 'CONTENT_TYPE' => 'application/json' }
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'dispatches a directory path to ingest_corpus with :dry_run honored' do
+      expect(Legion::Extensions::Knowledge::Runners::Ingest)
+        .to receive(:ingest_corpus)
+        .with(path: tmpdir, force: false, dry_run: true)
+        .and_return(success: true, files_scanned: 0)
+
+      post '/api/knowledge/ingest',
+           Legion::JSON.dump({ path: tmpdir, force: false, dry_run: true }),
+           { 'CONTENT_TYPE' => 'application/json' }
+
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'returns 400 when neither :content nor :path is supplied' do
+      post '/api/knowledge/ingest',
+           Legion::JSON.dump({ force: false }),
+           { 'CONTENT_TYPE' => 'application/json' }
+
+      expect(last_response.status).to eq(400)
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:error][:code]).to eq('missing_param')
+    end
+  end
+end

--- a/spec/legion/cli/knowledge_command_spec.rb
+++ b/spec/legion/cli/knowledge_command_spec.rb
@@ -238,6 +238,13 @@ RSpec.describe Legion::CLI::Knowledge do
           .and_return(ingest_file_result_success)
         described_class.start(['ingest', tmpfile, '--dry-run', '--no-color'])
       end
+
+      it 'omits dry_run from payload when --dry-run not given' do
+        expect_any_instance_of(described_class).to receive(:api_post)
+          .with('/api/knowledge/ingest', hash_excluding(:dry_run))
+          .and_return(ingest_file_result_success)
+        described_class.start(['ingest', tmpfile, '--no-color'])
+      end
     end
 
     context 'with a directory path' do


### PR DESCRIPTION
fix(knowledge-ingest): drop unsupported dry_run from single-file path (CLI + API)

## Problem

`legionio knowledge ingest <file>` returns `API 500 for /api/knowledge/ingest`. Two halves of the same contract mismatch, both shipped:

1. **CLI** (`lib/legion/cli/knowledge_command.rb`) — `#ingest` unconditionally includes `dry_run:` in the JSON body sent to `api_post`, even when `--dry-run` was not passed.
2. **API route** (`lib/legion/api/knowledge.rb`) — the single-file branch forwards `dry_run:` to `Legion::Extensions::Knowledge::Runners::Ingest.ingest_file`, whose signature in `lex-knowledge` 0.6.7 is `ingest_file(file_path:, force:)` (no `dry_run:` kwarg). Ruby raises `ArgumentError: unknown keyword: :dry_run` → 500.

`ingest_corpus` genuinely supports `dry_run:` because it has a scan/diff preview path; `ingest_file` does not (there's no "diff" to preview on a single file's chunking).

## Repro

```bash
echo "test" > /tmp/ingest-test.txt
legionio knowledge ingest /tmp/ingest-test.txt
# > API returned 500 for /api/knowledge/ingest
#
# Daemon log:
#   ArgumentError - unknown keyword: :dry_run (ArgumentError)
#   lex-knowledge-0.6.7/lib/legion/extensions/knowledge/runners/ingest.rb:126 (ingest_file)
```

## Fix

Two changes, both minimal:

### `lib/legion/cli/knowledge_command.rb`
```ruby
# BEFORE
result = api_post('/api/knowledge/ingest',
                  path: ::File.expand_path(path), force: options[:force], dry_run: options[:dry_run])

# AFTER
payload = { path: ::File.expand_path(path), force: options[:force] }
payload[:dry_run] = options[:dry_run] if options[:dry_run]
result = api_post('/api/knowledge/ingest', **payload)
```

### `lib/legion/api/knowledge.rb` (single-file branch only)
```ruby
# BEFORE
Legion::Extensions::Knowledge::Runners::Ingest.ingest_file(
  file_path: body[:path],
  force:     body[:force] || false,
  dry_run:   body[:dry_run] || false
)

# AFTER
Legion::Extensions::Knowledge::Runners::Ingest.ingest_file(
  file_path: body[:path],
  force:     body[:force] || false
)
```

Directory (corpus) branch unchanged — it still accepts and honors `dry_run:` because `ingest_corpus(path:, dry_run:, force:)` supports it.

## Alternative considered

Adding a no-op `dry_run:` kwarg to `ingest_file` in `lex-knowledge`. Rejected because:
1. A `dry_run: true` that still writes chunks would be misleading.
2. Callers who want dry-run semantics should use a directory path (the corpus branch already supports it properly).
3. Smaller surface area, fewer places for future contract drift.

## Tests

This PR adds the regression coverage `CONTRIBUTING.md` requires — and that would have caught the original bug.

### `spec/legion/cli/knowledge_command_spec.rb`
New negative-case test asserting the CLI omits `:dry_run` when `--dry-run` is not passed:
```ruby
it 'omits dry_run from payload when --dry-run not given' do
  expect_any_instance_of(described_class).to receive(:api_post)
    .with('/api/knowledge/ingest', hash_excluding(:dry_run))
    .and_return(ingest_file_result_success)
  described_class.start(['ingest', tmpfile, '--no-color'])
end
```

### `spec/api/knowledge_spec.rb` (new)
Previously there was no spec for the `/api/knowledge/*` route family. Added one covering four cases:
- `POST /api/knowledge/ingest` with a file path → dispatches to `ingest_file(file_path:, force:)` only
- `POST /api/knowledge/ingest` with a file path + `dry_run: true` in body → `:dry_run` **not** forwarded to `ingest_file`
- `POST /api/knowledge/ingest` with a directory path + `dry_run: true` → dispatches to `ingest_corpus(path:, force:, dry_run:)` with `dry_run` honored
- `POST /api/knowledge/ingest` with neither `:content` nor `:path` → returns `400 missing_param`

Uses `rack-test` + `ApiSpecSetup` (same pattern as `spec/api/transport_spec.rb`) and stubs `Legion::Extensions::Knowledge::Runners::Ingest` so `require_knowledge_ingest!` succeeds without a live `lex-knowledge` load.

## CHANGELOG

Added `[Unreleased]` / `### Fixed` entry covering both halves of the change, the root cause, and the regression coverage.

## Notes

- `knowledge maintain` was audited for the same kwarg-mismatch pattern. `Runners::Maintenance.cleanup_orphans(path:, dry_run: true)` properly accepts `dry_run:`, so the existing forwarding in the CLI and API is correct — no change needed there.
- This PR supersedes two separate earlier PRs (#162 CLI half, #163 API half) — consolidating them because they're two halves of the same contract.

## Test plan

- [x] `bundle exec rspec spec/legion/cli/knowledge_command_spec.rb` passes
- [x] `bundle exec rspec spec/api/knowledge_spec.rb` passes
- [x] `legionio knowledge ingest /some/file.md` returns `chunks_created: 1` (was `500`)
- [x] `legionio knowledge ingest /some/dir --dry-run` still previews without writing
- [x] `bundle exec rubocop` clean
