### PR TITLE
LLM extension load phase: phased boot, message resilience, provider self-registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.9.22] - 2026-05-06
+
+### Changed
+- Hot-reloading a `lex-llm-*` provider extension now asks `Legion::LLM::Call::Providers` to rediscover loaded provider modules, keeping LLM provider instances aligned after extension updates.
+- Bumped the packaged `legion-llm` dependency floor to `>= 0.9.1` for LLM-owned provider registration and reload-safe registry rebuilds.
+
 ## [1.9.21] - 2026-05-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.9.20] - 2026-05-06
+
+### Fixed
+- Nested LEX extensions now merge default settings into their nested `extensions` path (for example `lex-foo-bar` -> `extensions.foo.bar`) while underscored flat extensions continue to use the flat key (for example `lex-foo_bar` -> `extensions.foo_bar`).
+- Extension load-time settings checks now use the discovered settings path for nested extensions, keeping `enabled`, `min_version`, `workers`, and `remote_invocable` overrides aligned with where defaults are merged.
+
 ## [1.9.19] - 2026-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [1.9.21] - 2026-05-06
+
+### Changed
+- LegionIO now mounts `Legion::LLM::Routes` through the library route selector when `legion-llm` is available, leaving LLM API ownership with `legion-llm` instead of registering partial fallback routes first.
+- LLM provider health API and CLI output now require native `Legion::LLM::Inventory` data and return a clear unavailable response when inventory is not loaded.
+- Bumped packaged dependency floors to `legion-llm >= 0.9.0` and `legion-data >= 1.8.0` for the coordinated LLM route/schema sweep.
+
+### Fixed
+- Lite and local mode startup now write development mode through the public `Legion::Settings.set_prop` API.
+
+### Removed
+- Removed active `lex-llm-gateway` fallback paths from LLM chat, provider health, extension catalog, role filtering, and README documentation.
+
 ## [1.9.20] - 2026-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.9.19] - 2026-05-05
+
+### Added
+- `UnrecoverableMessageError` for messages that should be dead-lettered immediately (e.g., missing IV header on encrypted messages) instead of retried.
+- Subscription actors now extract `message_id` and `correlation_id` from AMQP metadata into the message hash for downstream tracing.
+- Runner builder auto-includes `Helpers::Lex` into runner modules when available, ensuring all runners have LEX metadata helpers.
+
+### Fixed
+- Encrypted messages (`encrypted/cs`) with a missing `iv` header now raise `UnrecoverableMessageError` and are dead-lettered rather than crashing with a nil argument to `Crypt.decrypt`.
+
 ## [1.9.18] - 2026-04-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.9.23] - 2026-05-07
+
+### Fixed
+- Fixed encrypted subscription handling to accept both string-keyed and symbol-keyed IV headers before decrypting `encrypted/cs` AMQP payloads.
+
 ## [1.9.22] - 2026-05-06
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -28,28 +28,32 @@ def local_gem_path(name, default_path, version_file, requirement)
   default_path
 end
 
+gem 'legion-apollo', path: '../legion-apollo' if File.exist?(File.expand_path('../legion-apollo', __dir__))
 gem 'legion-data', path: '../legion-data' if File.exist?(File.expand_path('../legion-data', __dir__))
+gem 'legion-logging', path: '../legion-logging' if File.exist?(File.expand_path('../legion-logging', __dir__))
+gem 'legion-settings', path: '../legion-settings' if File.exist?(File.expand_path('../legion-settings', __dir__))
+if (legion_tty_path = local_gem_path('legion-tty', '../legion-tty', 'lib/legion/tty/version.rb', '>= 0.5.4'))
+  gem 'legion-tty', path: legion_tty_path
+end
+
 gem 'legion-gaia', path: '../legion-gaia' if File.exist?(File.expand_path('../legion-gaia', __dir__))
 if (legion_llm_path = local_gem_path('legion-llm', '../legion-llm', 'lib/legion/llm/version.rb', '>= 0.8.47'))
   gem 'legion-llm', path: legion_llm_path
 end
-if (legion_tty_path = local_gem_path('legion-tty', '../legion-tty', 'lib/legion/tty/version.rb', '>= 0.5.4'))
-  gem 'legion-tty', path: legion_tty_path
-end
-gem 'legion-logging', path: '../legion-logging' if File.exist?(File.expand_path('../legion-logging', __dir__))
 gem 'legion-mcp', path: '../legion-mcp' if File.exist?(File.expand_path('../legion-mcp', __dir__))
-gem 'legion-settings', path: '../legion-settings' if File.exist?(File.expand_path('../legion-settings', __dir__))
 
-gem 'legion-apollo', path: '../legion-apollo' if File.exist?(File.expand_path('../legion-apollo', __dir__))
-gem 'lex-agentic-memory', path: '../extensions-agentic/lex-agentic-memory' if File.exist?(File.expand_path('../extensions-agentic/lex-agentic-memory', __dir__))
+gem 'lex-kerberos'
+
+gem 'lex-apollo', path: '../extensions/lex-apollo' if File.exist?(File.expand_path('../extensions/lex-apollo', __dir__))
 gem 'lex-llm', path: '../extensions-ai/lex-llm' if File.exist?(File.expand_path('../extensions-ai/lex-llm', __dir__))
 gem 'lex-llm-ledger', path: '../extensions-ai/lex-llm-ledger' if File.exist?(File.expand_path('../extensions-ai/lex-llm-ledger', __dir__))
+
 %w[anthropic azure-foundry bedrock gemini mlx ollama openai vertex vllm].each do |provider|
   provider_path = "../extensions-ai/lex-llm-#{provider}"
   gem "lex-llm-#{provider}", path: provider_path if File.exist?(File.expand_path(provider_path, __dir__))
 end
-gem 'lex-llm-gateway', path: '../extensions/lex-llm-gateway' if File.exist?(File.expand_path('../extensions/lex-llm-gateway', __dir__))
-gem 'lex-microsoft_teams', path: '../extensions/lex-microsoft_teams' if File.exist?(File.expand_path('../extensions/lex-microsoft_teams', __dir__))
+
+# gem 'lex-microsoft_teams', path: '../extensions/lex-microsoft_teams' if File.exist?(File.expand_path('../extensions/lex-microsoft_teams', __dir__))
 
 gem 'pg'
 

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Coordinated by [legion-gaia](https://github.com/LegionIO/legion-gaia), the cogni
 
 Powered by [legion-llm](https://github.com/LegionIO/legion-llm) with provider-neutral model offerings, local and fleet routing, hosted cloud providers, health tracking, metering, and automatic model discovery.
 
-`lex-llm-gateway` remains available only as legacy compatibility glue for older deployments. New `legion setup llm` and `legion setup agentic` installs use the native `legion-llm` / `lex-llm-*` stack and do not install the gateway by default.
+LLM API routes are mounted from `legion-llm` when available; LegionIO only hosts those route modules and does not provide a provider gateway fallback.
 
 ### Service Integrations (8 common + 15 additional)
 

--- a/legionio.gemspec
+++ b/legionio.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'legion-cache', '>= 1.3.22'
   spec.add_dependency 'legion-crypt', '>= 1.5.1'
-  spec.add_dependency 'legion-data', '>= 1.6.19'
+  spec.add_dependency 'legion-data', '>= 1.8.0'
   spec.add_dependency 'legion-json', '>= 1.2.1'
   spec.add_dependency 'legion-logging', '>= 1.5.0'
   spec.add_dependency 'legion-settings', '>= 1.3.25'
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'legion-apollo', '>= 0.4.0'
   spec.add_dependency 'legion-gaia', '>= 0.9.26'
-  spec.add_dependency 'legion-llm', '>= 0.8.47'
+  spec.add_dependency 'legion-llm', '>= 0.9.0'
   spec.add_dependency 'legion-tty', '>= 0.5.4'
   spec.add_dependency 'lex-node'
 end

--- a/legionio.gemspec
+++ b/legionio.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'legion-apollo', '>= 0.4.0'
   spec.add_dependency 'legion-gaia', '>= 0.9.26'
-  spec.add_dependency 'legion-llm', '>= 0.9.0'
+  spec.add_dependency 'legion-llm', '>= 0.9.1'
   spec.add_dependency 'legion-tty', '>= 0.5.4'
   spec.add_dependency 'lex-node'
 end

--- a/lib/legion/api/llm.rb
+++ b/lib/legion/api/llm.rb
@@ -24,49 +24,52 @@ module Legion
                 Legion::Cache.connected?
             end
 
-            define_method(:gateway_available?) do
-              defined?(Legion::Extensions::Llm::Gateway::Runners::Inference)
-            end
-
             define_method(:native_provider_stats_available?) do
               defined?(Legion::LLM::Inventory) && Legion::LLM::Inventory.respond_to?(:providers)
             end
 
-            define_method(:provider_health_report) do
-              if native_provider_stats_available?
-                groups = Legion::LLM::Inventory.providers
-                return [] unless groups.respond_to?(:map)
+            define_method(:require_llm_chat!) do
+              return if defined?(Legion::LLM) && Legion::LLM.respond_to?(:chat)
 
-                groups.map do |provider, offerings|
-                  provider_offerings = Array(offerings)
-                  health = provider_offerings.map { |offering| offering_value(offering, :health) }
-                                             .find { |entry| entry.is_a?(Hash) } || {}
-                  circuit = health[:circuit_state] || health['circuit_state'] || 'unknown'
-                  {
-                    provider:   provider.to_s,
-                    circuit:    circuit,
-                    adjustment: health[:adjustment] || health['adjustment'] || 0,
-                    healthy:    circuit.to_s != 'open',
-                    offerings:  provider_offerings.size,
-                    models:     provider_offerings.map { |offering| offering_value(offering, :model) }.compact.uniq,
-                    types:      provider_offerings.map { |offering| offering_value(offering, :type) }.compact.uniq,
-                    instances:  provider_offerings.map do |offering|
-                      offering_value(offering, :provider_instance) || offering_value(offering, :instance_id)
-                    end.compact.uniq
-                  }
-                end
-              elsif defined?(Legion::Extensions::Llm::Gateway::Runners::ProviderStats)
-                Legion::Extensions::Llm::Gateway::Runners::ProviderStats.health_report
-              else
-                []
+              halt 503, json_error('llm_chat_unavailable',
+                                   'Legion::LLM.chat is not available',
+                                   status_code: 503)
+            end
+
+            define_method(:require_provider_inventory!) do
+              return if native_provider_stats_available?
+
+              halt 503, json_error('providers_unavailable',
+                                   'LLM provider inventory is not loaded',
+                                   status_code: 503)
+            end
+
+            define_method(:provider_health_report) do
+              groups = Legion::LLM::Inventory.providers
+              return [] unless groups.respond_to?(:map)
+
+              groups.map do |provider, offerings|
+                provider_offerings = Array(offerings)
+                health = provider_offerings.map { |offering| offering_value(offering, :health) }
+                                           .find { |entry| entry.is_a?(Hash) } || {}
+                circuit = health[:circuit_state] || health['circuit_state'] || 'unknown'
+                {
+                  provider:   provider.to_s,
+                  circuit:    circuit,
+                  adjustment: health[:adjustment] || health['adjustment'] || 0,
+                  healthy:    circuit.to_s != 'open',
+                  offerings:  provider_offerings.size,
+                  models:     provider_offerings.map { |offering| offering_value(offering, :model) }.compact.uniq,
+                  types:      provider_offerings.map { |offering| offering_value(offering, :type) }.compact.uniq,
+                  instances:  provider_offerings.map do |offering|
+                    offering_value(offering, :provider_instance) || offering_value(offering, :instance_id)
+                  end.compact.uniq
+                }
               end
             end
 
             define_method(:provider_circuit_summary) do
               report = provider_health_report
-              return Legion::Extensions::Llm::Gateway::Runners::ProviderStats.circuit_summary if
-                report.empty? && defined?(Legion::Extensions::Llm::Gateway::Runners::ProviderStats)
-
               circuits = report.map { |entry| entry[:circuit].to_s }
               {
                 total:     report.size,
@@ -78,16 +81,10 @@ module Legion
 
             define_method(:provider_detail) do |provider|
               provider_name = provider.to_s
-              if native_provider_stats_available?
-                entry = provider_health_report.find { |candidate| candidate[:provider] == provider_name }
-                halt 404, json_error('provider_not_found', "Provider '#{provider_name}' not found", status_code: 404) unless entry
+              entry = provider_health_report.find { |candidate| candidate[:provider] == provider_name }
+              halt 404, json_error('provider_not_found', "Provider '#{provider_name}' not found", status_code: 404) unless entry
 
-                entry
-              elsif defined?(Legion::Extensions::Llm::Gateway::Runners::ProviderStats)
-                Legion::Extensions::Llm::Gateway::Runners::ProviderStats.provider_detail(provider: provider_name.to_sym)
-              else
-                halt 503, json_error('providers_unavailable', 'LLM provider inventory is not loaded', status_code: 503)
-              end
+              entry
             end
 
             define_method(:offering_value) do |offering, key|
@@ -157,55 +154,14 @@ module Legion
               end
             end
 
+            require_llm_chat!
+
             request_id = body[:request_id] || SecureRandom.uuid
             model      = body[:model]
             provider   = body[:provider]
 
-            # Compatibility fallback for legacy gateway installs. Native legion-llm handles routing first.
-            if !Legion::LLM.respond_to?(:chat) && gateway_available?
-              ingress_result = Legion::Ingress.run(
-                payload:      { message: message, model: model, provider: provider,
-                                request_id: request_id },
-                runner_class: 'Legion::Extensions::Llm::Gateway::Runners::Inference',
-                function:     'chat',
-                source:       'api'
-              )
-
-              unless ingress_result[:success]
-                Legion::Logging.error "[api/llm/chat] ingress failed: #{ingress_result}"
-                return json_response({ error: ingress_result[:error] || ingress_result[:status] },
-                                     status_code: 502)
-              end
-
-              result = ingress_result[:result]
-
-              if result.nil?
-                Legion::Logging.warn "[api/llm/chat] runner returned nil (status=#{ingress_result[:status]})"
-                return json_response({ error: { code:    'empty_result',
-                                                message: 'Gateway runner returned no result' } },
-                                     status_code: 502)
-              end
-
-              response_content = if result.respond_to?(:content)
-                                   result.content
-                                 elsif result.is_a?(Hash) && result[:error]
-                                   return json_response({ error: result[:error] }, status_code: 502)
-                                 elsif result.is_a?(Hash)
-                                   result[:response] || result[:content] || result.to_s
-                                 else
-                                   result.to_s
-                                 end
-
-              meta = { routed_via: 'gateway' }
-              meta[:model] = result.model.to_s if result.respond_to?(:model)
-              meta[:tokens_in] = result.input_tokens if result.respond_to?(:input_tokens)
-              meta[:tokens_out] = result.output_tokens if result.respond_to?(:output_tokens)
-
-              return json_response({ response: response_content, meta: meta }, status_code: 201)
-            end
-
             # Fallback: direct LLM call (no metering, no task tracking)
-            if cache_available? && env['HTTP_X_LEGION_SYNC'] != 'true'
+            if cache_available? && env['HTTP_X_LEGION_SYNC'] != 'true' && Legion::LLM.respond_to?(:chat_direct)
               llm = Legion::LLM
               rc  = Legion::LLM::ResponseCache
               rc.init_request(request_id)
@@ -469,6 +425,7 @@ module Legion
         def self.register_providers(app)
           app.get '/api/llm/providers' do
             require_llm!
+            require_provider_inventory!
 
             json_response({
                             providers: provider_health_report,
@@ -478,6 +435,7 @@ module Legion
 
           app.get '/api/llm/providers/:name' do
             require_llm!
+            require_provider_inventory!
 
             json_response(provider_detail(params[:name]))
           end

--- a/lib/legion/cli/chat/tools/provider_health.rb
+++ b/lib/legion/cli/chat/tools/provider_health.rb
@@ -75,7 +75,7 @@ module Legion
           end
 
           def provider_stats_available?
-            native_provider_stats_available? || gateway_stats_available?
+            native_provider_stats_available?
           end
 
           def native_provider_stats_available?
@@ -83,9 +83,7 @@ module Legion
           end
 
           def provider_health_report
-            return native_provider_health_report if native_provider_stats_available?
-
-            stats_module.health_report
+            native_provider_health_report
           end
 
           def native_provider_health_report
@@ -113,8 +111,6 @@ module Legion
           end
 
           def provider_circuit_summary(report)
-            return stats_module.circuit_summary unless native_provider_stats_available?
-
             circuits = report.map { |entry| entry[:circuit].to_s }
             {
               total:     report.size,
@@ -126,8 +122,6 @@ module Legion
 
           def provider_detail(provider)
             provider_name = provider.to_s
-            return stats_module.provider_detail(provider: provider_name.to_sym) unless native_provider_stats_available?
-
             provider_health_report.find { |entry| entry[:provider] == provider_name } || {}
           end
 
@@ -135,14 +129,6 @@ module Legion
             return unless offering.respond_to?(:[])
 
             offering[key] || offering[key.to_s]
-          end
-
-          def gateway_stats_available?
-            defined?(Legion::Extensions::Llm::Gateway::Runners::ProviderStats)
-          end
-
-          def stats_module
-            Legion::Extensions::Llm::Gateway::Runners::ProviderStats
           end
         end
       end

--- a/lib/legion/extensions.rb
+++ b/lib/legion/extensions.rb
@@ -143,12 +143,9 @@ module Legion
       def load_phase_extensions(phase_num, entries)
         eligible = entries.filter_map do |entry|
           gem_name = entry[:gem_name]
-          ext_name = entry[:require_path].split('/').last
+          ext_settings = extension_settings_for_entry(entry)
 
-          if Legion::Settings[:extensions].key?(ext_name.to_sym) &&
-             Legion::Settings[:extensions][ext_name.to_sym].is_a?(Hash) &&
-             Legion::Settings[:extensions][ext_name.to_sym].key?(:enabled) &&
-             !Legion::Settings[:extensions][ext_name.to_sym][:enabled]
+          if ext_settings.is_a?(Hash) && ext_settings.key?(:enabled) && !ext_settings[:enabled]
             Legion::Logging.info "Skipping #{gem_name} because it's disabled"
             next
           end
@@ -239,7 +236,7 @@ module Legion
         extension.extend Legion::Extensions::Core unless extension.singleton_class.include?(Legion::Extensions::Core)
 
         ext_name = entry[:segments].join('_')
-        ext_settings = Legion::Settings[:extensions][ext_name.to_sym]
+        ext_settings = extension_settings_for_entry(entry)
         min_version = ext_settings[:min_version] if ext_settings.is_a?(Hash)
         if min_version.is_a?(String)
           begin
@@ -427,8 +424,9 @@ module Legion
       end
 
       def hook_actor(extension:, extension_name:, actor_class:, size: 1, **opts)
-        size = if Legion::Settings[:extensions].key?(extension_name.to_sym) && Legion::Settings[:extensions][extension_name.to_sym].key?(:workers)
-                 Legion::Settings[:extensions][extension_name.to_sym][:workers]
+        ext_settings = extension_settings_for_actor(extension_name, opts[:settings_path])
+        size = if ext_settings.is_a?(Hash) && ext_settings.key?(:workers)
+                 ext_settings[:workers]
                elsif size.is_a? Integer
                  size
                else
@@ -595,7 +593,7 @@ module Legion
 
       def resolve_subscription_worker_count(actor_hash)
         ext_name = actor_hash[:extension_name]
-        ext_settings = Legion::Settings.dig(:extensions, ext_name.to_sym)
+        ext_settings = extension_settings_for_actor(ext_name, actor_hash[:settings_path])
         if ext_settings.is_a?(Hash) && ext_settings.key?(:workers)
           ext_settings[:workers]
         elsif actor_hash[:size].is_a?(Integer)
@@ -606,8 +604,7 @@ module Legion
       end
 
       def resolve_remote_invocable(extension_name, opts = {})
-        ext_key = extension_name.to_sym
-        ext_settings = Legion::Settings.dig(:extensions, ext_key)
+        ext_settings = extension_settings_for_actor(extension_name, opts[:settings_path])
         runner_name = opts[:actor_name]&.to_sym
 
         # 1. Per-runner settings override
@@ -955,6 +952,21 @@ module Legion
         nil
       end
 
+      def extension_settings_for_entry(entry)
+        extension_settings_for_path(entry[:settings_path])
+      end
+
+      def extension_settings_for_actor(extension_name, settings_path)
+        extension_settings_for_path(settings_path) || Legion::Settings.dig(:extensions, extension_name.to_sym)
+      end
+
+      def extension_settings_for_path(settings_path)
+        path = Array(settings_path).map(&:to_sym)
+        return nil if path.empty?
+
+        Legion::Settings.dig(:extensions, *path)
+      end
+
       def reset_runner_cache
         return unless defined?(Legion::Ingress) && Legion::Ingress.respond_to?(:reset_runner_cache!)
 
@@ -1119,7 +1131,16 @@ module Legion
         end
 
         { gem_name: gem_name, category: category, tier: tier,
-          segments: segments, const_path: const_path, require_path: require_path }
+          segments: segments, const_path: const_path, require_path: require_path,
+          settings_path: settings_path_for_entry(segments, nesting) }
+      end
+
+      def settings_path_for_entry(segments, nesting)
+        if nesting
+          segments.map(&:to_sym)
+        else
+          [segments.join('_').to_sym]
+        end
       end
 
       def probe_nesting(gem_name, segments)

--- a/lib/legion/extensions.rb
+++ b/lib/legion/extensions.rb
@@ -757,7 +757,7 @@ module Legion
       end
 
       def legacy_ai_extension_names
-        %w[azure-ai bedrock claude foundry gemini llm-gateway ollama openai xai].freeze
+        %w[azure-ai bedrock claude foundry gemini ollama openai xai].freeze
       end
 
       def service_extension_names

--- a/lib/legion/extensions.rb
+++ b/lib/legion/extensions.rb
@@ -911,6 +911,7 @@ module Legion
         entry = @extensions&.find { |candidate| candidate[:gem_name] == gem_name }
         raise "#{gem_name} failed to reload" if entry && !load_extension(entry)
 
+        refresh_llm_provider_registry(gem_name)
         update_extension_handle(gem_name, state: :running, reload_state: :idle, last_error: nil,
                                           latest_installed_version: latest_installed_version(gem_name))
         true
@@ -921,6 +922,13 @@ module Legion
 
       def extension_handle_registry
         @extension_handle_registry ||= HandleRegistry.new
+      end
+
+      def refresh_llm_provider_registry(gem_name)
+        return unless gem_name.start_with?('lex-llm-') && gem_name != 'lex-llm-ledger'
+        return unless defined?(Legion::LLM::Call::Providers)
+
+        Legion::LLM::Call::Providers.rediscover_all_providers
       end
 
       def transition_loaded_extensions(state)

--- a/lib/legion/extensions/actors/subscription.rb
+++ b/lib/legion/extensions/actors/subscription.rb
@@ -164,11 +164,14 @@ module Legion
           on_cancellation = block { cancel }
 
           @consumer = @queue.subscribe(manual_ack: manual_ack, block: false, consumer_tag: consumer_tag, on_cancellation: on_cancellation) do |*rmq_message|
-            payload = rmq_message.pop
-            metadata = rmq_message.last
-            delivery_info = rmq_message.first
-
+            delivery_info = nil
+            metadata = nil
+            payload = nil
             fn = nil
+
+            delivery_info = rmq_message.first
+            metadata = rmq_message.last
+            payload = rmq_message.pop
             message = process_message(payload, metadata, delivery_info)
             fn = find_function(message)
             log.debug "[Subscription] message received: #{lex_name}/#{fn}" if defined?(log)
@@ -197,11 +200,11 @@ module Legion
           rescue UnrecoverableMessageError => e
             handle_exception(e, lex: lex_name, fn: fn)
             log.warn "[Subscription] dead-lettering unrecoverable message for #{lex_name}/#{fn}: #{e.message}"
-            @queue.reject(delivery_info.delivery_tag, requeue: false) if manual_ack
+            @queue.reject(delivery_info.delivery_tag, requeue: false) if manual_ack && delivery_info
           rescue StandardError => e
             handle_exception(e)
             log.warn "[Subscription] retry-or-dlq for #{lex_name}/#{fn}"
-            reject_or_retry(delivery_info, metadata, payload) if manual_ack
+            reject_or_retry(delivery_info, metadata, payload) if manual_ack && delivery_info
           end
           log.info "[Subscription] subscribed: #{lex_name}/#{runner_name} (consumer registered)" if defined?(log)
         end

--- a/lib/legion/extensions/actors/subscription.rb
+++ b/lib/legion/extensions/actors/subscription.rb
@@ -9,6 +9,8 @@ require 'securerandom'
 module Legion
   module Extensions
     module Actors
+      class UnrecoverableMessageError < StandardError; end
+
       class Subscription
         extend Legion::Extensions::Actors::Dsl
         include Concurrent::Async
@@ -62,7 +64,7 @@ module Legion
           true
         end
 
-        def prepare
+        def prepare # rubocop:disable Metrics/AbcSize
           @queue = queue.new
           @queue.channel.prefetch(prefetch) if defined? prefetch
           consumer_tag = "#{Legion::Settings[:client][:name]}_#{lex_name}_#{runner_name}_#{SecureRandom.uuid}"
@@ -90,6 +92,10 @@ module Legion
             @queue.acknowledge(delivery_info.delivery_tag) if manual_ack
 
             cancel if Legion::Settings[:client][:shutting_down]
+          rescue UnrecoverableMessageError => e
+            handle_exception(e, lex: lex_name, fn: fn, routing_key: delivery_info.routing_key)
+            log.warn "[Subscription] dead-lettering unrecoverable message for #{lex_name}/#{fn}: #{e.message}"
+            @queue.reject(delivery_info.delivery_tag, requeue: false) if manual_ack
           rescue StandardError => e
             handle_exception(e, lex: lex_name, fn: fn, routing_key: delivery_info.routing_key)
             reject_or_retry(delivery_info, metadata, payload) if manual_ack
@@ -112,9 +118,12 @@ module Legion
           true
         end
 
-        def process_message(message, metadata, delivery_info)
+        def process_message(message, metadata, delivery_info) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
           payload = if metadata.content_encoding && metadata.content_encoding == 'encrypted/cs'
-                      Legion::Crypt.decrypt(message, metadata.headers['iv'])
+                      iv = metadata.headers&.dig('iv')
+                      raise UnrecoverableMessageError, "encrypted/cs message missing iv header (#{lex_name}/#{runner_name})" if iv.nil?
+
+                      Legion::Crypt.decrypt(message, iv)
                     elsif metadata.content_encoding && metadata.content_encoding == 'encrypted/pk'
                       Legion::Crypt.decrypt_from_keypair(metadata.headers[:public_key], message)
                     else
@@ -130,6 +139,9 @@ module Legion
             message = message.merge(metadata.headers.transform_keys(&:to_sym)) unless metadata.headers.nil?
             message[:routing_key] = delivery_info[:routing_key]
           end
+
+          message[:message_id] ||= metadata.message_id if metadata.respond_to?(:message_id) && metadata.message_id
+          message[:correlation_id] ||= metadata.correlation_id if metadata.respond_to?(:correlation_id) && metadata.correlation_id
 
           message[:timestamp] = (message[:timestamp_in_ms] / 1000).round if message.key?(:timestamp_in_ms) && !message.key?(:timestamp)
           message[:datetime] = Time.at(message[:timestamp].to_i).to_datetime.to_s if message.key?(:timestamp)
@@ -182,6 +194,10 @@ module Legion
             @queue.acknowledge(delivery_info.delivery_tag) if manual_ack
 
             cancel if Legion::Settings[:client][:shutting_down]
+          rescue UnrecoverableMessageError => e
+            handle_exception(e, lex: lex_name, fn: fn)
+            log.warn "[Subscription] dead-lettering unrecoverable message for #{lex_name}/#{fn}: #{e.message}"
+            @queue.reject(delivery_info.delivery_tag, requeue: false) if manual_ack
           rescue StandardError => e
             handle_exception(e)
             log.warn "[Subscription] retry-or-dlq for #{lex_name}/#{fn}"

--- a/lib/legion/extensions/actors/subscription.rb
+++ b/lib/legion/extensions/actors/subscription.rb
@@ -120,7 +120,8 @@ module Legion
 
         def process_message(message, metadata, delivery_info) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
           payload = if metadata.content_encoding && metadata.content_encoding == 'encrypted/cs'
-                      iv = metadata.headers&.dig('iv')
+                      headers = metadata.headers || {}
+                      iv = headers['iv'] || headers[:iv]
                       raise UnrecoverableMessageError, "encrypted/cs message missing iv header (#{lex_name}/#{runner_name})" if iv.nil?
 
                       Legion::Crypt.decrypt(message, iv)

--- a/lib/legion/extensions/builders/actors.rb
+++ b/lib/legion/extensions/builders/actors.rb
@@ -29,6 +29,7 @@ module Legion
             @actors[actor_name.to_sym] = {
               extension:      lex_class.to_s.downcase,
               extension_name: extension_name,
+              settings_path:  settings_path,
               actor_name:     actor_name,
               actor_class:    Kernel.const_get(actor_class),
               type:           'literal'
@@ -50,6 +51,7 @@ module Legion
             @actors[runner.to_sym] = {
               extension:      attr[:extension],
               extension_name: attr[:extension_name],
+              settings_path:  attr[:settings_path],
               actor_name:     attr[:runner_name],
               actor_class:    Kernel.const_get(actor_class),
               type:           'meta'

--- a/lib/legion/extensions/builders/hooks.rb
+++ b/lib/legion/extensions/builders/hooks.rb
@@ -34,6 +34,7 @@ module Legion
             @hooks[hook_name.to_sym] = {
               extension:      lex_class.to_s.downcase,
               extension_name: extension_name,
+              settings_path:  settings_path,
               hook_name:      hook_name,
               hook_class:     hook_class,
               route_path:     route_path

--- a/lib/legion/extensions/builders/runners.rb
+++ b/lib/legion/extensions/builders/runners.rb
@@ -24,6 +24,7 @@ module Legion
             runner_class = "#{lex_class}::Runners::#{runner_name.split('_').collect(&:capitalize).join}"
             loaded_runner = Kernel.const_get(runner_class)
             loaded_runner.extend(Legion::Extensions::Definitions) unless loaded_runner.respond_to?(:definition)
+            ensure_lex_helpers(loaded_runner, runner_class)
             Legion::Logging.debug "[Runners] registered: #{runner_class}" if defined?(Legion::Logging)
             @runners[runner_name.to_sym] = build_runner_entry(runner_name, runner_class, loaded_runner, file)
             populate_runner_methods(runner_name, loaded_runner)
@@ -74,6 +75,19 @@ module Legion
 
         def runner_files
           @runner_files ||= find_files('runners')
+        end
+
+        private
+
+        def ensure_lex_helpers(runner_module, runner_class)
+          return unless Legion::Extensions.const_defined?(:Helpers, false) &&
+                        Legion::Extensions::Helpers.const_defined?(:Lex, false)
+
+          lex_mod = Legion::Extensions::Helpers::Lex
+          return if runner_module.ancestors.include?(lex_mod)
+
+          runner_module.include(lex_mod)
+          Legion::Logging.info "[Runners] auto-included Helpers::Lex into #{runner_class}" if defined?(Legion::Logging)
         end
       end
     end

--- a/lib/legion/extensions/builders/runners.rb
+++ b/lib/legion/extensions/builders/runners.rb
@@ -35,6 +35,7 @@ module Legion
           entry = {
             extension:       lex_class.to_s.downcase,
             extension_name:  extension_name,
+            settings_path:   settings_path,
             extension_class: lex_class,
             runner_name:     runner_name,
             runner_class:    runner_class,

--- a/lib/legion/extensions/catalog/available.rb
+++ b/lib/legion/extensions/catalog/available.rb
@@ -14,7 +14,6 @@ module Legion
           { name: 'lex-exec',         category: 'core',     description: 'Shell command execution' },
           { name: 'lex-health',       category: 'core',     description: 'Health monitoring and metrics' },
           { name: 'lex-lex',          category: 'core',     description: 'Extension management' },
-          { name: 'lex-llm-gateway',  category: 'legacy',   description: 'Legacy LLM gateway compatibility' },
           { name: 'lex-llm-ledger',   category: 'core',     description: 'LLM cost and usage ledger' },
           { name: 'lex-log',          category: 'core',     description: 'Log shipping and aggregation' },
           { name: 'lex-metering',     category: 'core',     description: 'Resource metering and accounting' },

--- a/lib/legion/extensions/core.rb
+++ b/lib/legion/extensions/core.rb
@@ -219,27 +219,9 @@ module Legion
       end
 
       def build_settings
-        defaults = deep_dup_settings_value(Legion::Settings[:default_extension_settings] || {})
-
-        if Legion::Settings[:extensions].key?(lex_name.to_sym)
-          defaults.each do |key, value|
-            Legion::Settings[:extensions][lex_name.to_sym][key.to_sym] = if Legion::Settings[:extensions][lex_name.to_sym].key?(key.to_sym)
-                                                                           deep_dup_settings_value(value).merge(Legion::Settings[:extensions][lex_name.to_sym][key.to_sym])
-                                                                         else
-                                                                           deep_dup_settings_value(value)
-                                                                         end
-          end
-        else
-          Legion::Settings[:extensions][lex_name.to_sym] = defaults
-        end
-
-        default_settings.each do |key, value|
-          Legion::Settings[:extensions][lex_name.to_sym][key.to_sym] = if Legion::Settings[:extensions][lex_name.to_sym].key?(key.to_sym)
-                                                                         deep_dup_settings_value(value).merge(Legion::Settings[:extensions][lex_name.to_sym][key.to_sym])
-                                                                       else
-                                                                         deep_dup_settings_value(value)
-                                                                       end
-        end
+        target = extension_settings_target
+        merge_extension_defaults!(target, Legion::Settings[:default_extension_settings] || {})
+        merge_extension_defaults!(target, default_settings)
       end
 
       def default_settings
@@ -283,6 +265,29 @@ module Legion
         end
       rescue TypeError
         value
+      end
+
+      def extension_settings_target
+        settings_path.reduce(Legion::Settings[:extensions]) do |current, key|
+          current[key] = {} unless current[key].is_a?(Hash)
+          current[key]
+        end
+      end
+
+      def merge_extension_defaults!(target, defaults)
+        defaults.each do |key, value|
+          key = key.to_sym
+          target[key] = if target.key?(key)
+                          merge_extension_default_value(deep_dup_settings_value(value), target[key])
+                        else
+                          deep_dup_settings_value(value)
+                        end
+        end
+      end
+
+      def merge_extension_default_value(default_value, current_value)
+        merge_extension_defaults!(current_value, default_value) if default_value.is_a?(Hash) && current_value.is_a?(Hash)
+        current_value
       end
     end
   end

--- a/lib/legion/service.rb
+++ b/lib/legion/service.rb
@@ -209,7 +209,7 @@ module Legion
     def setup_local_mode
       if lite_mode?
         log.info 'Starting in lite mode (zero infrastructure)'
-        Legion::Settings[:dev] = true
+        Legion::Settings.set_prop(:dev, true)
         require 'legion/transport/local'
         require 'legion/crypt/mock_vault' if defined?(Legion::Crypt)
         return
@@ -218,7 +218,7 @@ module Legion
       return unless local_mode?
 
       log.info 'Starting in local development mode'
-      Legion::Settings[:dev] = true
+      Legion::Settings.set_prop(:dev, true)
 
       require 'legion/transport/local'
       require 'legion/crypt/mock_vault'

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.20'
+  VERSION = '1.9.21'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.19'
+  VERSION = '1.9.20'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.18'
+  VERSION = '1.9.19'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.21'
+  VERSION = '1.9.22'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.22'
+  VERSION = '1.9.23'
 end

--- a/spec/legion/api/library_routes_spec.rb
+++ b/spec/legion/api/library_routes_spec.rb
@@ -7,6 +7,13 @@ require 'legion/api'
 RSpec.describe Legion::API do
   let(:api_class) { Class.new(described_class) }
 
+  it 'mounts legion-llm routes as the primary LLM route owner during API construction' do
+    source = File.read(File.expand_path('../../../lib/legion/api.rb', __dir__))
+
+    expect(source).to include("mount_library_routes('llm', Routes::Llm, 'Legion::LLM::Routes')")
+    expect(source).not_to include('register Routes::Llm')
+  end
+
   describe '.mount_library_routes' do
     it 'prefers loaded library route modules and tracks them in discovery' do
       llm_routes = Module.new

--- a/spec/legion/api/llm_spec.rb
+++ b/spec/legion/api/llm_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe 'LLM API routes' do
   def stub_llm_started
     llm_mod = Module.new do
       def self.started? = true
+      def self.chat(*) = nil
+      def self.chat_direct(*) = nil
     end
     stub_const('Legion::LLM', llm_mod)
   end
@@ -144,108 +146,26 @@ RSpec.describe 'LLM API routes' do
     end
   end
 
-  # ──────────────────────────────────────────────────────────
-  # 201 gateway path (lex-llm-gateway available)
-  # ──────────────────────────────────────────────────────────
-
-  describe 'POST /api/llm/chat — gateway path' do
+  describe 'POST /api/llm/chat — native interface required' do
     before do
-      stub_llm_started
       stub_const('Legion::Extensions::Llm::Gateway::Runners::Inference', Module.new)
-
-      ingress_mod = Module.new
-      stub_const('Legion::Ingress', ingress_mod)
+      stub_const('Legion::Ingress', Module.new)
+      allow(Legion::Ingress).to receive(:run)
     end
 
-    it 'returns 201 with response when gateway succeeds' do
-      fake_result = double('GatewayResult',
-                           content:       'gateway response',
-                           model:         'claude-sonnet-4-6',
-                           input_tokens:  10,
-                           output_tokens: 20)
-      allow(fake_result).to receive(:respond_to?).with(:content).and_return(true)
-      allow(fake_result).to receive(:respond_to?).with(:model).and_return(true)
-      allow(fake_result).to receive(:respond_to?).with(:input_tokens).and_return(true)
-      allow(fake_result).to receive(:respond_to?).with(:output_tokens).and_return(true)
-      allow(fake_result).to receive(:is_a?).with(Hash).and_return(false)
+    it 'does not route through lex-llm-gateway when native chat is missing' do
+      llm_mod = Module.new do
+        def self.started? = true
+      end
+      stub_const('Legion::LLM', llm_mod)
 
-      allow(Legion::Ingress).to receive(:run).and_return({
-                                                           success: true,
-                                                           result:  fake_result
-                                                         })
-
-      post '/api/llm/chat', Legion::JSON.dump({ message: 'via gateway' }),
+      post '/api/llm/chat', Legion::JSON.dump({ message: 'native required' }),
            'CONTENT_TYPE' => 'application/json'
-      expect(last_response.status).to eq(201)
+
+      expect(Legion::Ingress).not_to have_received(:run)
+      expect(last_response.status).to eq(503)
       body = Legion::JSON.load(last_response.body)
-      expect(body[:data][:response]).to eq('gateway response')
-      expect(body[:data][:meta][:routed_via]).to eq('gateway')
-      expect(body[:data][:meta][:tokens_in]).to eq(10)
-    end
-
-    it 'returns 502 when ingress fails' do
-      allow(Legion::Ingress).to receive(:run).and_return({
-                                                           success: false,
-                                                           error:   'runner not found'
-                                                         })
-
-      post '/api/llm/chat', Legion::JSON.dump({ message: 'fail test' }),
-           'CONTENT_TYPE' => 'application/json'
-      expect(last_response.status).to eq(502)
-    end
-
-    it 'returns 502 when runner returns nil' do
-      allow(Legion::Ingress).to receive(:run).and_return({
-                                                           success: true,
-                                                           result:  nil,
-                                                           status:  'completed'
-                                                         })
-
-      post '/api/llm/chat', Legion::JSON.dump({ message: 'nil result' }),
-           'CONTENT_TYPE' => 'application/json'
-      expect(last_response.status).to eq(502)
-      body = Legion::JSON.load(last_response.body)
-      expect(body[:data][:error][:code]).to eq('empty_result')
-    end
-
-    it 'handles hash result with error' do
-      allow(Legion::Ingress).to receive(:run).and_return({
-                                                           success: true,
-                                                           result:  { error: 'model unavailable' }
-                                                         })
-
-      post '/api/llm/chat', Legion::JSON.dump({ message: 'hash error' }),
-           'CONTENT_TYPE' => 'application/json'
-      expect(last_response.status).to eq(502)
-    end
-
-    it 'handles hash result with response key' do
-      allow(Legion::Ingress).to receive(:run).and_return({
-                                                           success: true,
-                                                           result:  { response: 'hash response text' }
-                                                         })
-
-      post '/api/llm/chat', Legion::JSON.dump({ message: 'hash response' }),
-           'CONTENT_TYPE' => 'application/json'
-      expect(last_response.status).to eq(201)
-      body = Legion::JSON.load(last_response.body)
-      expect(body[:data][:response]).to eq('hash response text')
-    end
-
-    it 'passes correct runner params to Ingress.run' do
-      allow(Legion::Ingress).to receive(:run).and_return({ success: true, result: { response: 'ok' } })
-
-      post '/api/llm/chat',
-           Legion::JSON.dump({ message: 'test msg', model: 'gpt-4o', provider: 'openai' }),
-           'CONTENT_TYPE' => 'application/json'
-
-      expect(Legion::Ingress).to have_received(:run).with(
-        hash_including(
-          runner_class: 'Legion::Extensions::Llm::Gateway::Runners::Inference',
-          function:     'chat',
-          source:       'api'
-        )
-      )
+      expect(body[:error][:code]).to eq('llm_chat_unavailable')
     end
   end
 
@@ -413,43 +333,11 @@ RSpec.describe 'LLM API routes' do
     context 'when provider inventory is not loaded' do
       before { stub_llm_started }
 
-      it 'returns an empty provider list' do
+      it 'returns a clear unavailable response' do
         get '/api/llm/providers'
-        expect(last_response.status).to eq(200)
+        expect(last_response.status).to eq(503)
         body = Legion::JSON.load(last_response.body)
-        expect(body[:data][:providers]).to eq([])
-        expect(body[:data][:summary]).to include(total: 0, closed: 0, open: 0, half_open: 0)
-      end
-
-      it 'keeps the LegionIO provider route ahead of colliding library routes registered later' do
-        colliding_routes = Module.new do
-          def self.registered(app)
-            app.get '/api/llm/providers' do
-              json_response({ providers: [{ provider: 'legion-llm' }],
-                              summary:   { total: 1, routing_enabled: true } })
-            end
-          end
-        end
-
-        collision_app = Class.new(Sinatra::Base) do
-          helpers Legion::API::Helpers
-          helpers Legion::API::Validators
-
-          set :show_exceptions, false
-          set :raise_errors, false
-          set :host_authorization, permitted: :any
-
-          register Legion::API::Routes::Llm
-          register colliding_routes
-        end
-
-        response = Rack::MockRequest.new(collision_app).get('/api/llm/providers')
-        body = Legion::JSON.load(response.body)
-
-        expect(response.status).to eq(200)
-        expect(body[:data][:providers]).to eq([])
-        expect(body[:data][:summary]).to include(total: 0, closed: 0, open: 0, half_open: 0)
-        expect(body[:data][:summary]).not_to include(:routing_enabled)
+        expect(body[:error][:code]).to eq('providers_unavailable')
       end
     end
 
@@ -503,7 +391,7 @@ RSpec.describe 'LLM API routes' do
       end
     end
 
-    context 'when gateway loaded' do
+    context 'when gateway provider stats are loaded without native inventory' do
       let(:stats_mod) do
         Module.new do
           def self.health_report
@@ -525,12 +413,11 @@ RSpec.describe 'LLM API routes' do
         stub_const('Legion::Extensions::Llm::Gateway::Runners::ProviderStats', stats_mod)
       end
 
-      it 'returns 200 with providers and summary' do
+      it 'does not fall back to gateway provider stats' do
         get '/api/llm/providers'
-        expect(last_response.status).to eq(200)
+        expect(last_response.status).to eq(503)
         body = Legion::JSON.load(last_response.body)
-        expect(body[:data][:providers].length).to eq(2)
-        expect(body[:data][:summary][:total]).to eq(2)
+        expect(body[:error][:code]).to eq('providers_unavailable')
       end
     end
   end
@@ -595,12 +482,11 @@ RSpec.describe 'LLM API routes' do
         stub_const('Legion::Extensions::Llm::Gateway::Runners::ProviderStats', stats_mod)
       end
 
-      it 'returns 200 with provider detail' do
+      it 'does not fall back to gateway provider detail' do
         get '/api/llm/providers/anthropic'
-        expect(last_response.status).to eq(200)
+        expect(last_response.status).to eq(503)
         body = Legion::JSON.load(last_response.body)
-        expect(body[:data][:provider]).to eq('anthropic')
-        expect(body[:data][:healthy]).to be true
+        expect(body[:error][:code]).to eq('providers_unavailable')
       end
     end
   end

--- a/spec/legion/cli/chat/tools/provider_health_spec.rb
+++ b/spec/legion/cli/chat/tools/provider_health_spec.rb
@@ -6,29 +6,6 @@ require 'legion/cli/chat/tools/provider_health'
 RSpec.describe Legion::CLI::Chat::Tools::ProviderHealth do
   subject(:tool) { described_class.new }
 
-  let(:stats_mod) do
-    Module.new do
-      def self.health_report
-        [
-          { provider: 'anthropic', circuit: 'closed', adjustment: 0, healthy: true },
-          { provider: 'openai', circuit: 'open', adjustment: -50, healthy: false }
-        ]
-      end
-
-      def self.provider_detail(provider:)
-        { provider: provider.to_s, circuit: 'closed', adjustment: 0, healthy: true }
-      end
-
-      def self.circuit_summary
-        { total: 2, closed: 1, open: 1, half_open: 0 }
-      end
-    end
-  end
-
-  before do
-    stub_const('Legion::Extensions::Llm::Gateway::Runners::ProviderStats', stats_mod)
-  end
-
   describe '#execute' do
     context 'when native provider inventory is loaded' do
       let(:inventory_mod) do
@@ -60,7 +37,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ProviderHealth do
         stub_const('Legion::LLM::Inventory', inventory_mod)
       end
 
-      it 'returns health report from inventory before gateway stats' do
+      it 'returns health report from inventory' do
         result = tool.execute
         expect(result).to include('Provider Health Report')
         expect(result).to include('anthropic')
@@ -81,29 +58,21 @@ RSpec.describe Legion::CLI::Chat::Tools::ProviderHealth do
       end
     end
 
-    it 'returns health report by default' do
-      result = tool.execute
-      expect(result).to include('Provider Health Report')
-      expect(result).to include('anthropic')
-      expect(result).to include('openai')
-    end
-
-    it 'returns detail for a specific provider' do
-      result = tool.execute(provider: 'anthropic')
-      expect(result).to include('Provider: anthropic')
-      expect(result).to include('Healthy:    YES')
-    end
-
     it 'returns error when provider inventory is not available' do
-      hide_const('Legion::Extensions::Llm::Gateway::Runners::ProviderStats')
       result = tool.execute
       expect(result).to eq('LLM provider inventory not available.')
     end
 
-    it 'includes circuit summary in report' do
+    it 'does not fall back to legacy gateway provider stats' do
+      stats_mod = Module.new do
+        def self.health_report
+          [{ provider: 'gateway', circuit: 'closed', adjustment: 0, healthy: true }]
+        end
+      end
+      stub_const('Legion::Extensions::Llm::Gateway::Runners::ProviderStats', stats_mod)
+
       result = tool.execute
-      expect(result).to include('1 closed')
-      expect(result).to include('1 open')
+      expect(result).to eq('LLM provider inventory not available.')
     end
   end
 end

--- a/spec/legion/cli/chat/tools/summarize_traces_spec.rb
+++ b/spec/legion/cli/chat/tools/summarize_traces_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SummarizeTraces do
                                                                      max_latency_ms:   1200,
                                                                      time_range:       { from: '2026-03-22', to: '2026-03-23' },
                                                                      status_counts:    { 'success' => 140, 'failure' => 10 },
-                                                                     top_extensions:   [{ name: 'lex-llm-gateway', count: 80 }],
+                                                                     top_extensions:   [{ name: 'lex-llm-openai', count: 80 }],
                                                                      top_workers:      [{ id: 'worker-1', count: 60 }]
                                                                    })
 
@@ -32,7 +32,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SummarizeTraces do
       expect(result).to include('$3.4567')
       expect(result).to include('avg 245.3ms')
       expect(result).to include('success: 140')
-      expect(result).to include('lex-llm-gateway (80)')
+      expect(result).to include('lex-llm-openai (80)')
       expect(result).to include('worker-1 (60)')
     end
 

--- a/spec/legion/cli/trace_command_spec.rb
+++ b/spec/legion/cli/trace_command_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Legion::CLI::TraceCommand do
   let(:search_result) do
     {
       results:   [
-        { created_at: Time.utc(2026, 3, 23, 12, 0, 0), extension: 'lex-llm-gateway',
-          runner_function: 'route_request', status: 'success', cost_usd: 0.0042,
+        { created_at: Time.utc(2026, 3, 23, 12, 0, 0), extension: 'lex-llm-openai',
+          runner_function: 'chat', status: 'success', cost_usd: 0.0042,
           tokens_in: 120, tokens_out: 350, wall_clock_ms: 1200, worker_id: 'w-1' },
         { created_at: Time.utc(2026, 3, 23, 11, 30, 0), extension: 'lex-apollo',
           runner_function: 'ingest', status: 'failure', cost_usd: 0.0,
@@ -52,7 +52,7 @@ RSpec.describe Legion::CLI::TraceCommand do
     end
 
     it 'shows extension and function' do
-      expect { described_class.start(%w[search all --no-color]) }.to output(/lex-llm-gateway\.route_request/).to_stdout
+      expect { described_class.start(%w[search all --no-color]) }.to output(/lex-llm-openai\.chat/).to_stdout
     end
 
     it 'shows cost' do

--- a/spec/legion/extensions/actors/subscription_encryption_spec.rb
+++ b/spec/legion/extensions/actors/subscription_encryption_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Extensions::Actors::Subscription do
+  let(:actor) { described_class.allocate }
+  let(:delivery_info) { { routing_key: 'lex.test.runner' } }
+
+  before do
+    allow(actor).to receive(:lex_name).and_return('test')
+    allow(actor).to receive(:runner_name).and_return('runner')
+  end
+
+  describe '#process_message encrypted/cs handling' do
+    it 'decrypts with a string-keyed iv header' do
+      metadata = metadata_for(headers: { 'iv' => 'string-iv' })
+
+      expect(Legion::Crypt).to receive(:decrypt).with('ciphertext', 'string-iv').and_return('{"ok":true}')
+
+      message = actor.process_message('ciphertext', metadata, delivery_info)
+
+      expect(message).to include(ok: true, iv: 'string-iv', routing_key: 'lex.test.runner')
+    end
+
+    it 'decrypts with a symbol-keyed iv header' do
+      metadata = metadata_for(headers: { iv: 'symbol-iv' })
+
+      expect(Legion::Crypt).to receive(:decrypt).with('ciphertext', 'symbol-iv').and_return('{"ok":true}')
+
+      message = actor.process_message('ciphertext', metadata, delivery_info)
+
+      expect(message).to include(ok: true, iv: 'symbol-iv', routing_key: 'lex.test.runner')
+    end
+
+    it 'dead-letters encrypted messages that are missing an iv before decrypting' do
+      metadata = metadata_for(headers: {})
+
+      expect(Legion::Crypt).not_to receive(:decrypt)
+
+      expect do
+        actor.process_message('ciphertext', metadata, delivery_info)
+      end.to raise_error(
+        Legion::Extensions::Actors::UnrecoverableMessageError,
+        'encrypted/cs message missing iv header (test/runner)'
+      )
+    end
+
+    it 'does not decrypt identity encoded messages' do
+      metadata = metadata_for(content_encoding: 'identity', headers: { iv: 'ignored' })
+
+      expect(Legion::Crypt).not_to receive(:decrypt)
+
+      message = actor.process_message('{"ok":true}', metadata, delivery_info)
+
+      expect(message).to include(ok: true, iv: 'ignored', routing_key: 'lex.test.runner')
+    end
+  end
+
+  def metadata_for(content_encoding: 'encrypted/cs', content_type: 'application/json', headers: {})
+    instance_double(
+      Bunny::MessageProperties,
+      content_encoding: content_encoding,
+      content_type:     content_type,
+      headers:          headers
+    )
+  end
+end

--- a/spec/legion/extensions/catalog_available_spec.rb
+++ b/spec/legion/extensions/catalog_available_spec.rb
@@ -19,12 +19,8 @@ RSpec.describe Legion::Extensions::Catalog::Available do
       )
     end
 
-    it 'marks lex-llm-gateway as legacy compatibility' do
-      expect(described_class.find('lex-llm-gateway')).to include(
-        name:        'lex-llm-gateway',
-        category:    'legacy',
-        description: 'Legacy LLM gateway compatibility'
-      )
+    it 'does not advertise lex-llm-gateway' do
+      expect(described_class.find('lex-llm-gateway')).to be_nil
     end
   end
 end

--- a/spec/legion/extensions/core_spec.rb
+++ b/spec/legion/extensions/core_spec.rb
@@ -4,6 +4,54 @@ require 'spec_helper'
 require 'tmpdir'
 
 RSpec.describe Legion::Extensions::Core do
+  describe '.build_settings' do
+    around do |example|
+      original_loader = Legion::Settings.instance_variable_get(:@loader)
+      Legion::Settings.instance_variable_set(:@loader, Legion::Settings::Loader.new)
+      example.run
+    ensure
+      Legion::Settings.instance_variable_set(:@loader, original_loader)
+    end
+
+    it 'merges nested extension defaults into the nested settings path' do
+      stub_const('Legion::Extensions::Foo', Module.new)
+      stub_const('Legion::Extensions::Foo::Bar', Module.new do
+        extend Legion::Extensions::Core
+
+        def self.default_settings
+          { enabled: true, runners: { ping: { desc: 'default' } } }
+        end
+      end)
+
+      Legion::Settings[:extensions][:foo] = { bar: { enabled: false } }
+
+      Legion::Extensions::Foo::Bar.build_settings
+
+      expect(Legion::Settings.dig(:extensions, :foo, :bar)).to include(
+        enabled: false,
+        runners: { ping: { desc: 'default' } }
+      )
+      expect(Legion::Settings.dig(:extensions, :foo_bar)).to be_nil
+    end
+
+    it 'keeps flat underscored extension defaults under the flat settings key' do
+      stub_const('Legion::Extensions::FooBar', Module.new do
+        extend Legion::Extensions::Core
+
+        def self.default_settings
+          { enabled: true, workers: 1 }
+        end
+      end)
+
+      Legion::Settings[:extensions][:foo_bar] = { enabled: false }
+
+      Legion::Extensions::FooBar.build_settings
+
+      expect(Legion::Settings.dig(:extensions, :foo_bar)).to include(enabled: false, workers: 1)
+      expect(Legion::Settings.dig(:extensions, :foo)).to be_nil
+    end
+  end
+
   describe '.sticky_tools?' do
     it 'returns true by default' do
       stub_const('Legion::Extensions::StickyTest', Module.new { extend Legion::Extensions::Core })

--- a/spec/legion/extensions/find_extensions_spec.rb
+++ b/spec/legion/extensions/find_extensions_spec.rb
@@ -214,6 +214,18 @@ RSpec.describe Legion::Extensions do
       entry = result.first
       expect(entry).to include(:gem_name, :category, :tier, :segments, :const_path, :require_path)
     end
+
+    it 'derives a nested settings path for hyphenated nested extensions' do
+      entry = described_class.build_extension_entry('lex-foo-bar', :default, {}, nesting: false)
+      expect(entry[:const_path]).to eq('Legion::Extensions::Foo::Bar')
+      expect(entry[:settings_path]).to eq(%i[foo bar])
+    end
+
+    it 'derives a flat settings path for underscored flat extensions' do
+      entry = described_class.build_extension_entry('lex-foo_bar', :default, {}, nesting: false)
+      expect(entry[:const_path]).to eq('Legion::Extensions::FooBar')
+      expect(entry[:settings_path]).to eq([:foo_bar])
+    end
   end
 
   describe '.check_reserved_words' do

--- a/spec/legion/extensions/find_extensions_spec.rb
+++ b/spec/legion/extensions/find_extensions_spec.rb
@@ -272,7 +272,6 @@ RSpec.describe Legion::Extensions do
         build_entry('lex-memory',    :default, 5),
         build_entry('lex-claude',    :ai,      2),
         build_entry('lex-llm',       :ai,      2),
-        build_entry('lex-llm-gateway', :core,  1),
         build_entry('lex-llm-openai', :ai,     2),
         build_entry('lex-github',    :default, 5),
         build_entry('lex-slack',     :default, 5)
@@ -291,7 +290,7 @@ RSpec.describe Legion::Extensions do
       it 'loads all extensions' do
         allow(Legion::Settings).to receive(:[]).with(:role).and_return({ profile: nil })
         described_class.send(:apply_role_filter)
-        expect(described_class.instance_variable_get(:@extensions).count).to eq(11)
+        expect(described_class.instance_variable_get(:@extensions).count).to eq(10)
       end
     end
 
@@ -301,7 +300,7 @@ RSpec.describe Legion::Extensions do
         described_class.send(:apply_role_filter)
         names = ext_gem_names
         expect(names).to include('lex-node', 'lex-tasker', 'lex-health')
-        expect(names).not_to include('lex-attention', 'lex-llm-gateway', 'lex-slack')
+        expect(names).not_to include('lex-attention', 'lex-slack')
       end
     end
 
@@ -311,7 +310,7 @@ RSpec.describe Legion::Extensions do
         described_class.send(:apply_role_filter)
         names = ext_gem_names
         expect(names).to include('lex-node', 'lex-memory')
-        expect(names).not_to include('lex-claude', 'lex-llm', 'lex-llm-gateway', 'lex-llm-openai')
+        expect(names).not_to include('lex-claude', 'lex-llm', 'lex-llm-openai')
       end
     end
 
@@ -332,7 +331,7 @@ RSpec.describe Legion::Extensions do
         described_class.send(:apply_role_filter)
         names = ext_gem_names
         expect(names).to include('lex-node', 'lex-memory', 'lex-llm', 'lex-llm-openai')
-        expect(names).not_to include('lex-claude', 'lex-llm-gateway', 'lex-slack', 'lex-github')
+        expect(names).not_to include('lex-claude', 'lex-slack', 'lex-github')
       end
     end
 
@@ -340,7 +339,7 @@ RSpec.describe Legion::Extensions do
       it 'loads all extensions' do
         allow(Legion::Settings).to receive(:[]).with(:role).and_return({ profile: 'unknown_thing' })
         described_class.send(:apply_role_filter)
-        expect(described_class.instance_variable_get(:@extensions).count).to eq(11)
+        expect(described_class.instance_variable_get(:@extensions).count).to eq(10)
       end
     end
   end

--- a/spec/legion/extensions/runtime_handles_spec.rb
+++ b/spec/legion/extensions/runtime_handles_spec.rb
@@ -50,15 +50,15 @@ RSpec.describe Legion::Extensions do
 
   it 'matches multi-segment extension modules to hyphenated lex handles' do
     ext_mod = Module.new do
-      def self.name = 'Legion::Extensions::Llm::Gateway'
+      def self.name = 'Legion::Extensions::Llm::Openai'
       def self.runner_modules = []
     end
-    described_class.const_set(:GatewayForSpec, ext_mod)
-    described_class.register_extension_handle('lex-llm-gateway', state: :running)
+    described_class.const_set(:OpenaiForSpec, ext_mod)
+    described_class.register_extension_handle('lex-llm-openai', state: :running)
 
     expect(described_class.loaded_extension_modules).to contain_exactly(ext_mod)
   ensure
-    described_class.send(:remove_const, :GatewayForSpec) if described_class.const_defined?(:GatewayForSpec, false)
+    described_class.send(:remove_const, :OpenaiForSpec) if described_class.const_defined?(:OpenaiForSpec, false)
   end
 
   it 'does not mark a gem loaded when require fails' do

--- a/spec/legion/extensions/runtime_handles_spec.rb
+++ b/spec/legion/extensions/runtime_handles_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Legion::Extensions do
   after do
     described_class.reset_runtime_handles!
     described_class.instance_variable_set(:@loaded_extensions, nil)
+    described_class.instance_variable_set(:@extensions, nil)
   end
 
   it 'exposes extension handles without requiring callers to read ivars' do
@@ -83,5 +84,20 @@ RSpec.describe Legion::Extensions do
     expect(handle.last_error).to be_nil
     expect(described_class).to have_received(:unregister_capabilities).with('lex-example')
     expect(Legion::Ingress).to have_received(:reset_runner_cache!)
+  end
+
+  it 'refreshes the LLM provider registry after hot-reloading a lex-llm provider extension' do
+    providers = Module.new do
+      def self.rediscover_all_providers; end
+    end
+    stub_const('Legion::LLM::Call::Providers', providers)
+    allow(providers).to receive(:rediscover_all_providers)
+    allow(described_class).to receive(:unregister_capabilities)
+    allow(described_class).to receive(:load_extension).and_return(true)
+    described_class.instance_variable_set(:@extensions, [{ gem_name: 'lex-llm-vllm' }])
+
+    expect(described_class.reload_extension('lex-llm-vllm')).to be true
+
+    expect(providers).to have_received(:rediscover_all_providers)
   end
 end

--- a/spec/legion/service_lite_spec.rb
+++ b/spec/legion/service_lite_spec.rb
@@ -21,4 +21,17 @@ RSpec.describe Legion::Service do
       expect(service.lite_mode?).to be true
     end
   end
+
+  describe '#setup_local_mode' do
+    it 'marks dev mode through the public settings writer in lite mode' do
+      service = described_class.allocate
+      allow(Legion::Mode).to receive(:lite?).and_return(true)
+      allow(service).to receive(:require).with('legion/transport/local')
+      allow(service).to receive(:require).with('legion/crypt/mock_vault')
+
+      expect(Legion::Settings).to receive(:set_prop).with(:dev, true)
+
+      service.__send__(:setup_local_mode)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- **Phased extension loading**: identity providers (phase 0) fully boot before other extensions (phase 1), ensuring auth/encryption infrastructure is available at startup.
- **Nested extension settings paths**: nested `lex-*` gems now merge and read default settings through their discovered settings path, so `lex-foo-bar` writes to `extensions.foo.bar` while `lex-foo_bar` stays at `extensions.foo_bar`.
- **LLM route ownership**: LegionIO now mounts `Legion::LLM::Routes` from `legion-llm` when available instead of keeping partial fallback API ownership locally.
- **LLM gateway removal**: active `lex-llm-gateway` fallback paths were removed from chat, provider health, extension catalog, role filtering, and docs.
- **LLM dependency sweep**: packaged floors now require `legion-llm >= 0.9.0` and `legion-data >= 1.8.0` for the coordinated provider/schema work.
- **Message resilience**: encrypted messages missing IV headers are now dead-lettered immediately via `UnrecoverableMessageError` instead of crashing; AMQP `message_id` and `correlation_id` propagate into the message hash for tracing.
- **Runner builder hardening**: auto-includes `Helpers::Lex` into runner modules when available.
- **Catalog write optimization**: skip no-op extension catalog writes at startup.
- Bumps version to 1.9.21.

## Test plan
- [x] `bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt`
- [x] `bundle exec rubocop -A`
- [ ] Verify encrypted message without IV header is dead-lettered (not retried)
- [ ] Verify `message_id`/`correlation_id` appear in runner payloads
- [ ] Confirm LLM providers register without RubyLLM gem loaded
- [ ] Confirm phase 0 identity extensions load before phase 1 extensions
