### PR TITLE
[codex] add extension runtime handles and hot reload guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-04-25
+
+### Added
+- Extension runtime handles now expose authoritative active/latest versions, reload state, pending-reload status, hot-reload eligibility, and owned runtime resources through `/api/extension_catalog`.
+- Extension dispatch quiescing now blocks API, ingress, and subscription runner dispatch while an extension is stopping or actively reloading.
+- `Legion::Tools::Registry.unregister_extension` removes callable tools owned by an extension during unload/reload cleanup.
+
+### Fixed
+- Runtime handle `loaded?` no longer reports `stopped` or `failed` extensions as loaded.
+- Extension registration publication now happens after extension autobuild and runtime side effects complete, avoiding durable registration of failed loads.
+
 ## [1.9.0] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - Runtime handle `loaded?` no longer reports `stopped` or `failed` extensions as loaded.
 - Extension registration publication now happens after extension autobuild and runtime side effects complete, avoiding durable registration of failed loads.
+- Extension runtime handles now transition to loaded only after `require` and extension side effects succeed, and multi-segment extension modules keep their hyphenated lex identity.
 
 ## [1.9.0] - 2026-04-24
 

--- a/lib/legion/api/extensions.rb
+++ b/lib/legion/api/extensions.rb
@@ -22,33 +22,21 @@ module Legion
 
         def self.register_extension_routes(app)
           app.get '/api/extension_catalog' do
-            entries = Legion::Extensions::Catalog.all.map do |name, entry|
-              { name: name, state: entry[:state].to_s,
-                registered_at: entry[:registered_at]&.iso8601,
-                started_at: entry[:started_at]&.iso8601 }
-            end
+            entries = Routes::Extensions.extension_entries
             entries = entries.select { |e| e[:state] == params[:state] } if params[:state]
             json_response(entries)
           end
 
           app.get '/api/extension_catalog/:name' do
             name = params[:name]
-            entry = Legion::Extensions::Catalog.entry(name)
+            entry = Routes::Extensions.extension_entry(name)
             halt_not_found("extension '#{name}' not found") unless entry
 
             ext_mod = find_extension_module(name)
-            version = ext_mod&.const_defined?(:VERSION) ? ext_mod::VERSION : nil
 
             runners = ext_mod ? runner_summaries(ext_mod) : []
 
-            json_response({
-              name:          name,
-              state:         entry[:state].to_s,
-              version:       version,
-              registered_at: entry[:registered_at]&.iso8601,
-              started_at:    entry[:started_at]&.iso8601,
-              runners:       runners
-            }.compact)
+            json_response(entry.merge(runners: runners).compact)
           end
         end
 
@@ -154,6 +142,52 @@ module Legion
         end
 
         class << self
+          def extension_entries
+            handles = if Legion::Extensions.respond_to?(:extension_handles)
+                        Legion::Extensions.extension_handles
+                      else
+                        []
+                      end
+            return handles.map { |handle| serialize_handle(handle) } unless handles.empty?
+
+            Legion::Extensions::Catalog.all.filter_map do |name, entry|
+              serialize_catalog_entry(name, entry)
+            end
+          end
+
+          def extension_entry(name)
+            handle = Legion::Extensions.extension_handle(name) if Legion::Extensions.respond_to?(:extension_handle)
+            return serialize_handle(handle) if handle
+
+            serialize_catalog_entry(name, Legion::Extensions::Catalog.entry(name))
+          end
+
+          def serialize_handle(handle)
+            {
+              name:                     handle.lex_name,
+              state:                    handle.state.to_s,
+              active_version:           handle.active_version&.to_s,
+              latest_installed_version: handle.latest_installed_version&.to_s,
+              reload_state:             handle.reload_state.to_s,
+              pending_reload:           handle.pending_reload?,
+              hot_reloadable:           handle.hot_reloadable,
+              loaded_at:                handle.loaded_at&.iso8601,
+              last_error:               handle.last_error,
+              routes:                   handle.routes,
+              tools:                    handle.tools,
+              absorbers:                handle.absorbers,
+              owned_runners:            handle.runners
+            }.compact
+          end
+
+          def serialize_catalog_entry(name, entry)
+            return nil unless entry
+
+            { name: name, state: entry[:state].to_s,
+              registered_at: entry[:registered_at]&.iso8601,
+              started_at: entry[:started_at]&.iso8601 }
+          end
+
           private :register_available_route, :register_extension_routes,
                   :register_runner_routes, :register_function_routes, :register_invoke_route
         end

--- a/lib/legion/api/stats.rb
+++ b/lib/legion/api/stats.rb
@@ -20,21 +20,23 @@ module Legion
           end
         end
 
-        EXTENSION_IVARS = {
-          loaded:       :@loaded_extensions,
+        EXTENSION_TASK_IVARS = {
           discovered:   :@extensions,
           subscription: :@subscription_tasks,
           every:        :@timer_tasks,
           poll:         :@poll_tasks,
           once:         :@once_tasks,
           loop:         :@loop_tasks,
-          running:      :@running_instances
+          actors:       :@running_instances
         }.freeze
 
         class << self
           def collect_extensions
             ext = Legion::Extensions
-            EXTENSION_IVARS.transform_values { |ivar| ext.instance_variable_get(ivar)&.count || 0 }
+            {
+              loaded:  ext.extension_handle_registry.loaded.count,
+              running: ext.extension_handle_registry.running.count
+            }.merge(EXTENSION_TASK_IVARS.transform_values { |ivar| ext.instance_variable_get(ivar)&.count || 0 })
           rescue StandardError => e
             { error: e.message }
           end

--- a/lib/legion/extensions.rb
+++ b/lib/legion/extensions.rb
@@ -2,6 +2,7 @@
 
 require 'legion/extensions/core'
 require 'legion/extensions/catalog'
+require 'legion/extensions/handle_registry'
 require 'legion/extensions/permissions'
 require 'legion/runner'
 
@@ -22,6 +23,7 @@ module Legion
         @actors = []
         @running_instances = Concurrent::Array.new
         @loaded_extensions = []
+        reset_runtime_handles!
         @pending_registrations = Concurrent::Array.new
 
         find_extensions
@@ -33,7 +35,7 @@ module Legion
           hook_phase_actors(phase_num)
         end
 
-        @loaded_extensions&.each { |name| Catalog.transition(name, :running) }
+        transition_loaded_extensions(:running)
         Catalog.flush_persisted_transitions
 
         load_yaml_agents
@@ -47,7 +49,7 @@ module Legion
         deadline = Legion::Settings.dig(:extensions, :shutdown_timeout) || 15
         shutdown_start = Time.now
 
-        @loaded_extensions.each { |name| Catalog.transition(name, :stopping) }
+        transition_loaded_extensions(:stopping)
 
         if @subscription_pool
           @subscription_pool.shutdown
@@ -100,10 +102,7 @@ module Legion
 
         Legion::Dispatch.shutdown if defined?(Legion::Dispatch) && Legion::Dispatch.instance_variable_get(:@dispatcher)
 
-        @loaded_extensions.each do |name|
-          Catalog.transition(name, :stopped)
-          unregister_capabilities(name)
-        end
+        transition_loaded_extensions(:stopped) { |name| unregister_capabilities(name) }
         Legion::Logging.info "Successfully shut down all actors (#{(Time.now - shutdown_start).round(1)}s)"
       end
 
@@ -146,6 +145,8 @@ module Legion
           end
 
           Catalog.register(gem_name)
+          register_extension_handle(gem_name, state:                    :registered,
+                                              latest_installed_version: latest_installed_version(gem_name))
           entry
         end
 
@@ -211,9 +212,11 @@ module Legion
         results.each_with_index do |result, idx|
           if result
             Catalog.transition(result[:gem_name], :loaded)
+            transition_extension_handle(result[:gem_name], :loaded)
             register_in_registry(gem_name: result[:gem_name], version: result[:version])
             @loaded_extensions.push(result[:gem_name])
           else
+            transition_extension_handle(eligible[idx][:gem_name], :failed)
             Legion::Logging.warn("#{eligible[idx][:gem_name]} failed to load")
           end
         end
@@ -275,14 +278,6 @@ module Legion
         has_logger = extension.respond_to?(:log)
         extension.autobuild
 
-        require 'legion/transport/messages/lex_register'
-        registration = Legion::Transport::Messages::LexRegister.new(function: 'save', opts: extension.runners)
-        if @pending_registrations
-          @pending_registrations << registration
-        else
-          registration.publish
-        end
-
         register_capabilities(entry[:gem_name], extension.runners) if extension.respond_to?(:runners)
         write_lex_cli_manifest(entry, extension)
         register_absorber_capabilities(entry[:gem_name], extension.absorbers) if extension.respond_to?(:absorbers)
@@ -300,6 +295,14 @@ module Legion
         end
         extension.log.info "Loaded v#{extension::VERSION}"
         Legion::Events.emit('extension.loaded', name: ext_name, version: entry[:gem_name])
+
+        require 'legion/transport/messages/lex_register'
+        registration = Legion::Transport::Messages::LexRegister.new(function: 'save', opts: extension.runners)
+        if @pending_registrations
+          @pending_registrations << registration
+        else
+          registration.publish
+        end
 
         begin
           if defined?(Legion::Data) && defined?(Legion::Data::Model::DigitalWorker)
@@ -599,9 +602,12 @@ module Legion
       public
 
       def loaded_extension_modules
+        handles = extension_handles
+        active_names = handles.select(&:dispatchable?).map(&:lex_name)
         constants(false).filter_map do |const_name|
           mod = const_get(const_name, false)
           next nil unless mod.is_a?(Module) && mod.respond_to?(:runner_modules)
+          next nil if handles.any? && !active_names.include?(module_lex_name(mod))
 
           mod
         rescue StandardError => e
@@ -611,7 +617,11 @@ module Legion
       end
 
       # Legacy capability registration - now handled by Tools::Discovery
-      def unregister_capabilities(_gem_name); end
+      def unregister_capabilities(gem_name)
+        return unless defined?(Legion::Tools::Registry) && Legion::Tools::Registry.respond_to?(:unregister_extension)
+
+        Legion::Tools::Registry.unregister_extension(gem_name)
+      end
 
       def register_absorber_capabilities(_gem_name, _absorbers); end
 
@@ -620,7 +630,12 @@ module Legion
       def gem_load(entry)
         gem_name     = entry[:gem_name]
         require_path = entry[:require_path]
-        gem_dir      = Gem::Specification.find_by_name(gem_name).gem_dir
+        spec         = Gem::Specification.find_by_name(gem_name)
+        gem_dir      = spec.gem_dir
+        entry[:spec] = spec
+        entry[:version] = spec.version.to_s
+        register_extension_handle(gem_name, spec: spec, state: :loaded, loaded_at: Time.now,
+                                            latest_installed_version: latest_installed_version(gem_name))
         require "#{gem_dir}/lib/#{require_path}"
         true
       rescue Gem::MissingSpecError => e
@@ -762,6 +777,82 @@ module Legion
         @extensions
       end
 
+      def loaded_extensions
+        extension_handle_registry.loaded.map(&:lex_name)
+      end
+
+      def extension_handles
+        extension_handle_registry.all
+      end
+
+      def extension_handle(name)
+        extension_handle_registry.fetch(name)
+      end
+
+      def register_extension_handle(name, **attrs)
+        extension_handle_registry.register(name, **attrs)
+      end
+
+      def transition_extension_handle(name, state)
+        extension_handle_registry.transition(name, state)
+      end
+
+      def update_extension_handle(name, **attrs)
+        extension_handle_registry.update(name, **attrs)
+      end
+
+      def reset_runtime_handles!
+        extension_handle_registry.reset!
+      end
+
+      def dispatch_allowed?(lex_name)
+        extension_handle_registry.dispatch_allowed?(normalize_lex_name(lex_name))
+      end
+
+      def dispatch_allowed_for_runner?(runner_class)
+        lex_name = lex_name_for_runner_class(runner_class)
+        return true unless lex_name
+
+        dispatch_allowed?(lex_name)
+      end
+
+      def record_extension_resource(lex_name, resource_type, value)
+        handle = extension_handle(lex_name) || register_extension_handle(normalize_lex_name(lex_name))
+        values = Array(handle.public_send(resource_type))
+        return handle if values.include?(value)
+
+        update_extension_handle(handle.lex_name, resource_type => values + [value])
+      end
+
+      def reload_extension(name)
+        gem_name = normalize_lex_name(name)
+        update_extension_handle(gem_name, reload_state: :updating)
+        unregister_capabilities(gem_name)
+        reset_runner_cache
+
+        entry = @extensions&.find { |candidate| candidate[:gem_name] == gem_name }
+        raise "#{gem_name} failed to reload" if entry && !load_extension(entry)
+
+        update_extension_handle(gem_name, state: :running, reload_state: :idle, last_error: nil,
+                                          latest_installed_version: latest_installed_version(gem_name))
+        true
+      rescue StandardError => e
+        update_extension_handle(gem_name, reload_state: :failed, last_error: e.message)
+        raise
+      end
+
+      def extension_handle_registry
+        @extension_handle_registry ||= HandleRegistry.new
+      end
+
+      def transition_loaded_extensions(state)
+        @loaded_extensions&.each do |name|
+          Catalog.transition(name, state)
+          transition_extension_handle(name, state)
+          yield name if block_given?
+        end
+      end
+
       def load_yaml_agents
         @load_yaml_agents ||= begin
           require 'legion/settings/agent_loader'
@@ -776,6 +867,54 @@ module Legion
       end
 
       private
+
+      def latest_installed_version(gem_name)
+        Gem::Specification.find_all_by_name(gem_name).map(&:version).max
+      rescue StandardError
+        nil
+      end
+
+      def reset_runner_cache
+        return unless defined?(Legion::Ingress) && Legion::Ingress.respond_to?(:reset_runner_cache!)
+
+        Legion::Ingress.reset_runner_cache!
+      end
+
+      def normalize_lex_name(name)
+        str = name.to_s
+        str.start_with?('lex-') ? str : "lex-#{str.tr('.', '-').tr('_', '-')}"
+      end
+
+      def module_lex_name(mod)
+        parts = mod.name.to_s.split('::')
+        idx = parts.index('Extensions')
+        return nil unless idx
+
+        segment = parts[idx + 1]
+        return nil if segment.nil?
+
+        "lex-#{camel_to_snake(segment).tr('_', '-')}"
+      end
+
+      def lex_name_for_runner_class(runner_class)
+        parts = runner_class.to_s.split('::')
+        idx = parts.index('Extensions')
+        return nil unless idx
+
+        extension_parts = []
+        parts[(idx + 1)..].to_a.each do |part|
+          break if %w[Actor Actors Runners Helpers Transport Data Hooks Skills].include?(part)
+
+          extension_parts << camel_to_snake(part)
+        end
+        return nil if extension_parts.empty?
+
+        "lex-#{extension_parts.join('-')}"
+      end
+
+      def camel_to_snake(value)
+        value.to_s.gsub(/(?<!^)[A-Z]/) { "_#{Regexp.last_match(0)}" }.downcase
+      end
 
       def default_agents_directory
         custom = Legion::Settings.dig(:agents, :directory)

--- a/lib/legion/extensions.rb
+++ b/lib/legion/extensions.rb
@@ -323,6 +323,8 @@ module Legion
           Legion::Logging.debug "Extensions#load_extension failed to register digital worker for #{ext_name}: #{e.message}" if defined?(Legion::Logging)
           nil
         end
+        register_extension_handle(entry[:gem_name], spec: entry[:spec], state: :loaded, loaded_at: Time.now,
+                                                    latest_installed_version: latest_installed_version(entry[:gem_name]))
         true
       rescue StandardError => e
         Legion::Logging.log_exception(e, lex: entry[:gem_name], component_type: :boot)
@@ -634,8 +636,6 @@ module Legion
         gem_dir      = spec.gem_dir
         entry[:spec] = spec
         entry[:version] = spec.version.to_s
-        register_extension_handle(gem_name, spec: spec, state: :loaded, loaded_at: Time.now,
-                                            latest_installed_version: latest_installed_version(gem_name))
         require "#{gem_dir}/lib/#{require_path}"
         true
       rescue Gem::MissingSpecError => e
@@ -890,10 +890,10 @@ module Legion
         idx = parts.index('Extensions')
         return nil unless idx
 
-        segment = parts[idx + 1]
-        return nil if segment.nil?
+        extension_parts = extension_parts_from_const(parts, idx)
+        return nil if extension_parts.empty?
 
-        "lex-#{camel_to_snake(segment).tr('_', '-')}"
+        "lex-#{extension_parts.join('-')}"
       end
 
       def lex_name_for_runner_class(runner_class)
@@ -901,15 +901,18 @@ module Legion
         idx = parts.index('Extensions')
         return nil unless idx
 
-        extension_parts = []
-        parts[(idx + 1)..].to_a.each do |part|
-          break if %w[Actor Actors Runners Helpers Transport Data Hooks Skills].include?(part)
-
-          extension_parts << camel_to_snake(part)
-        end
+        extension_parts = extension_parts_from_const(parts, idx)
         return nil if extension_parts.empty?
 
         "lex-#{extension_parts.join('-')}"
+      end
+
+      def extension_parts_from_const(parts, idx)
+        parts[(idx + 1)..].to_a.each_with_object([]) do |part, extension_parts|
+          break extension_parts if %w[Actor Actors Runners Helpers Transport Data Hooks Skills].include?(part)
+
+          extension_parts << camel_to_snake(part).tr('_', '-')
+        end
       end
 
       def camel_to_snake(value)

--- a/lib/legion/extensions/actors/subscription.rb
+++ b/lib/legion/extensions/actors/subscription.rb
@@ -214,6 +214,11 @@ module Legion
         end
 
         def dispatch_runner(message, runner_cls, function, check_subtask, generate_task)
+          unless extension_dispatch_allowed?
+            log.warn "[Subscription] rejecting #{lex_name}/#{function}: extension is not accepting new work" if defined?(log)
+            return { success: false, status: 'task.blocked', error: { code: 'extension_quiescing' } }
+          end
+
           run_block = lambda {
             ctx = message.merge(runner_class: runner_cls.to_s, function: function.to_s)
             Legion::Context.with_task_context(ctx) do
@@ -230,6 +235,12 @@ module Legion
           else
             run_block.call
           end
+        end
+
+        def extension_dispatch_allowed?
+          return true unless defined?(Legion::Extensions) && Legion::Extensions.respond_to?(:dispatch_allowed?)
+
+          Legion::Extensions.dispatch_allowed?(lex_name)
         end
 
         def reject_or_retry(delivery_info, metadata, payload)

--- a/lib/legion/extensions/handle.rb
+++ b/lib/legion/extensions/handle.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Legion
+  module Extensions
+    class Handle
+      STATES = %i[registered loaded starting running stopping stopped failed].freeze
+      LOADED_STATES = %i[loaded starting running stopping].freeze
+      DISPATCHABLE_STATES = %i[loaded starting running].freeze
+      RELOAD_STATES = %i[idle pending updating rolling_back failed].freeze
+      DISPATCH_BLOCKING_RELOAD_STATES = %i[updating rolling_back].freeze
+
+      attr_reader :lex_name, :gem_name, :active_version, :state, :reload_state, :hot_reloadable,
+                  :latest_installed_version, :spec, :gem_dir, :loaded_features, :actors, :routes, :tools, :absorbers,
+                  :runners, :loaded_at, :last_error
+
+      def initialize(**attrs)
+        lex_name = attrs.fetch(:lex_name)
+        spec = attrs[:spec]
+        @lex_name = lex_name.to_s
+        @gem_name = (attrs[:gem_name] || lex_name).to_s
+        @spec = spec
+        @active_version = normalize_version(attrs[:active_version] || spec&.version)
+        @latest_installed_version = normalize_version(attrs[:latest_installed_version] || attrs[:installed_version] || @active_version)
+        @state = normalize_state(attrs.fetch(:state, :registered))
+        @reload_state = normalize_reload_state(attrs.fetch(:reload_state, :idle))
+        @hot_reloadable = attrs[:hot_reloadable] == true
+        @gem_dir = attrs[:gem_dir] || spec&.gem_dir
+        @loaded_features = Array(attrs.fetch(:loaded_features, [])).dup.freeze
+        @actors = Array(attrs.fetch(:actors, [])).dup.freeze
+        @routes = Array(attrs.fetch(:routes, [])).dup.freeze
+        @tools = Array(attrs.fetch(:tools, [])).dup.freeze
+        @absorbers = Array(attrs.fetch(:absorbers, [])).dup.freeze
+        @runners = Array(attrs.fetch(:runners, [])).dup.freeze
+        @loaded_at = attrs.fetch(:loaded_at, Time.now)
+        @last_error = attrs[:last_error]
+      end
+
+      def loaded?
+        LOADED_STATES.include?(state)
+      end
+
+      def running?
+        state == :running
+      end
+
+      def pending_reload?
+        return false if active_version.nil? || latest_installed_version.nil?
+
+        latest_installed_version > active_version
+      end
+
+      def dispatchable?
+        DISPATCHABLE_STATES.include?(state) && !DISPATCH_BLOCKING_RELOAD_STATES.include?(reload_state)
+      end
+
+      def with(**attrs)
+        self.class.new(**to_h, **attrs)
+      end
+
+      def to_h
+        {
+          lex_name:                 lex_name,
+          gem_name:                 gem_name,
+          active_version:           active_version,
+          latest_installed_version: latest_installed_version,
+          state:                    state,
+          reload_state:             reload_state,
+          hot_reloadable:           hot_reloadable,
+          spec:                     spec,
+          gem_dir:                  gem_dir,
+          loaded_features:          loaded_features,
+          actors:                   actors,
+          routes:                   routes,
+          tools:                    tools,
+          absorbers:                absorbers,
+          runners:                  runners,
+          loaded_at:                loaded_at,
+          last_error:               last_error
+        }
+      end
+
+      private
+
+      def normalize_version(value)
+        return nil if value.nil?
+        return value if value.is_a?(Gem::Version)
+
+        Gem::Version.new(value.to_s)
+      end
+
+      def normalize_state(value)
+        normalized = value.to_sym
+        return normalized if STATES.include?(normalized)
+
+        raise ArgumentError, "unknown extension state: #{value.inspect}"
+      end
+
+      def normalize_reload_state(value)
+        normalized = value.to_sym
+        return normalized if RELOAD_STATES.include?(normalized)
+
+        raise ArgumentError, "unknown extension reload state: #{value.inspect}"
+      end
+    end
+  end
+end

--- a/lib/legion/extensions/handle_registry.rb
+++ b/lib/legion/extensions/handle_registry.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'legion/extensions/handle'
+
+module Legion
+  module Extensions
+    class HandleRegistry
+      def initialize
+        @handles = {}
+        @mutex = Mutex.new
+      end
+
+      def register(lex_name, **attrs)
+        key = normalize_name(lex_name)
+        @mutex.synchronize do
+          current = @handles[key]
+          @handles[key] = current ? current.with(**attrs) : Handle.new(lex_name: key, **attrs)
+        end
+      end
+
+      def transition(lex_name, state)
+        update(lex_name, state: state)
+      end
+
+      def update(lex_name, **attrs)
+        key = normalize_name(lex_name)
+        @mutex.synchronize do
+          current = @handles[key] || Handle.new(lex_name: key)
+          @handles[key] = current.with(**attrs)
+        end
+      end
+
+      def fetch(lex_name)
+        @mutex.synchronize { @handles[normalize_name(lex_name)] }
+      end
+
+      def all
+        @mutex.synchronize { @handles.values.dup }
+      end
+
+      def running
+        all.select(&:running?)
+      end
+
+      def loaded
+        all.select(&:loaded?)
+      end
+
+      def dispatch_allowed?(lex_name)
+        handle = fetch(lex_name)
+        return true unless handle
+
+        handle.dispatchable?
+      end
+
+      def delete(lex_name)
+        @mutex.synchronize { @handles.delete(normalize_name(lex_name)) }
+      end
+
+      def reset!
+        @mutex.synchronize { @handles.clear }
+      end
+
+      private
+
+      def normalize_name(lex_name)
+        lex_name.to_s
+      end
+    end
+  end
+end

--- a/lib/legion/ingress.rb
+++ b/lib/legion/ingress.rb
@@ -64,6 +64,14 @@ module Legion
         fn_str = fn.to_s
         raise InvalidFunction, "invalid function format: #{fn_str}" unless fn_str.match?(FUNCTION_PATTERN)
 
+        unless extension_dispatch_allowed?(rc)
+          return {
+            success: false,
+            status:  'task.blocked',
+            error:   { code: 'extension_quiescing', message: "extension for #{rc} is not accepting new work" }
+          }
+        end
+
         # RAI invariant #2: registration precedes permission
         if defined?(Legion::DigitalWorker::Registry) && message[:worker_id]
           Legion::DigitalWorker::Registry.validate_execution!(
@@ -138,7 +146,17 @@ module Legion
         false
       end
 
+      def reset_runner_cache!
+        @registered_runner_modules = nil
+      end
+
       private
+
+      def extension_dispatch_allowed?(runner_class)
+        return true unless defined?(Legion::Extensions) && Legion::Extensions.respond_to?(:dispatch_allowed_for_runner?)
+
+        Legion::Extensions.dispatch_allowed_for_runner?(runner_class)
+      end
 
       def resolve_runner_class(runner_class)
         return runner_class unless runner_class.is_a?(String)
@@ -167,10 +185,6 @@ module Legion
           end
         end
         @registered_runner_modules = modules
-      end
-
-      def reset_runner_cache!
-        @registered_runner_modules = nil
       end
 
       def parse_payload(payload)

--- a/lib/legion/tools/discovery.rb
+++ b/lib/legion/tools/discovery.rb
@@ -123,7 +123,9 @@ module Legion
             ext: ext, runner_mod: runner_mod, func_name: func_name,
             meta: meta, defn: defn, deferred: is_deferred
           )
-          Legion::Tools::Registry.register(tool_class)
+          return unless Legion::Tools::Registry.register(tool_class)
+
+          record_tool_owner(ext, tool_class)
         end
 
         def resolve_mcp_tools_enabled(ext, runner_mod)
@@ -212,6 +214,15 @@ module Legion
               error_response(e.message)
             end
           end
+        end
+
+        def record_tool_owner(ext, tool_class)
+          return unless defined?(Legion::Extensions) && Legion::Extensions.respond_to?(:record_extension_resource)
+
+          ext_name = derive_extension_name(ext)
+          Legion::Extensions.record_extension_resource("lex-#{ext_name.tr('_', '-')}", :tools, tool_class.tool_name)
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :record_tool_owner)
         end
 
         def merge_trigger_words(ext, runner_mod)

--- a/lib/legion/tools/registry.rb
+++ b/lib/legion/tools/registry.rb
@@ -56,7 +56,8 @@ module Legion
         end
 
         def for_extension(ext_name)
-          all_tools.select { |t| t.respond_to?(:extension) && t.extension == ext_name }
+          normalized = normalize_extension(ext_name)
+          all_tools.select { |t| t.respond_to?(:extension) && normalize_extension(t.extension) == normalized }
         end
 
         def for_runner(runner_name)
@@ -72,6 +73,22 @@ module Legion
             @always.clear
             @deferred.clear
           end
+        end
+
+        def unregister_extension(ext_name)
+          normalized = normalize_extension(ext_name)
+          @mutex.synchronize do
+            before = @always.size + @deferred.size
+            @always.reject! { |t| t.respond_to?(:extension) && normalize_extension(t.extension) == normalized }
+            @deferred.reject! { |t| t.respond_to?(:extension) && normalize_extension(t.extension) == normalized }
+            before - (@always.size + @deferred.size)
+          end
+        end
+
+        private
+
+        def normalize_extension(ext_name)
+          ext_name.to_s.delete_prefix('lex-').tr('-', '_')
         end
       end
     end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.0'
+  VERSION = '1.9.1'
 end

--- a/spec/legion/api/extensions_spec.rb
+++ b/spec/legion/api/extensions_spec.rb
@@ -62,10 +62,22 @@ RSpec.describe Legion::API::Routes::Extensions do
 
   before do
     Legion::Extensions::Catalog.reset!
+    Legion::Extensions.reset_runtime_handles!
     Legion::Extensions::Catalog.register('lex-fake_ext', state: :running)
     Legion::Extensions::Catalog.transition('lex-fake_ext', :running)
+    Legion::Extensions.register_extension_handle('lex-fake_ext',
+                                                 state:                    :running,
+                                                 active_version:           '1.2.3',
+                                                 latest_installed_version: '1.2.4',
+                                                 reload_state:             :pending,
+                                                 hot_reloadable:           true,
+                                                 runners:                  ['things'])
 
     allow(Legion::Extensions).to receive(:loaded_extension_modules).and_return([fake_extension])
+  end
+
+  after do
+    Legion::Extensions.reset_runtime_handles!
   end
 
   let(:test_app) do
@@ -85,13 +97,20 @@ RSpec.describe Legion::API::Routes::Extensions do
   end
 
   describe 'GET /api/extension_catalog' do
-    it 'returns loaded extensions from catalog' do
+    it 'returns runtime handles as the authoritative loaded extensions' do
       get '/api/extension_catalog'
       expect(last_response.status).to eq(200)
       body = Legion::JSON.load(last_response.body)
       expect(body[:data]).to be_an(Array)
-      names = body[:data].map { |e| e[:name] }
-      expect(names).to include('lex-fake_ext')
+      entry = body[:data].find { |e| e[:name] == 'lex-fake_ext' }
+      expect(entry).to include(
+        state:                    'running',
+        active_version:           '1.2.3',
+        latest_installed_version: '1.2.4',
+        reload_state:             'pending',
+        pending_reload:           true,
+        hot_reloadable:           true
+      )
     end
 
     it 'filters by state when ?state= param given' do
@@ -129,6 +148,8 @@ RSpec.describe Legion::API::Routes::Extensions do
       body = Legion::JSON.load(last_response.body)
       expect(body[:data][:name]).to eq('lex-fake_ext')
       expect(body[:data][:state]).to eq('running')
+      expect(body[:data][:active_version]).to eq('1.2.3')
+      expect(body[:data][:pending_reload]).to be true
       expect(body[:data][:runners]).to be_an(Array)
     end
 

--- a/spec/legion/api/stats_spec.rb
+++ b/spec/legion/api/stats_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/api/stats'
+
+RSpec.describe Legion::API::Routes::Stats do
+  before do
+    Legion::Extensions.reset_runtime_handles!
+    Legion::Extensions.instance_variable_set(:@loaded_extensions, %w[legacy-only])
+  end
+
+  after do
+    Legion::Extensions.reset_runtime_handles!
+    Legion::Extensions.instance_variable_set(:@loaded_extensions, nil)
+  end
+
+  it 'counts loaded and running extensions from runtime handles instead of ivars' do
+    Legion::Extensions.register_extension_handle('lex-loaded', state: :loaded)
+    Legion::Extensions.register_extension_handle('lex-running', state: :running)
+
+    stats = described_class.collect_extensions
+
+    expect(stats[:loaded]).to eq(2)
+    expect(stats[:running]).to eq(1)
+  end
+end

--- a/spec/legion/extensions/handle_registry_spec.rb
+++ b/spec/legion/extensions/handle_registry_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/extensions/handle_registry'
+
+RSpec.describe Legion::Extensions::HandleRegistry do
+  subject(:registry) { described_class.new }
+
+  let(:spec) do
+    instance_double(Gem::Specification,
+                    name:    'lex-example',
+                    version: Gem::Version.new('1.2.3'),
+                    gem_dir: '/gems/lex-example-1.2.3')
+  end
+
+  it 'registers an extension handle with runtime metadata' do
+    handle = registry.register('lex-example', spec: spec, state: :loaded)
+
+    expect(handle.lex_name).to eq('lex-example')
+    expect(handle.gem_name).to eq('lex-example')
+    expect(handle.active_version).to eq(Gem::Version.new('1.2.3'))
+    expect(handle.gem_dir).to eq('/gems/lex-example-1.2.3')
+    expect(handle.state).to eq(:loaded)
+    expect(handle.reload_state).to eq(:idle)
+    expect(handle.loaded_at).to be_a(Time)
+  end
+
+  it 'transitions state without replacing unrelated metadata' do
+    registry.register('lex-example', spec: spec)
+
+    handle = registry.transition('lex-example', :running)
+
+    expect(handle.state).to eq(:running)
+    expect(handle.active_version).to eq(Gem::Version.new('1.2.3'))
+  end
+
+  it 'updates controlled fields on an existing handle' do
+    registry.register('lex-example', spec: spec)
+
+    handle = registry.update('lex-example', reload_state: :pending, last_error: 'newer version installed')
+
+    expect(handle.reload_state).to eq(:pending)
+    expect(handle.last_error).to eq('newer version installed')
+  end
+
+  it 'returns state-filtered handle collections' do
+    registry.register('lex-loaded', state: :loaded)
+    registry.register('lex-running', state: :running)
+
+    expect(registry.loaded.map(&:lex_name)).to contain_exactly('lex-loaded', 'lex-running')
+    expect(registry.running.map(&:lex_name)).to contain_exactly('lex-running')
+  end
+
+  it 'does not treat stopped or failed handles as loaded' do
+    registry.register('lex-loaded', state: :loaded)
+    registry.register('lex-stopped', state: :stopped)
+    registry.register('lex-failed', state: :failed)
+
+    expect(registry.loaded.map(&:lex_name)).to contain_exactly('lex-loaded')
+  end
+
+  it 'derives pending reload from installed and active versions' do
+    handle = registry.register('lex-example',
+                               active_version:           '1.2.3',
+                               latest_installed_version: '1.2.4')
+
+    expect(handle.pending_reload?).to be true
+  end
+
+  it 'reports non-dispatchable handles while reload or stop is in progress' do
+    registry.register('lex-example', state: :running, reload_state: :updating)
+
+    expect(registry.fetch('lex-example')).not_to be_dispatchable
+  end
+
+  it 'can delete and reset handles' do
+    registry.register('lex-example')
+    expect(registry.delete('lex-example').lex_name).to eq('lex-example')
+    expect(registry.fetch('lex-example')).to be_nil
+
+    registry.register('lex-other')
+    registry.reset!
+    expect(registry.all).to be_empty
+  end
+end

--- a/spec/legion/extensions/runtime_handles_spec.rb
+++ b/spec/legion/extensions/runtime_handles_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Extensions do
+  before do
+    described_class.reset_runtime_handles!
+    described_class.instance_variable_set(:@loaded_extensions, %w[lex-example])
+  end
+
+  after do
+    described_class.reset_runtime_handles!
+    described_class.instance_variable_set(:@loaded_extensions, nil)
+  end
+
+  it 'exposes extension handles without requiring callers to read ivars' do
+    described_class.register_extension_handle('lex-example', state: :loaded)
+    described_class.transition_extension_handle('lex-example', :running)
+
+    handle = described_class.extension_handle('lex-example')
+
+    expect(handle.state).to eq(:running)
+    expect(described_class.extension_handles.map(&:lex_name)).to contain_exactly('lex-example')
+    expect(described_class.loaded_extensions).to eq(%w[lex-example])
+  end
+
+  it 'blocks dispatch when a handle is stopping or reloading' do
+    described_class.register_extension_handle('lex-example', state: :running)
+    expect(described_class.dispatch_allowed?('lex-example')).to be true
+
+    described_class.update_extension_handle('lex-example', reload_state: :updating)
+    expect(described_class.dispatch_allowed?('lex-example')).to be false
+
+    described_class.update_extension_handle('lex-example', reload_state: :idle, state: :stopping)
+    expect(described_class.dispatch_allowed?('lex-example')).to be false
+  end
+
+  it 'does not expose modules for handles that are not dispatchable' do
+    ext_mod = Module.new do
+      def self.name = 'Legion::Extensions::Example'
+      def self.runner_modules = []
+    end
+    described_class.const_set(:Example, ext_mod)
+    described_class.register_extension_handle('lex-example', state: :failed)
+
+    expect(described_class.loaded_extension_modules).to be_empty
+  ensure
+    described_class.send(:remove_const, :Example) if described_class.const_defined?(:Example, false)
+  end
+
+  it 'provides a scoped reload hook that quiesces, cleans callable state, and reopens dispatch' do
+    described_class.register_extension_handle('lex-example', state: :running, tools: ['legion-example-runner-call'])
+    allow(described_class).to receive(:unregister_capabilities)
+    stub_const('Legion::Ingress', Module.new)
+    allow(Legion::Ingress).to receive(:reset_runner_cache!)
+
+    expect(described_class.reload_extension('lex-example')).to be true
+
+    handle = described_class.extension_handle('lex-example')
+    expect(handle.state).to eq(:running)
+    expect(handle.reload_state).to eq(:idle)
+    expect(handle.last_error).to be_nil
+    expect(described_class).to have_received(:unregister_capabilities).with('lex-example')
+    expect(Legion::Ingress).to have_received(:reset_runner_cache!)
+  end
+end

--- a/spec/legion/extensions/runtime_handles_spec.rb
+++ b/spec/legion/extensions/runtime_handles_spec.rb
@@ -48,6 +48,27 @@ RSpec.describe Legion::Extensions do
     described_class.send(:remove_const, :Example) if described_class.const_defined?(:Example, false)
   end
 
+  it 'matches multi-segment extension modules to hyphenated lex handles' do
+    ext_mod = Module.new do
+      def self.name = 'Legion::Extensions::Llm::Gateway'
+      def self.runner_modules = []
+    end
+    described_class.const_set(:GatewayForSpec, ext_mod)
+    described_class.register_extension_handle('lex-llm-gateway', state: :running)
+
+    expect(described_class.loaded_extension_modules).to contain_exactly(ext_mod)
+  ensure
+    described_class.send(:remove_const, :GatewayForSpec) if described_class.const_defined?(:GatewayForSpec, false)
+  end
+
+  it 'does not mark a gem loaded when require fails' do
+    spec = instance_double(Gem::Specification, gem_dir: Dir.tmpdir, version: Gem::Version.new('1.2.3'))
+    allow(Gem::Specification).to receive(:find_by_name).with('lex-broken').and_return(spec)
+
+    expect(described_class.send(:gem_load, { gem_name: 'lex-broken', require_path: 'missing_lex_for_spec' })).to be_nil
+    expect(described_class.extension_handle('lex-broken')).to be_nil
+  end
+
   it 'provides a scoped reload hook that quiesces, cleans callable state, and reopens dispatch' do
     described_class.register_extension_handle('lex-example', state: :running, tools: ['legion-example-runner-call'])
     allow(described_class).to receive(:unregister_capabilities)

--- a/spec/legion/ingress_spec.rb
+++ b/spec/legion/ingress_spec.rb
@@ -144,5 +144,28 @@ RSpec.describe Legion::Ingress do
         expect(result[:error]).to be_nil
       end
     end
+
+    context 'when an extension handle is quiescing' do
+      before do
+        Legion::Extensions.reset_runtime_handles!
+        Legion::Extensions.register_extension_handle('lex-example', state: :running, reload_state: :updating)
+      end
+
+      after { Legion::Extensions.reset_runtime_handles! }
+
+      it 'blocks runner dispatch for that extension before Runner.run' do
+        result = described_class.run(
+          payload:      {},
+          runner_class: 'Legion::Extensions::Example::Runners::Worker',
+          function:     'do_work',
+          source:       'test'
+        )
+
+        expect(result[:success]).to be false
+        expect(result[:status]).to eq('task.blocked')
+        expect(result[:error][:code]).to eq('extension_quiescing')
+        expect(Legion::Runner).not_to have_received(:run)
+      end
+    end
   end
 end

--- a/spec/legion/tools/registry_spec.rb
+++ b/spec/legion/tools/registry_spec.rb
@@ -73,6 +73,25 @@ RSpec.describe Legion::Tools::Registry do
       expect(described_class.for_extension('node')).to include(tool)
       expect(described_class.for_extension('other')).to be_empty
     end
+
+    it 'unregisters all tools owned by an extension' do
+      node_tool = Class.new(Legion::Tools::Base) do
+        tool_name 'test.node_tool'
+        extension 'node'
+      end
+      other_tool = Class.new(Legion::Tools::Base) do
+        tool_name 'test.other_tool'
+        extension 'other'
+      end
+      described_class.register(node_tool)
+      described_class.register(other_tool)
+
+      removed = described_class.unregister_extension('node')
+
+      expect(removed).to eq(1)
+      expect(described_class.for_extension('node')).to be_empty
+      expect(described_class.for_extension('other')).to include(other_tool)
+    end
   end
 
   describe '.tagged' do


### PR DESCRIPTION
## Summary
Adds explicit runtime extension handles as the live source of truth for loaded/running/reload state and wires that state into catalog APIs, stats, tool cleanup, dispatch quiescing, and scoped reload.

## What changed
- Added `Legion::Extensions::Handle` and `HandleRegistry` for active/latest version, reload state, pending reload, hot-reload eligibility, errors, and owned resources.
- Made `/api/extension_catalog` and `/api/stats` derive runtime status from handles instead of ivars or the thin catalog alone.
- Added dispatch quiescing through `Legion::Ingress`, subscription actors, and `Legion::Extensions.dispatch_allowed?` so stopping/updating extensions do not accept new work.
- Added extension-owned tool unregister support and records discovered tool ownership on handles.
- Added `Legion::Extensions.reload_extension` plus public `Ingress.reset_runner_cache!` for scoped reload cleanup.
- Delays `LexRegister` publication until after extension autobuild and runtime side effects complete.
- Bumped `legionio` to `1.9.1` and updated `CHANGELOG.md`.

## Why
The adversarial review found the previous implementation only started Phase 1 and still leaked stale callable state, counted failed/stopped extensions as loaded, and published durable registration before load success.

## Validation
- `bundle exec rubocop -A`
- `bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt`