### PR TITLE
[codex] Skip no-op extension catalog writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /.yardoc
 Gemfile.lock
+*.gem
 /_yardoc/
 /coverage/
 /doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.9.3] - 2026-04-27
+
+### Fixed
+- Extension catalog persistence now skips no-op startup updates when the stored state already matches, reducing local SQLite write churn. Fixes #176
+
 ## [1.9.2] - 2026-04-27
 
 ### Fixed

--- a/lib/legion/extensions/catalog.rb
+++ b/lib/legion/extensions/catalog.rb
@@ -85,6 +85,8 @@ module Legion
             pending.each do |lex_name, new_state|
               existing = model.where(lex_name: lex_name).first
               if existing
+                next if existing.respond_to?(:state) && existing.state == new_state.to_s
+
                 existing.update(state: new_state.to_s, updated_at: now)
               else
                 model.insert(lex_name: lex_name, state: new_state.to_s, created_at: now, updated_at: now)

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.2'
+  VERSION = '1.9.3'
 end

--- a/spec/legion/extensions/catalog_spec.rb
+++ b/spec/legion/extensions/catalog_spec.rb
@@ -184,5 +184,31 @@ RSpec.describe Legion::Extensions::Catalog do
         path: kind_of(String)
       )
     end
+
+    it 'skips persisted transition updates when the stored state is unchanged' do
+      connection = double('Sequel::Database', tables: [:extension_catalog])
+      existing = double('ExtensionCatalogRow', state: 'loaded')
+      dataset = instance_double('Sequel::Dataset', first: existing)
+      model = double('Sequel::Model', where: dataset)
+      local = Module.new do
+        class << self
+          attr_accessor :connection
+        end
+
+        def self.connected? = true
+        def self.registered_migrations = { extension_catalog: '/tmp/extension_catalog' }
+      end
+      local.connection = connection
+      allow(connection).to receive(:transaction) { |&blk| blk.call }
+      allow(local).to receive(:model).with(:extension_catalog).and_return(model)
+      allow(existing).to receive(:update)
+      stub_const('Legion::Data::Local', local)
+
+      described_class.register('lex-detect')
+      described_class.transition('lex-detect', :loaded)
+      described_class.flush_persisted_transitions
+
+      expect(existing).not_to have_received(:update)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Skips extension catalog persistence updates when the stored state already matches.
- Avoids touching updated_at on every startup for unchanged extension states.
- Adds regression coverage and bumps version/changelog.

## Validation
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A
- git diff --check
