### PR TITLE
Remove deprecated direct AI provider extensions from catalog

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--exclude-pattern spec/live/**/*_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.9.26] - 2026-05-07
+
+### Fixed
+- Use the local `Legion::Identity::Process` identity for unauthenticated loopback API principals even when the process is only fallback-bound, avoiding generic `system:system` attribution in downstream LLM audit flows.
+
 ## [1.9.25] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.9.27] - 2026-05-08
+
+### Fixed
+- Preserve omitted `/api/llm/inference` client tool definitions as absent instead of `tools: []`, allowing legion-llm registry and trigger-based tool injection to run for normal API requests.
+
 ## [1.9.26] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 ## [Unreleased]
 
+## [1.9.28] - 2026-05-08
+
+### Fixed
+- Task outcome observation now ignores internal runner completions without task ids, preventing periodic mesh gossip ticks from feeding meta-learning and Apollo ingestion.
+- Identity resolver database persistence now targets the current identity provider, principal, identity, and audit log schema.
+
 ## [1.9.27] - 2026-05-08
 
 ### Fixed
 - Preserve omitted `/api/llm/inference` client tool definitions as absent instead of `tools: []`, allowing legion-llm registry and trigger-based tool injection to run for normal API requests.
+- Added an opt-in live daemon integration spec suite that uses explicit Faraday test dependencies and its own isolated RSpec helper.
 
 ## [1.9.26] - 2026-05-07
 
@@ -20,7 +27,7 @@
 ## [1.9.24] - 2026-05-07
 
 ### Changed
-- Removed deprecated direct AI provider extensions (`lex-bedrock`, `lex-claude`, `lex-gemini`, `lex-ollama`, `lex-openai`) from the extension catalog; use their `lex-llm-*` counterparts instead.
+- Removed deprecated direct AI provider extensions (`lex-azure-ai`, `lex-bedrock`, `lex-claude`, `lex-foundry`, `lex-gemini`, `lex-ollama`, `lex-openai`) from the extension catalog; use their `lex-llm-*` counterparts instead.
 
 ## [1.9.23] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.9.25] - 2026-05-07
+
+### Fixed
+- Updated identity model references in `identity_audit.rb` and `identity/broker.rb` to use the portable namespace (`Identity::AuditLog`, `Identity::Principal`, `Identity::GroupMembership`) after legacy top-level identity models were removed from legion-data.
+
 ## [1.9.24] - 2026-05-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.9.24] - 2026-05-07
+
+### Changed
+- Removed deprecated direct AI provider extensions (`lex-bedrock`, `lex-claude`, `lex-gemini`, `lex-ollama`, `lex-openai`) from the extension catalog; use their `lex-llm-*` counterparts instead.
+
 ## [1.9.23] - 2026-05-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,805 +1,98 @@
-# LegionIO: Async Job Engine and Task Framework
+# LegionIO
 
-**Repository Level 3 Documentation**
-- **Parent**: `../CLAUDE.md`
-
-## Purpose
-
-The primary gem for the LegionIO framework. An extensible async job engine for scheduling tasks, creating relationships between services, and running them concurrently via RabbitMQ. Orchestrates all `legion-*` gems and loads Legion Extensions (LEXs).
+Primary gem. Orchestrates all `legion-*` gems and loads LEX extensions.
 
 **GitHub**: https://github.com/LegionIO/LegionIO
-**Gem**: `legionio`
-**Version**: 1.8.12
-**License**: Apache-2.0
-**Docker**: `legionio/legion`
-**Ruby**: >= 3.4
+**Gem**: `legionio` | **Ruby**: >= 3.4
 
 ## Binary Split
 
 | Binary | Purpose |
 |--------|---------|
-| `legion` | Interactive TTY shell + dev-workflow commands (chat, commit, review, plan, memory, init) |
-| `legionio` | Daemon lifecycle + all operational commands (start, stop, lex, task, config, mcp, etc.) |
+| `legion` | Interactive TTY shell + dev-workflow (chat, commit, review, plan, memory) |
+| `legionio` | Daemon lifecycle + operational commands (start, stop, lex, task, config, mcp) |
 
-`legion` with no args launches the TTY interactive shell. With args, it routes to dev-workflow subcommands.
-`legionio` is the full operational CLI — all 40+ subcommands.
+## Boot Sequence
 
-## Architecture
-
-### Boot Sequence (exe/legion)
-
-Before any Legion code loads, `exe/legion` applies three performance optimizations:
-
-1. **YJIT** — `RubyVM::YJIT.enable` for 15-30% runtime throughput (guarded with `if defined?`)
-2. **GC tuning** — pre-allocates 600k heap slots, raises malloc limits (all `||=` so ENV overrides are respected)
-3. **bootsnap** — caches YARV bytecodes and `$LOAD_PATH` resolution at `~/.legionio/cache/bootsnap/`
-
-### Startup Sequence
+`exe/legion` applies: YJIT, GC tuning (600k heap slots), bootsnap cache.
 
 ```
-Legion.start
-  └── Legion::Service.new
-      ├── 1.  setup_logging      (legion-logging)
-      ├── 2.  setup_settings     (legion-settings, loads /etc/legionio, ~/legionio, ./settings)
-      ├── 3.  Legion::Crypt.start (legion-crypt, Vault connection)
-      ├── 4.  setup_transport    (legion-transport, RabbitMQ connection)
-      ├── 5.  require legion-cache
-      ├── 6.  setup_data         (legion-data, MySQL/SQLite + migrations, optional)
-      ├── 7.  setup_rbac         (legion-rbac, optional)
-      ├── 8.  setup_llm          (legion-llm, AI provider setup + routing, optional)
-      ├── 9.  setup_apollo       (legion-apollo, shared + local knowledge store, optional)
-      ├── 10. setup_gaia         (legion-gaia, cognitive coordination layer, optional)
-      ├── 11. setup_telemetry    (OpenTelemetry, optional)
-      ├── 12. setup_supervision  (process supervision)
-      ├── 13. load_extensions    (multi-phase: phase 0 (identity providers) loads and hooks actors first, then phase 1 (everything else))
-      ├── 14. Legion::Crypt.cs   (distribute cluster secret)
-      └── 15. setup_api          (start Sinatra/Puma on port 4567)
+Legion.start → Legion::Service.new
+  1.  setup_logging
+  2.  setup_settings
+  3.  Legion::Crypt.start
+  4.  setup_transport (RabbitMQ)
+  5.  require legion-cache
+  6.  setup_data (optional)
+  7.  setup_rbac (optional)
+  8.  setup_llm (optional)
+  9.  setup_apollo (optional)
+  10. setup_gaia (optional)
+  11. setup_telemetry (optional)
+  12. setup_supervision
+  13. load_extensions (multi-phase: phase 0 identity, phase 1 everything else, parallel)
+  14. Legion::Crypt.cs (distribute cluster secret)
+  15. setup_api (Sinatra/Puma on port 4567)
 ```
 
-Each phase calls `Legion::Readiness.mark_ready(:component)`. All phases are individually toggleable via `Service.new(transport: false, ...)`.
+Extension loading: phase 0 = `lex-identity-*` (sequential), phase 1 = everything else on `Concurrent::FixedThreadPool(24)`. After all phases: catalog transitions + registry writes.
 
-Extension loading is multi-phase and parallel: `hook_extensions` calls `group_by_phase` to partition discovered extensions by phase number (from the category registry), then iterates phases sequentially. Phase 0 contains identity providers (`lex-identity-*` gems, category `:identity`, tier 0); phase 1 contains all other extensions. Within each phase, extensions are `require`d and `autobuild` runs concurrently on a `Concurrent::FixedThreadPool(min(count, extensions.parallel_pool_size))`, collecting actors into a thread-safe `Concurrent::Array` of `@pending_actors`. Pool size defaults to 24, configurable via `Legion::Settings[:extensions][:parallel_pool_size]`. After each phase's extensions are loaded, `hook_phase_actors` starts AMQP subscriptions, timers, and other actor types for that phase sequentially — ensuring identity providers are fully running before any other extension boots. Catalog transitions (`transition(:running)` and `flush_persisted_transitions`) happen after all phases complete. Thread safety relies on ThreadLocal AMQP channels, per-extension Settings keys, and sequential post-processing of Catalog transitions and Registry writes.
+## Extension Discovery
 
-### Reload Sequence
+`find_extensions` discovers `lex-*` gems via Bundler or `Gem::Specification`. Category registry determines load phase and tier. Extensions declare requirements via `data_required?`, `cache_required?`, `crypt_required?`, `vault_required?`, `llm_required?` — skipped if dependency unavailable.
 
-`Legion.reload` shuts down all subsystems in reverse order, waits for them to drain, then re-runs setup from settings onward. Extensions and API are re-loaded fresh.
+Role profiles filter extensions: `nil` (all), `:core` (14), `:cognitive` (core + agentic), `:service` (core + integrations), `:dev` (core + AI + essential agentic), `:custom` (explicit list).
 
-### Module Structure
+## CLI Design Rules
 
-```
-Legion (lib/legion.rb)
-├── Service            # Orchestrator: initializes all modules, manages lifecycle
-│                      # Entry points: Legion.start, .shutdown, .reload
-├── Process            # Daemonization: PID management, signal traps (SIGINT=quit), main loop
-├── Readiness          # Startup readiness tracking
-│                      # COMPONENTS: settings, crypt, transport, cache, data, gaia, extensions, api
-│                      # Readiness.ready? checks all; /api/ready returns JSON status
-├── Events             # In-process pub/sub event bus
-│                      # Events.on(name) / .emit(name, **payload) / .once / .off
-│                      # Wildcard '*' listener supported
-│                      # Lifecycle: service.ready, service.shutting_down, service.shutdown
-│                      # Extension: extension.loaded
-│                      # Runner: ingress.received
-├── Ingress            # Universal entry point for runner invocation
-│                      # Sources: amqp, http, cli, api — all normalize through here
-│                      # Ingress.run(payload:, runner_class:, function:, source:)
-│                      # Ingress.normalize returns message hash without executing
-├── Extensions         # LEX discovery, loading, and lifecycle management
-│   ├── Core           # Mixin: data_required?, cache_required?, crypt_required?, mcp_tools?, mcp_tools_deferred?, etc.
-│   ├── Actors/        # Actor execution modes
-│   │   ├── Base       # Base actor class
-│   │   ├── Every      # Run at interval (timer)
-│   │   ├── Loop       # Continuous loop
-│   │   ├── Once       # Run once at startup
-│   │   ├── Poll       # Polling actor
-│   │   ├── Subscription  # AMQP subscription (FixedThreadPool per worker count)
-│   │   └── Nothing    # No-op actor
-│   ├── Builders/      # Build actors and runners from LEX definitions
-│   │   ├── Actors     # Build actors from extension definitions
-│   │   ├── Runners    # Build runners from extension definitions; exposes `runner_modules` accessor for Discovery
-│   │   ├── Helpers    # Builder utilities
-│   │   ├── Hooks      # Webhook hook system builder
-│   │   └── Routes     # Auto-route builder: introspects runners, registers POST /api/extensions/* routes
-│   ├── Helpers/       # Helper mixins for extensions
-│   │   ├── Base       # Base helper mixin
-│   │   ├── Core       # Core helper mixin
-│   │   ├── Cache      # Cache access helper
-│   │   ├── Data       # Database access helper
-│   │   ├── Logger     # Logging helper
-│   │   ├── Transport  # AMQP transport helper
-│   │   ├── Task       # Task management helper (generate_task_id)
-│   │   └── Lex        # LEX metadata helper
-│   ├── Data/          # Extension data layer
-│   │   ├── Migrator   # Extension-specific migrations
-│   │   └── Model      # Extension-specific models
-│   ├── Hooks/
-│   │   └── Base       # Webhook hook system base class
-│   └── Transport      # Extension transport setup
-│
-├── API (Sinatra)      # Full REST API under /api/ prefix, served by Puma
-│   ├── Helpers        # json_response, json_collection, json_error, pagination, redact_hash
-│   │                  # parse_request_body, paginate dataset
-│   ├── Routes/
-│   │   ├── Tasks      # CRUD + trigger via Ingress, task logs
-│   │   ├── Extensions # Nested: extensions/runners/functions + invoke
-│   │   ├── Nodes      # List/show nodes (filterable by active/status)
-│   │   ├── Schedules  # CRUD for lex-scheduler schedules + logs
-│   │   ├── Relationships # CRUD (backed by legion-data migration 013)
-│   │   ├── Chains     # Stub (501) - no data model yet
-│   │   ├── Settings   # Read/write settings with redaction + readonly guards
-│   │   ├── Events     # SSE stream (sinatra stream) + ring buffer polling fallback
-│   │   ├── Transport  # Connection status, exchanges, queues, publish
-│   │   ├── Hooks      # List + trigger registered extension hooks
-│   │   ├── LexDispatch # Dispatch: `POST /api/extensions/:lex/:type/:component/:method` + discovery GET
-│   │   ├── Workers    # Digital worker lifecycle (`/api/workers/*`) + team routes (`/api/teams/*`)
-│   │   ├── Coldstart  # `POST /api/coldstart/ingest` — trigger lex-coldstart ingest from API
-│   │   ├── Capacity   # Aggregate, forecast, per-worker capacity endpoints
-│   │   ├── Tenants    # Tenant listing, provisioning, suspension, quota
-│   │   ├── Audit      # Audit log query: list, show, count, export
-│   │   ├── Rbac       # RBAC: role listing, permission grants, access checks
-│   │   ├── Webhooks   # Webhook subscription CRUD + delivery status
-│   │   └── Validators # Request body schema validation helpers
-│   ├── Middleware/
-│   │   ├── Auth       # JWT Bearer auth middleware (real validation, skip paths for health/ready)
-│   │   ├── Tenant     # Tenant extraction from JWT/header, sets TenantContext
-│   │   ├── ApiVersion # `/api/v1/` rewrite, Deprecation/Sunset headers
-│   │   ├── BodyLimit  # Request body size limit (1MB max, returns 413)
-│   │   └── RateLimit  # Sliding-window rate limiting with per-IP/agent/tenant tiers
-│   └── router         # Class-level Router: extension_names, find_extension_route, registered_routes
-│                      # Populated by Builders::Routes during autobuild via LexDispatch
-│
-├── MCP (legion-mcp gem)  # Extracted to standalone gem — see legion-mcp/CLAUDE.md
-│   └── (tools, 2 resources, TierRouter, PatternStore, ContextGuard, Observer, EmbeddingIndex)
-│
-├── Tools              # Canonical tool layer — replaces Extensions::Capability and Catalog::Registry
-│   ├── Base           # Base class for all framework tools (Do, Status, Config are built-in statics)
-│   ├── Registry       # always/deferred classification for all tools; replaces Catalog::Registry
-│   │                  # Extensions declare tools via `mcp_tools?` / `mcp_tools_deferred?` DSL on Core
-│   ├── Discovery      # Auto-discovers tools from extension runner modules at boot
-│   │                  # `runner_modules` accessor on Builders::Runners feeds Discovery
-│   │                  # `loaded_extension_modules` on Extensions exposes the full set
-│   └── EmbeddingCache # 5-tier persistent embedding cache:
-│                      #   L0 in-memory hash → L1 Cache::Local → L2 Cache → L3 Data::Local → L4 Data
-│
-├── DigitalWorker      # Digital worker platform (AI-as-labor governance)
-│   ├── Lifecycle      # Worker state machine (active/paused/retired/terminated)
-│   ├── Registry       # In-process worker registry
-│   ├── RiskTier       # AIRB risk tier classification + governance constraints
-│   └── ValueMetrics   # Token/cost/latency value tracking
-│
-├── Graph              # Task relationship visualization
-│   ├── Builder        # Builds adjacency graph from relationships table (chain/worker filtering)
-│   └── Exporter       # Renders to Mermaid and DOT (Graphviz) formats
-│
-├── TraceSearch        # Natural language trace search via LLM structured output
-│                      # Translates NL queries to safe JSON filter DSL (column allowlist)
-│                      # Uses Legion::LLM.structured for JSON extraction
-│
-├── Runner             # Task execution engine
-│   ├── Log            # Task logging
-│   └── Status         # Task status tracking
-│
-├── Supervision        # Process supervision
-├── Lex                # Legacy LEX gem discovery (see Extensions for current code)
-│
-└── CLI (Thor)         # Unified CLI: exe/legion -> Legion::CLI::Main
-    ├── Output::Formatter  # color tables, JSON mode, status indicators, ANSI stripping
-    ├── Theme              # Purple palette, orbital ASCII banner, branded CLI output
-    ├── Connection         # Lazy connection manager (ensure_settings, ensure_transport, etc.)
-    ├── Error              # CLI-specific error class
-    ├── Start              # `legion start` - daemon boot via Legion::Process
-    ├── Status             # `legion status` - probes API or shows static info
-    ├── Check              # `legion check` - smoke-test subsystems, 3 depth levels
-    ├── Lex                # `legion lex` - list, info, create, enable, disable, exec/invoke_ext + LexGenerator
-    ├── Task               # `legion task` - list, show, logs, trigger (mapped as run), purge
-    ├── Chain              # `legion chain` - list, create, delete
-    ├── Config             # `legion config` - show (redacted), path, validate, scaffold
-    ├── ConfigScaffold     # `legion config scaffold` - generates starter JSON config files
-    ├── Generate           # `legion generate` - runner, actor, exchange, queue, message
-    ├── Mcp                # `legion mcp` - stdio (default) or HTTP transport
-    ├── Worker             # `legion worker` - digital worker lifecycle management
-    ├── Coldstart          # `legion coldstart` - ingest CLAUDE.md/MEMORY.md into lex-memory
-    ├── Chat               # `legion chat` - interactive AI REPL + headless prompt mode
-    │   ├── Session        # Multi-turn chat session with streaming
-    │   ├── SessionStore   # Persistent session save/load/list/resume/fork
-    │   ├── Permissions    # Tool permission model (interactive/auto_approve/read_only)
-    │   ├── ToolRegistry   # Chat tool discovery and registration (40 built-in tools + extension tools)
-    │   ├── ExtensionTool    # permission_tier DSL module for LEX chat tools (:read/:write/:shell)
-    │   ├── ExtensionToolLoader # Lazy discovery of tools/ directories from loaded extensions
-    │   ├── Context        # Project awareness (git, language, instructions, extra dirs)
-    │   ├── MarkdownRenderer # Terminal markdown rendering with syntax highlighting
-    │   ├── WebFetch       # /fetch slash command for web page context injection
-    │   ├── WebSearch      # DuckDuckGo HTML scraping search engine
-    │   ├── Checkpoint     # File edit checkpointing with /rewind undo
-    │   ├── MemoryStore    # Persistent memory (project + global scopes, markdown files)
-    │   ├── Subagent       # Background subagent spawning via headless subprocess
-    │   ├── AgentRegistry  # Custom agent definitions from .legion/agents/ (JSON/YAML)
-    │   ├── AgentDelegator # @name at-mention parsing and agent dispatch
-    │   ├── ChatLogger     # Chat-specific logging
-    │   └── Tools/         # Built-in tools: read_file, write_file, edit_file,
-    │                      #   search_files, search_content, run_command,
-    │                      #   save_memory, search_memory, web_search, spawn_agent,
-    │                      #   search_traces, query_knowledge, ingest_knowledge,
-    │                      #   consolidate_memory, relate_knowledge, knowledge_maintenance,
-    │                      #   knowledge_stats, summarize_traces, list_extensions,
-    │                      #   manage_tasks, system_status, view_events
-    ├── Memory             # `legion memory` - persistent memory CLI (list/add/forget/search)
-    ├── Plan               # `legion plan` - read-only exploration mode
-    ├── Swarm              # `legion swarm` - multi-agent workflow orchestration
-    ├── Commit             # `legion commit` - AI-generated commit messages via LLM
-    ├── Pr                 # `legion pr` - AI-generated PR title and description via LLM
-    ├── Review             # `legion review` - AI code review with severity levels
-    ├── Gaia               # `legion gaia` - Gaia status
-    ├── Llm                # `legion llm` - LLM subsystem status and provider health
-    ├── Detect             # `legion detect scan` - scan environment and recommend extensions
-    ├── Observe            # `legion observe stats` - MCP tool usage statistics from Observer
-    ├── Tty                # `legion tty interactive` - launch rich terminal UI (legion-tty)
-    ├── Graph              # `legion graph show` - task relationship graph (mermaid/dot)
-    ├── Trace              # `legion trace search` - NL trace search via LLM
-    ├── Dashboard          # `legion dashboard` - TUI operational dashboard with auto-refresh
-    │   ├── DataFetcher    # Polls REST API for workers, health, events
-    │   └── Renderer       # Terminal-based dashboard rendering
-    ├── Cost               # `legion cost` - cost summary, worker, team, top, budget, export
-    │   └── DataClient     # API client for cost data aggregation
-    ├── Skill              # `legion skill` - list, show, create, run skill files
-    ├── Audit              # `legion audit` - query audit log (list, show, count, export)
-    ├── Rbac               # `legion rbac` - role management, permission grants, access check
-    ├── Init               # `legion init` - interactive project setup wizard
-    │   ├── ConfigGenerator    # Generates starter config files from templates
-    │   └── EnvironmentDetector # Detects runtime environment (Docker, CI, services)
-    ├── Marketplace        # `legion marketplace` - extension marketplace (search, install, publish)
-    ├── Notebook           # `legion notebook` - interactive task notebook REPL
-    ├── Update             # `legion update` - self-update via Homebrew or gem
-    ├── Schedule           # `legion schedule` - schedule list/show/add/remove/logs
-    └── Completion         # `legion completion` - bash/zsh tab completion scripts
-```
+- Thor 1.5+ reserves `run` — use `map 'run' => :trigger` in Task subcommand
+- `::Process` must be explicit (resolves to `Legion::Process` otherwise)
+- `::JSON` must be explicit (resolves to `Legion::JSON` otherwise)
+- All commands support `--json` and `--no-color` at class_option level
+- `Connection` module has class-level `ensure_*` methods, not instance-based
 
-### Extension Discovery
+## API Design
 
-`Legion::Extensions.find_extensions` discovers lex-* gems via `Bundler.load.specs` (when running under Bundler) or falls back to `Gem::Specification.all_names`. It also processes `Legion::Settings[:extensions]` for explicitly configured extensions, attempting `Gem.install` for missing ones if `auto_install` is enabled.
+- `Legion::API < Sinatra::Base` with `set :host_authorization, permitted: :any`
+- Response: `{ data: ..., meta: { timestamp:, node: } }`
+- Error: `{ error: { code:, message: }, meta: ... }`
+- `Legion::JSON.dump` — 1 positional arg, wrap kwargs in `{}`
+- `Legion::JSON.load` — returns symbol keys
 
-**Category registry**: Extensions are classified by `categorize_and_order` using `default_category_registry`. Each category has a `type` (`:list` or `:prefix`), `tier` (load order within a phase), and `phase`:
-
-| Category | Type | Tier | Phase | Matches |
-|----------|------|------|-------|---------|
-| `identity` | prefix | 0 | 0 | `lex-identity-*` gems |
-| `core` | list | 1 | 1 | explicitly listed core extensions |
-| `ai` | list | 2 | 1 | explicitly listed AI provider extensions |
-| `gaia` | list | 3 | 1 | explicitly listed GAIA extensions |
-| `agentic` | prefix | 4 | 1 | `lex-agentic-*` gems |
-
-**Role-based filtering**: After discovery, `apply_role_filter` prunes extensions based on `Legion::Settings[:role][:profile]`:
-
-| Profile | What loads |
-|---------|-----------|
-| `nil` (default) | Everything — no filtering |
-| `:core` | 14 core operational extensions only |
-| `:cognitive` | core + all agentic extensions |
-| `:service` | core + service + other integrations |
-| `:dev` | core + AI + essential agentic (~20 extensions) |
-| `:custom` | only what's listed in `role[:extensions]` |
-
-Configure via settings JSON: `{"role": {"profile": "dev"}}`
-
-Loader checks per extension:
-- `data_required?` — skipped if legion-data not connected
-- `cache_required?` — skipped if legion-cache not connected
-- `crypt_required?` — skipped if cluster secret not available
-- `vault_required?` — skipped if Vault not connected
-- `llm_required?` — skipped if legion-llm not connected
-
-After loading, each extension calls `autobuild` then publishes a `LexRegister` message to RabbitMQ to persist runners in the database.
-
-### CLI Details
+## Module Structure (Key Parts)
 
 ```
-legion
-  version                           # Component versions + installed extension count
-  start [-d] [-p PID] [-l LOG] [-t SECS] [--log-level info] [--http-port PORT]
-  stop [-p PID] [--signal INT]
-  status
-  check [--extensions] [--full]     # exit code 0/1
-
-  lex
-    list [-a]
-    info <name>
-    create <name>
-    enable <name>
-    disable <name>
-
-  task
-    list [-n 20] [-s status] [-e extension]
-    show <id>
-    logs <id> [-n 50]
-    run <ext.runner.func> [key:val ...]  # 'run' is mapped to trigger method
-    purge [--days 7] [-y]
-
-  chain
-    list [-n 20]
-    create <name>
-    delete <id> [-y]
-
-  config
-    show [-s section]
-    path
-    validate
-    scaffold [--dir ./settings] [--only transport,data,...] [--full] [--force]
-
-  generate (alias: g)
-    runner <name> [--functions x]
-    actor <name> [--type sub]
-    exchange <name>
-    queue <name>
-    message <name>
-    tool <name>
-
-  mcp
-    stdio                            # default
-    http [--port 9393] [--host localhost]
-
-  worker
-    list [-s status] [-t risk_tier]
-    show <id>
-    create <name> --entra_app_id ID --owner_msid EMAIL --extension NAME [--team T] [--client_secret S]
-    pause <id>
-    activate <id>
-    retire <id>
-    terminate <id>
-    costs [--days 30]
-
-  coldstart
-    ingest <path>                    # file or directory, parses CLAUDE.md / MEMORY.md
-    preview <path>                   # dry-run, shows traces without storing
-    status
-
-  chat                               # interactive AI REPL (requires legion-llm)
-    prompt <text>                    # headless single-prompt mode (also accepts stdin pipe)
-    [--model MODEL] [--provider PROVIDER]
-    [--no_markdown] [--incognito]
-    [--max_budget_usd N] [--auto_approve / -y]
-    [--add_dir DIR ...] [--personality STYLE]
-    [--continue / -c] [--resume NAME] [--fork NAME]
-    # Slash commands:
-    #   /help, /quit, /cost, /status, /clear, /new
-    #   /save NAME, /load NAME, /sessions, /compact
-    #   /fetch URL, /search QUERY, /diff, /copy
-    #   /rewind [N|FILE], /memory [add TEXT]
-    #   /agent TASK, /agents, /plan, /swarm NAME
-    #   /review [SCOPE], /permissions [MODE], /personality STYLE
-    #   /model X, /edit (open $EDITOR)
-    #   /commit, /workers, /dream
-    # Bang commands: !<shell command> (quick shell exec with context injection)
-    # At-mentions: @agent_name <task> (delegate to custom agent)
-
-  memory                             # persistent memory management
-    list [--global]
-    add TEXT [--global]
-    forget INDEX [--global]
-    search QUERY
-    clear [--global] [-y]
-
-  plan                               # read-only exploration mode (no writes/edits/shell)
-    [--model MODEL] [--provider PROVIDER]
-    # Slash commands: /save (writes plan to docs/work/planning/), /help, /quit
-
-  swarm                              # multi-agent workflow orchestration
-    start NAME                       # run a workflow from .legion/swarms/NAME.json
-    list                             # list available workflows
-    show NAME                        # show workflow details
-    [--model MODEL]
-
-  commit                             # AI-generated commit message via LLM
-    [--model MODEL] [--provider PROVIDER]
-
-  pr                                 # AI-generated PR title + description via LLM
-    [--model MODEL] [--provider PROVIDER]
-    [--base BRANCH] [--draft]
-
-  review [FILES...]                  # AI code review with severity levels
-    [--model MODEL] [--provider PROVIDER]
-    [--diff]                         # review staged/unstaged diff instead of files
-
-  gaia
-    status                           # show Gaia system status
-
-  schedule
-    list
-    show <id>
-    add <name> <cron> <runner>
-    remove <id>
-    logs <id>
-
-  completion
-    bash                             # output bash completion script
-    zsh                              # output zsh completion script
-    install                          # print installation instructions
-
-  openapi
-    generate [-o FILE]               # output OpenAPI 3.1.0 spec JSON
-    routes                           # list all API routes with HTTP method + summary
-
-  doctor [--fix] [--json]            # diagnose environment, suggest/apply fixes
-                                     # checks: Ruby, bundle, config, RabbitMQ, DB, cache, Vault,
-                                     #   extensions, PID files, permissions
-                                     # exit 0=all pass, 1=any fail
-
-  telemetry
-    stats [SESSION_ID]               # aggregate or per-session telemetry stats
-    ingest PATH                      # manually ingest a session log file
-
-  graph
-    show [--chain ID] [--worker ID]  # display task relationship graph
-    [--format mermaid|dot] [--output FILE] [--limit N]
-
-  trace
-    search QUERY [--limit N]         # natural language trace search via LLM
-
-  dashboard
-    start [--url URL] [--refresh N]  # TUI operational dashboard with auto-refresh
-
-  cost
-    summary                          # overall cost summary (today/week/month)
-    worker <id>                      # per-worker cost breakdown
-    team <name>                      # per-team cost attribution
-    top [--limit 10]                 # top cost consumers
-    budget                           # budget status
-    export [--format csv|json]       # export cost data
-
-  skill
-    list                             # list discovered skills
-    show <name>                      # display skill definition
-    create <name>                    # scaffold new skill file
-    run <name> [args]                # run skill outside of chat
-
-  audit
-    list [--entity TYPE] [--action ACT] [--limit N]
-    show <id>
-    count [--entity TYPE] [--since TIME]
-    export [--format json|csv]
-
-  rbac
-    roles                            # list roles
-    grants <identity>                # list grants for identity
-    check <identity> <resource> <action>  # check access
-
-  init                               # interactive project setup wizard
-    [--dir PATH] [--template NAME]
-
-  marketplace
-    search QUERY                     # search extension marketplace
-    install NAME                     # install extension
-    publish                          # publish current extension
-
-  notebook                           # interactive task notebook REPL
-
-  update                             # self-update via Homebrew or gem
-
-  auth
-    teams [--tenant-id ID] [--client-id ID]  # browser OAuth flow for Microsoft Teams
+Legion
+├── Service        # Lifecycle orchestrator
+├── Process        # PID, signals, daemonization
+├── Readiness      # Component readiness tracking
+├── Events         # In-process pub/sub (on/emit/once/off, wildcard *)
+├── Ingress        # Universal runner entry point (normalize + run)
+├── Extensions     # Discovery, loading, actors, builders, helpers
+│   ├── Core       # Mixin: requirement flags, autobuild
+│   ├── Actors/    # Every, Loop, Once, Poll, Subscription, Nothing
+│   └── Builders/  # Actors, Runners, Helpers, Hooks, Routes
+├── Tools          # Registry (always/deferred), Discovery, EmbeddingCache
+├── API            # Sinatra routes, middleware (Auth, Tenant, RateLimit, BodyLimit)
+├── DigitalWorker  # AI-as-labor: Lifecycle, Registry, RiskTier, ValueMetrics
+├── CLI            # Thor commands (40+ subcommands)
+│   └── Chat       # Interactive AI REPL (sessions, tools, memory, agents, skills)
+└── Graph          # Task relationship visualization (Mermaid/DOT)
 ```
 
-**CLI design rules:**
-- Thor 1.5+ reserves `run` as a method name - use `map 'run' => :trigger` in Task subcommand
-- `::Process` must be explicit inside `Legion::` namespace (resolves to `Legion::Process` otherwise)
-- `Connection` is a module with class-level `ensure_*` methods, not instance-based
-- All commands support `--json` and `--no-color` at the class_option level
-- `::JSON` must be explicit inside `Legion::` namespace (resolves to `Legion::JSON` otherwise) — affects `pretty_generate` in config scaffold
+## Lite Mode
 
-### API Design
-
-- Base class: `Legion::API < Sinatra::Base`
-- All routes registered via `register Routes::ModuleName`
-- Requires `set :host_authorization, permitted: :any` (Sinatra 4.0+, else all requests get 403)
-- Response format: `{ data: ..., meta: { timestamp:, node: } }`
-- Error format: `{ error: { code:, message: }, meta: { timestamp:, node: } }`
-- `Legion::JSON.dump` takes exactly 1 positional arg — wrap kwargs in explicit `{}`
-- `Legion::JSON.load` returns symbol keys
-- Settings write: `Legion::Settings.loader.settings[:key] = value`
-- `Legion::Settings.loader.to_hash` for full settings hash
-
-### MCP Design
-
-Extracted to the `legion-mcp` gem (v0.7.3). See `legion-mcp/CLAUDE.md` for full architecture.
-
-- `Legion::MCP.server` is memoized singleton — call `Legion::MCP.reset!` in tests
-- Tool naming: `legion.snake_case_name` (dot namespace, not slash)
-- Tier 0 routing: PatternStore + TierRouter + ContextGuard for LLM-free cached responses
-
-### Lite Mode
-
-`LEGION_MODE=lite` (or `--lite` CLI flag, or `:lite` ProcessRole) launches LegionIO without RabbitMQ, Redis, or Memcached:
-
-- `legion-transport` activates the `InProcess` adapter (stub Session/Channel/Exchange/Queue/Consumer that delegate to `Transport::Local` in-memory pub/sub)
-- `legion-cache` activates the `Memory` adapter (pure in-memory cache with TTL expiry and Mutex synchronization)
-- Useful for single-machine development, CI, and testing without infrastructure dependencies
-- Detection: `Connection.lite_mode?` checks `TYPE == 'local'`; cache checks `LEGION_MODE=lite` env var
-
-### `legion do`
-
-Natural-language intent router at the CLI level:
-
-```bash
-legion do "list all running tasks"
-legion do "start the email extension"
-```
-
-Resolves free-text intent to Capability Registry entries. If the daemon is running, delegates to the MCP `legion.do` tool (Tier 0 fast path). If no daemon, runs in-process. Returns the runner's response.
-
-### `legion mind-growth`
-
-CLI for the autonomous cognitive architecture expansion system (`lex-mind-growth`). 10 subcommands:
-
-```bash
-legion mind-growth status           # current growth cycle state
-legion mind-growth analyze          # gap analysis against 5 reference models
-legion mind-growth propose          # propose a new concept
-legion mind-growth evaluate <id>    # evaluate a proposal
-legion mind-growth build <id>       # run staged build pipeline
-legion mind-growth list             # list proposals
-legion mind-growth approve <id>     # manually approve
-legion mind-growth reject <id>      # manually reject
-legion mind-growth profile          # cognitive profile across all models
-legion mind-growth health           # extension fitness validation
-```
-
-Requires `lex-mind-growth` to be loaded. Also exposes 6 MCP tools in the `legion.mind_growth_*` namespace via `legion-mcp`.
-
-## Dependencies
-
-### Runtime Gems
-| Gem | Purpose |
-|-----|---------|
-| `legion-cache` (>= 0.3) | Caching (Redis/Memcached) |
-| `legion-crypt` (>= 0.3) | Encryption, Vault, JWT |
-| `legion-json` (>= 1.2) | JSON serialization (multi_json wrapper) |
-| `legion-logging` (>= 0.3) | Logging |
-| `legion-settings` (>= 0.3) | Configuration + schema validation |
-| `legion-transport` (>= 1.2) | RabbitMQ AMQP messaging |
-| `lex-node` | Node identity extension |
-| `concurrent-ruby` + `ext` (>= 1.2) | Thread pool, concurrency primitives |
-| `daemons` (>= 1.4) | Process daemonization |
-| `bootsnap` (>= 1.18) | YARV bytecode + load-path caching |
-| `oj` (>= 3.16) | Fast JSON (C extension) |
-| `puma` (>= 6.0) | HTTP server for API |
-| `rackup` (>= 2.0) | Rack server launcher for MCP HTTP transport |
-| `legion-mcp` (>= 0.5) | MCP server + Tier 0 routing (extracted gem) |
-| `reline` (>= 0.5) | Interactive line editing for chat REPL |
-| `rouge` (>= 4.0) | Syntax highlighting for chat markdown rendering |
-| `tty-spinner` (~> 0.9) | Spinner animation for CLI loading states |
-| `sinatra` (>= 4.0) | HTTP API framework |
-| `thor` (>= 1.3) | CLI framework |
-
-### Optional at Runtime (loaded dynamically)
-| Gem | Purpose |
-|-----|---------|
-| `legion-data` | MySQL/SQLite persistence (tasks, extensions, scheduling) |
-| `legion-llm` | LLM integration (Bedrock, Anthropic, OpenAI, Gemini, Ollama) |
-
-### Dev Dependencies
-```
-rack-test, rake, rspec, rubocop, rubocop-rspec, simplecov
-```
-
-## File Map
-
-| Path | Purpose |
-|------|---------|
-| `lib/legion.rb` | Entry point: `Legion.start`, `.shutdown`, `.reload` |
-| `lib/legion/version.rb` | `Legion::VERSION` constant |
-| `lib/legion/service.rb` | Module orchestrator, startup + shutdown + reload sequences |
-| `lib/legion/process.rb` | Daemon lifecycle: PID management, daemonize, signal traps, main loop |
-| `lib/legion/readiness.rb` | Component readiness tracking (COMPONENTS constant, `ready?`, `to_h`) |
-| `lib/legion/events.rb` | In-process pub/sub: `on`, `emit`, `once`, `off`, wildcard `*` |
-| `lib/legion/ingress.rb` | Universal runner invocation: `normalize`, `run` |
-| `lib/legion/extensions.rb` | LEX discovery, loading, actor hooking, shutdown; exposes `loaded_extension_modules` for Tools::Discovery |
-| `lib/legion/extensions/core.rb` | Extension mixin (requirement flags, autobuild) |
-| `lib/legion/extensions/actors/` | Actor types: base, every, loop, once, poll, subscription, nothing, defaults |
-| `lib/legion/extensions/builders/` | Build actors, runners, helpers, hooks, routes from definitions |
-| `lib/legion/extensions/helpers/` | Mixins: base, core, cache, data, logger, transport, task, lex |
-| `lib/legion/extensions/data/` | Extension-level migrator and model |
-| `lib/legion/extensions/hooks/base.rb` | Webhook hook base class |
-| `lib/legion/extensions/transport.rb` | Extension transport setup |
-| `lib/legion/graph/builder.rb` | Graph builder: adjacency list from relationships table with chain/worker filtering |
-| `lib/legion/graph/exporter.rb` | Graph exporter: renders to Mermaid (`graph TD`) and DOT (Graphviz `digraph`) formats |
-| `lib/legion/trace_search.rb` | NL trace search: LLM structured output to JSON filter DSL with column allowlist |
-| `lib/legion/guardrails.rb` | Input validation guardrails for runner payloads |
-| `lib/legion/isolation.rb` | Process isolation for untrusted extension execution |
-| `lib/legion/sandbox.rb` | Sandboxed execution environment for extensions |
-| `lib/legion/context.rb` | Thread-local execution context (request tracing, tenant) |
-| `lib/legion/catalog.rb` | Extension catalog: registry of available extensions with metadata (Catalog::Registry removed — replaced by Tools::Registry) |
-| `lib/legion/tools.rb` | Tools module entry point |
-| `lib/legion/tools/base.rb` | Tools::Base — canonical base class for all tools |
-| `lib/legion/tools/registry.rb` | Tools::Registry — always/deferred classification, replaces Catalog::Registry |
-| `lib/legion/tools/discovery.rb` | Tools::Discovery — auto-discovers tools from extension runner_modules at boot |
-| `lib/legion/tools/embedding_cache.rb` | Tools::EmbeddingCache — 5-tier persistent embedding cache (L0–L4) |
-| `lib/legion/registry.rb` | Extension registry with security scanning |
-| `lib/legion/registry/security_scanner.rb` | Gem security scanner (CVE checks, signature verification) |
-| `lib/legion/webhooks.rb` | Webhook delivery system: HTTP POST with retry, HMAC signing |
-| `lib/legion/runner.rb` | Task execution engine |
-| `lib/legion/runner/log.rb` | Task logging |
-| `lib/legion/runner/status.rb` | Task status tracking |
-| `lib/legion/supervision.rb` | Process supervision |
-| `lib/legion/lex.rb` | Legacy `Legion::Cli::LexBuilder` (preserved, not used by new CLI) |
-| **API** | |
-| `lib/legion/api.rb` | Sinatra base app, health/ready routes, error handlers, hook registry |
-| `lib/legion/api/helpers.rb` | json_response, json_collection, json_error, pagination, redact_hash |
-| `lib/legion/api/tasks.rb` | Tasks: list, create (via Ingress), show, delete, logs |
-| `lib/legion/api/extensions.rb` | Extensions: nested REST (extensions/runners/functions + invoke) |
-| `lib/legion/api/nodes.rb` | Nodes: list (filterable), show |
-| `lib/legion/api/schedules.rb` | Schedules: CRUD + logs (requires lex-scheduler) |
-| `lib/legion/api/relationships.rb` | Relationships: CRUD (backed by legion-data migration 013) |
-| `lib/legion/api/chains.rb` | Chains: stub (501, no data model yet) |
-| `lib/legion/api/settings.rb` | Settings: read/write with redaction + readonly guards |
-| `lib/legion/api/events.rb` | Events: SSE stream + polling fallback (ring buffer) |
-| `lib/legion/api/transport.rb` | Transport: status, exchanges, queues, publish |
-| `lib/legion/api/lex_dispatch.rb` | LexDispatch: `POST /api/extensions/:lex/:type/:component/:method` dispatch + `GET` discovery; remote AMQP forwarding, hook-aware routing via `Routes::LexDispatch` |
-| `lib/legion/api/workers.rb` | Workers + Teams: digital worker lifecycle REST endpoints (`/api/workers/*`) and team cost endpoints (`/api/teams/*`) |
-| `lib/legion/api/coldstart.rb` | Coldstart: `POST /api/coldstart/ingest` — triggers lex-coldstart ingest runner (requires lex-coldstart + lex-memory) |
-| `lib/legion/api/gaia.rb` | Gaia: system status endpoints |
-| `lib/legion/api/token.rb` | Token: JWT token issuance endpoint |
-| `lib/legion/api/openapi.rb` | OpenAPI: `Legion::API::OpenAPI.spec` / `.to_json`; also served at `GET /api/openapi.json` |
-| `lib/legion/api/capacity.rb` | Capacity: aggregate, forecast, and per-worker capacity endpoints |
-| `lib/legion/api/tenants.rb` | Tenants: listing, provisioning, suspension, quota check |
-| `lib/legion/api/catalog.rb` | Catalog: extension catalog with metadata endpoints |
-| `lib/legion/api/llm.rb` | LLM: provider status and routing configuration endpoints |
-| `lib/legion/api/audit.rb` | Audit: list, show, count, export audit log entries |
-| `lib/legion/api/auth.rb` | Auth: combined token exchange endpoint (`POST /api/auth/token` — JWKS verify + RBAC claims mapper) |
-| `lib/legion/api/auth_human.rb` | Auth: human user authentication endpoints |
-| `lib/legion/api/auth_worker.rb` | Auth: digital worker authentication endpoints |
-| `lib/legion/api/rbac.rb` | RBAC: role listing, permission grants, access checks |
-| `lib/legion/api/validators.rb` | Request validators: schema validation helpers for API inputs |
-| `lib/legion/api/webhooks.rb` | Webhooks: CRUD for webhook subscriptions + delivery status |
-| `lib/legion/audit.rb` | Audit logging: AMQP publish + query layer (recent_for, count_for, resources_for, recent) backed by AuditLog model |
-| `lib/legion/audit/hash_chain.rb` | Tamper-evident hash chain for audit entries |
-| `lib/legion/audit/siem_export.rb` | SIEM export: format audit entries for Splunk/ELK ingestion |
-| `lib/legion/alerts.rb` | Configurable alerting rules engine: pattern matching, count conditions, cooldown dedup |
-| `lib/legion/telemetry.rb` | Opt-in OpenTelemetry tracing: `with_span` wrapper, `sanitize_attributes`, `record_exception` |
-| `lib/legion/metrics.rb` | Opt-in Prometheus metrics: event-driven counters, pull-based gauges, `prometheus-client` guarded |
-| `lib/legion/api/metrics.rb` | `GET /metrics` Prometheus text-format endpoint with gauge refresh |
-| `lib/legion/api/stats.rb` | `GET /api/stats` comprehensive daemon runtime stats (extensions, gaia, transport, cache, llm, data, api) |
-| `lib/legion/chat/notification_queue.rb` | Thread-safe priority queue for background notifications (critical/info/debug) |
-| `lib/legion/chat/notification_bridge.rb` | Event-driven bridge: matches Legion events to chat notifications via fnmatch patterns |
-| `lib/legion/api/middleware/auth.rb` | Auth: JWT Bearer auth middleware (real token validation, skip paths for health/ready) |
-| `lib/legion/api/middleware/api_version.rb` | ApiVersion: rewrites `/api/v1/` to `/api/`, adds Deprecation/Sunset headers on unversioned paths |
-| `lib/legion/api/middleware/body_limit.rb` | BodyLimit: request body size limit (1MB max, returns 413) |
-| `lib/legion/api/middleware/rate_limit.rb` | RateLimit: sliding-window rate limiting with per-IP/agent/tenant tiers |
-| `lib/legion/api/middleware/tenant.rb` | Tenant: extracts tenant_id from JWT/header, sets TenantContext per request |
-| `lib/legion/tenant_context.rb` | Thread-local tenant context propagation (set, clear, with block) |
-| `lib/legion/tenants.rb` | Tenant CRUD, suspension, quota enforcement |
-| `lib/legion/capacity/model.rb` | Workforce capacity calculation (throughput, utilization, forecast, per-worker) |
-| **MCP** (extracted to `legion-mcp` gem) | |
-| `lib/legion/digital_worker.rb` | DigitalWorker module entry point |
-| `lib/legion/digital_worker/lifecycle.rb` | Worker state machine |
-| `lib/legion/digital_worker/registry.rb` | In-process worker registry |
-| `lib/legion/digital_worker/risk_tier.rb` | AIRB risk tier + governance constraints |
-| `lib/legion/digital_worker/value_metrics.rb` | Token/cost/latency tracking |
-| **CLI v2** | |
-| `lib/legion/cli.rb` | `Legion::CLI::Main` Thor app, global flags, version, start/stop/status/check |
-| `lib/legion/cli/output.rb` | `Output::Formatter`: color, tables, JSON mode, ANSI stripping |
-| `lib/legion/cli/connection.rb` | Lazy connection manager (`ensure_settings`, `ensure_transport`, etc.) |
-| `lib/legion/cli/error.rb` | `CLI::Error` exception class |
-| `lib/legion/cli/start.rb` | `legion start` — boots Legion::Process |
-| `lib/legion/cli/status.rb` | `legion status` — probes API or returns static info |
-| `lib/legion/cli/check_command.rb` | `legion check` — 3-level smoke test, exit code 0/1 |
-| `lib/legion/cli/lex_command.rb` | `legion lex` subcommands + LexGenerator scaffolding + `invoke_ext`/`exec` dispatch via LexCliManifest |
-| `lib/legion/cli/lex_cli_manifest.rb` | JSON manifest cache for LEX CLI commands (alias resolution, staleness check) |
-| `lib/legion/cli/task_command.rb` | `legion task` subcommands (list, show, logs, trigger/run, purge) |
-| `lib/legion/cli/chain_command.rb` | `legion chain` subcommands (list, create, delete) |
-| `lib/legion/cli/config_command.rb` | `legion config` subcommands (show, path, validate, scaffold) |
-| `lib/legion/cli/config_scaffold.rb` | `legion config scaffold` — generates starter JSON config files per subsystem |
-| `lib/legion/cli/generate_command.rb` | `legion generate` subcommands (runner, actor, exchange, queue, message) |
-| `lib/legion/cli/mcp_command.rb` | `legion mcp` subcommand (stdio + HTTP transports) |
-| `lib/legion/cli/worker_command.rb` | `legion worker` subcommands (list, show, create, pause, retire, terminate, activate, costs) |
-| `lib/legion/cli/coldstart_command.rb` | `legion coldstart` subcommands (ingest, preview, status) |
-| `lib/legion/cli/chat_command.rb` | `legion chat` — interactive AI REPL + headless prompt mode |
-| `lib/legion/cli/chat/session.rb` | Chat session: multi-turn conversation, streaming, tool use |
-| `lib/legion/cli/chat/session_store.rb` | Session persistence: save, load, list, resume, fork |
-| `lib/legion/cli/chat/permissions.rb` | Tool permission model (interactive/auto_approve/read_only) |
-| `lib/legion/cli/chat/tool_registry.rb` | Chat tool discovery and registration (40 tools) |
-| `lib/legion/cli/chat/extension_tool.rb` | permission_tier DSL module for extension chat tools |
-| `lib/legion/cli/chat/extension_tool_loader.rb` | Lazy discovery engine: scans loaded extensions for tools/ directories |
-| `lib/legion/cli/chat/context.rb` | Project awareness: git info, language detection, instructions, extra dirs |
-| `lib/legion/cli/chat/markdown_renderer.rb` | Terminal markdown rendering with Rouge syntax highlighting |
-| `lib/legion/cli/chat/web_fetch.rb` | `/fetch` slash command: fetches web page, extracts text for context |
-| `lib/legion/cli/chat/web_search.rb` | DuckDuckGo HTML scraping search (parse results, extract URLs, auto-fetch) |
-| `lib/legion/cli/chat/checkpoint.rb` | File edit checkpointing: save prior state, rewind (N steps, per-file) |
-| `lib/legion/cli/chat/memory_store.rb` | Persistent memory: project (`.legion/memory.md`) + global (`~/.legion/memory/`) |
-| `lib/legion/cli/chat/subagent.rb` | Background subagent spawning via `Open3.capture3` to `legion chat prompt` |
-| `lib/legion/cli/chat/agent_registry.rb` | Custom agent definitions from `.legion/agents/*.json` and `.yaml` |
-| `lib/legion/cli/chat/agent_delegator.rb` | `@name` at-mention parsing and dispatch via Subagent |
-| `lib/legion/cli/chat/chat_logger.rb` | Chat-specific logging |
-| `lib/legion/cli/chat/context_manager.rb` | Context window management: dedup, compression, summarization strategies |
-| `lib/legion/cli/chat/progress_bar.rb` | Progress bar rendering for long operations |
-| `lib/legion/cli/chat/status_indicator.rb` | Status indicator (spinner, checkmark, cross) |
-| `lib/legion/cli/chat/team.rb` | Multi-user team support for chat sessions |
-| `lib/legion/cli/chat/tools/` | 40 built-in tools: read_file, write_file, edit_file, search_files, search_content, run_command, save_memory, search_memory, web_search, spawn_agent, search_traces, query_knowledge, ingest_knowledge, consolidate_memory, relate_knowledge, knowledge_maintenance, knowledge_stats, summarize_traces, list_extensions, manage_tasks, system_status, view_events, cost_summary, reflect, manage_schedules, worker_status, detect_anomalies, view_trends, trigger_dream, generate_insights, budget_status, provider_health, model_comparison, shadow_eval_status, entity_extract, arbitrage_status, escalation_status, graph_explore, scheduling_status, memory_status |
-| `lib/legion/chat/skills.rb` | Skill discovery: parses `.legion/skills/` and `~/.legionio/skills/` YAML frontmatter files |
-| `lib/legion/cli/graph_command.rb` | `legion graph` subcommands (show with --format mermaid\|dot, --chain, --output) |
-| `lib/legion/cli/trace_command.rb` | `legion trace search` — NL trace search via LLM |
-| `lib/legion/cli/dashboard_command.rb` | `legion dashboard` — TUI operational dashboard |
-| `lib/legion/cli/dashboard/data_fetcher.rb` | Dashboard API poller: workers, health, events |
-| `lib/legion/cli/dashboard/renderer.rb` | Dashboard terminal renderer with sections |
-| `lib/legion/cli/cost_command.rb` | `legion cost` — cost summary, worker, team, top, budget, export |
-| `lib/legion/cli/cost/data_client.rb` | Cost data aggregation API client |
-| `lib/legion/cli/skill_command.rb` | `legion skill` — list, show, create, run skill files |
-| `lib/legion/cli/audit_command.rb` | `legion audit` — query audit log (list, show, count, export) |
-| `lib/legion/cli/rbac_command.rb` | `legion rbac` — role management, permission grants, access checks |
-| `lib/legion/cli/init_command.rb` | `legion init` — interactive project setup wizard |
-| `lib/legion/cli/init/config_generator.rb` | Config file generation from templates |
-| `lib/legion/cli/init/environment_detector.rb` | Runtime environment detection (Docker, CI, services) |
-| `lib/legion/cli/marketplace_command.rb` | `legion marketplace` — extension search, install, publish |
-| `lib/legion/cli/notebook_command.rb` | `legion notebook` — interactive task notebook REPL |
-| `lib/legion/cli/update_command.rb` | `legion update` — self-update via Homebrew or gem |
-| `lib/legion/cli/lex_templates.rb` | LEX scaffold templates for generator |
-| `lib/legion/cli/version.rb` | CLI version display helper |
-| `lib/legion/docs/site_generator.rb` | Static documentation site generator |
-| `lib/legion/cli/memory_command.rb` | `legion memory` subcommands (list, add, forget, search, clear) |
-| `lib/legion/cli/plan_command.rb` | `legion plan` — read-only exploration mode with /save to docs/work/planning/ |
-| `lib/legion/cli/swarm_command.rb` | `legion swarm` — multi-agent workflow orchestration from `.legion/swarms/` |
-| `lib/legion/cli/commit_command.rb` | `legion commit` — AI-generated commit messages via LLM |
-| `lib/legion/cli/pr_command.rb` | `legion pr` — AI-generated PR title + description via LLM |
-| `lib/legion/cli/review_command.rb` | `legion review` — AI code review with severity levels (CRITICAL/WARNING/SUGGESTION/NOTE) |
-| `lib/legion/cli/gaia_command.rb` | `legion gaia` subcommands (status) |
-| `lib/legion/cli/llm_command.rb` | `legion llm` subcommands (status) — LLM subsystem status and provider health |
-| `lib/legion/cli/detect_command.rb` | `legion detect scan` — scan environment and recommend extensions |
-| `lib/legion/cli/observe_command.rb` | `legion observe stats` — MCP tool usage statistics from Observer |
-| `lib/legion/cli/tty_command.rb` | `legion tty interactive` — launch rich terminal UI (legion-tty interactive shell) |
-| `lib/legion/cli/interactive.rb` | `Interactive` Thor class — shared CLI module for `legion` binary entry point |
-| `lib/legion/cli/config_import.rb` | `legion config import` — import config from external sources |
-| `lib/legion/cli/schedule_command.rb` | `legion schedule` subcommands (list, show, add, remove, logs) |
-| `lib/legion/cli/completion_command.rb` | `legion completion` subcommands (bash, zsh, install) |
-| `lib/legion/cli/openapi_command.rb` | `legion openapi` subcommands (generate, routes); also `GET /api/openapi.json` endpoint |
-| `lib/legion/cli/doctor_command.rb` | `legion doctor` — 11-check environment diagnosis; `Doctor::Result` value object with status/message/prescription/auto_fixable |
-| `lib/legion/cli/doctor/` | Individual check modules: ruby_version, bundle, config, rabbitmq, database, cache, vault, extensions, pid, permissions, plus result.rb |
-| `lib/legion/cli/telemetry_command.rb` | `legion telemetry` subcommands (stats, ingest) — session log analytics |
-| `lib/legion/cli/auth_command.rb` | `legion auth` subcommands (teams) — delegated OAuth browser flow for external services |
-| `lib/legion/cli/admin_command.rb` | `legion admin` subcommands (purge-topology) — ops tooling for v2.0 AMQP topology cleanup |
-| `completions/legion.bash` | Bash tab completion script |
-| `completions/_legion` | Zsh tab completion script |
-| `lib/legion/cli/theme.rb` | Purple palette, orbital ASCII banner, branded CLI output |
-| **Legacy CLI (preserved, not loaded by new CLI)** | |
-| `lib/legion/cli/task.rb` | Old task commands |
-| `lib/legion/cli/trigger.rb` | Old trigger command |
-| `lib/legion/cli/chain.rb` | Old chain commands |
-| `lib/legion/cli/cohort.rb` | Old cohort commands |
-| `lib/legion/cli/function.rb` | Old function commands |
-| `lib/legion/cli/relationship.rb` | Old relationship commands |
-| `lib/legion/cli/lex/` | Old LEX sub-generators + ERB templates (still used by LexGenerator) |
-| **Executables** | |
-| `exe/legion` | Executable: YJIT, GC tuning, bootsnap, then `Legion::CLI::Main.start(ARGV)` |
-| `Dockerfile` | Docker build |
-| `docker_deploy.rb` | Build + push Docker image |
-| **Specs** | |
-| `spec/spec_helper.rb` | RSpec configuration |
-
-## Known Stubs / TODO
-
-| Area | Status |
-|------|--------|
-| `API::Routes::Relationships` | Fully implemented (backed by legion-data migration 013) |
-| `API::Routes::Chains` | 501 stub - no data model |
-| `API::Middleware::Auth` | JWT Bearer auth middleware — real token validation and API key (`X-API-Key` header) auth both implemented |
-| `legion-data` chains/relationships models | Not yet implemented |
-
-## Rubocop Notes
-
-- `.rubocop.yml` excludes `spec/**/*`, `legionio.gemspec`, `chat_command.rb`, `plan_command.rb`, `swarm_command.rb`, and `schedule_command.rb` from `Metrics/BlockLength`
-- `chat_command.rb` also excluded from `Metrics/AbcSize`, `Metrics/MethodLength`, and `Metrics/CyclomaticComplexity` (large REPL loop + slash command dispatch)
-- Hash alignment: `table` style enforced for both rocket and colon
-- `Naming/PredicateMethod` disabled
+`LEGION_MODE=lite` — `InProcess` transport adapter + `Memory` cache adapter. No RabbitMQ/Redis needed.
 
 ## Development
 
 ```bash
-bundle install
-bundle exec rspec       # ~3500+ examples, 0 failures
+bundle exec rspec       # ~3500+ examples
 bundle exec rubocop     # 0 offenses
 ```
 
-**Always run a full `bundle exec rspec` and `bundle exec rubocop -A` and fix all errors before committing.**
+Always run both before committing. Specs use `rack-test`. `Legion::JSON.load` returns symbol keys.
 
-Specs use `rack-test` for API testing. `Legion::JSON.load` returns symbol keys — use `body[:data]` not `body['data']` in specs.
+## Rubocop
 
----
-
-**Maintained By**: Matthew Iverson (@Esity)
+`.rubocop.yml` excludes `spec/**/*` from `Metrics/BlockLength`. `chat_command.rb` excluded from most Metrics cops. Hash alignment: `table` style.

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ gem 'kramdown', '>= 2.0'
 gem 'mysql2'
 
 group :test do
+  gem 'faraday'
+  gem 'faraday-net_http'
   gem 'graphql'
   gem 'lex-codegen'
   gem 'lex-eval'

--- a/lib/legion/api/identity_audit.rb
+++ b/lib/legion/api/identity_audit.rb
@@ -9,13 +9,13 @@ module Legion
 
           app.get '/api/identity/audit' do
             require_data!
-            halt 503, json_error('unavailable', 'identity audit log not available') unless defined?(Legion::Data::Model::IdentityAuditLog)
+            halt 503, json_error('unavailable', 'identity audit log not available') unless defined?(Legion::Data::Model::Identity::AuditLog)
 
-            dataset = Legion::Data::Model::IdentityAuditLog.dataset
+            dataset = Legion::Data::Model::Identity::AuditLog.dataset
 
             principal = params[:principal]
-            if principal && defined?(Legion::Data::Model::Principal)
-              principal_record = Legion::Data::Model::Principal.where(canonical_name: principal).first
+            if principal && defined?(Legion::Data::Model::Identity::Principal)
+              principal_record = Legion::Data::Model::Identity::Principal.where(canonical_name: principal).first
               halt 404, json_error('not_found', "principal '#{principal}' not found") unless principal_record
               dataset = dataset.where(principal_id: principal_record.id)
             end

--- a/lib/legion/api/llm.rb
+++ b/lib/legion/api/llm.rb
@@ -213,7 +213,8 @@ module Legion
             validate_required!(body, :messages)
 
             messages        = body[:messages]
-            tools           = body[:tools] || []
+            tools_present   = body.key?(:tools)
+            tools           = tools_present ? Array(body[:tools]) : []
             model           = body[:model]
             provider        = body[:provider]
             requested_tools = body[:requested_tools] || []
@@ -267,17 +268,19 @@ module Legion
                          end
 
             caller_metadata = body[:metadata].is_a?(Hash) ? body[:metadata] : {}
-            req = Legion::LLM::Inference::Request.build(
+            request_args = {
               messages:        messages,
               system:          body[:system],
               routing:         { provider: provider, model: model },
-              tools:           tool_classes,
               caller:          caller_ctx,
               conversation_id: body[:conversation_id],
               metadata:        caller_metadata.merge(requested_tools: requested_tools),
               stream:          streaming,
               cache:           { strategy: :default, cacheable: true }
-            )
+            }
+            request_args[:tools] = tool_classes if tools_present
+
+            req = Legion::LLM::Inference::Request.build(**request_args)
             executor = Legion::LLM::Inference::Executor.new(req)
 
             if streaming

--- a/lib/legion/extensions/catalog/available.rb
+++ b/lib/legion/extensions/catalog/available.rb
@@ -27,13 +27,6 @@ module Legion
           { name: 'lex-transformer',  category: 'core',     description: 'Task chain transformation' },
           { name: 'lex-webhook',      category: 'core',     description: 'Inbound webhook receiver' },
           # ai
-          { name: 'lex-azure-ai',     category: 'ai',       description: 'Azure OpenAI provider integration' },
-          { name: 'lex-bedrock',      category: 'ai',       description: 'AWS Bedrock LLM provider integration' },
-          { name: 'lex-claude',       category: 'ai',       description: 'Anthropic Claude provider integration' },
-          { name: 'lex-foundry',      category: 'ai',       description: 'Azure AI Foundry provider integration' },
-          { name: 'lex-gemini',       category: 'ai',       description: 'Google Gemini provider integration' },
-          { name: 'lex-ollama',       category: 'ai',       description: 'Ollama local LLM provider integration' },
-          { name: 'lex-openai',       category: 'ai',       description: 'OpenAI provider integration' },
           { name: 'lex-xai',          category: 'ai',       description: 'xAI Grok provider integration' },
           { name: 'lex-llm',          category: 'ai',       description: 'Common LLM provider base and routing metadata' },
           { name: 'lex-llm-anthropic', category: 'ai',      description: 'Anthropic LLM provider integration' },

--- a/lib/legion/identity/broker.rb
+++ b/lib/legion/identity/broker.rb
@@ -275,7 +275,7 @@ module Legion
           return [] unless defined?(Legion::Data) && Legion::Data.respond_to?(:connected?) && Legion::Data.connected?
 
           model = begin
-            Legion::Data::Model::IdentityGroupMembership
+            Legion::Data::Model::Identity::GroupMembership
           rescue StandardError
             nil
           end

--- a/lib/legion/identity/middleware.rb
+++ b/lib/legion/identity/middleware.rb
@@ -115,22 +115,40 @@ module Legion
       end
 
       def system_principal
-        canonical = if defined?(Legion::Identity::Process) && Legion::Identity::Process.resolved?
-                      Legion::Identity::Process.canonical_name
-                    else
-                      'system'
-                    end
+        attrs = system_identity_attributes
 
-        if @system_principal&.canonical_name != canonical
+        if @system_principal&.canonical_name != attrs[:canonical_name] ||
+           @system_principal&.kind != attrs[:kind] ||
+           @system_principal&.source != Identity::Request::SOURCE_NORMALIZATION.fetch(attrs[:source], attrs[:source])
           @system_principal = Identity::Request.new(
-            principal_id:   "system:#{canonical}",
-            canonical_name: canonical,
-            kind:           :service,
+            principal_id:   "system:#{attrs[:canonical_name]}",
+            canonical_name: attrs[:canonical_name],
+            kind:           attrs[:kind],
             groups:         [],
-            source:         :local
+            source:         attrs[:source]
           )
         end
         @system_principal
+      end
+
+      def system_identity_attributes
+        process = defined?(Legion::Identity::Process) ? Legion::Identity::Process : nil
+        canonical = process_value(process, :canonical_name)
+        canonical = 'system' if canonical.nil? || canonical.to_s.empty?
+
+        {
+          canonical_name: canonical.to_s,
+          kind:           process_value(process, :kind) || :service,
+          source:         process_value(process, :source) || :local
+        }
+      end
+
+      def process_value(process, method_name)
+        return nil unless process.respond_to?(method_name)
+
+        process.public_send(method_name)
+      rescue StandardError
+        nil
       end
     end
   end

--- a/lib/legion/identity/resolver.rb
+++ b/lib/legion/identity/resolver.rb
@@ -316,57 +316,74 @@ module Legion
           @resolved.make_true
         end
 
-        def persist_to_db(composite) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+        def persist_to_db(composite) # rubocop:disable Metrics/MethodLength
           return unless defined?(Legion::Data) && Legion::Data.respond_to?(:connected?) && Legion::Data.connected?
-          return unless defined?(Legion::Data::Connection) &&
-                        Legion::Data::Connection.respond_to?(:adapter) &&
-                        Legion::Data::Connection.adapter == :postgres
 
-          # upsert identity_providers
-          composite[:providers]&.each do |name, info|
-            Legion::Data.db[:identity_providers].insert_conflict(
+          now = Time.now.utc
+          db = Legion::Data.db
+
+          composite[:providers]&.each_key do |name|
+            db[:identity_providers].insert_conflict(
               target: :name,
-              update: { status: info[:status].to_s, trust_level: info[:trust]&.to_s, last_seen_at: Time.now }
-            ).insert(name: name.to_s, status: info[:status].to_s, trust_level: info[:trust]&.to_s, last_seen_at: Time.now)
+              update: { updated_at: now }
+            ).insert(
+              uuid:          SecureRandom.uuid,
+              name:          name.to_s,
+              provider_type: 'authenticate',
+              facing:        'both',
+              source:        'resolver',
+              enabled:       true,
+              created_at:    now,
+              updated_at:    now
+            )
           end
 
-          # upsert principals
-          Legion::Data.db[:principals].insert_conflict(
-            target: :canonical_name,
-            update: { kind: composite[:kind].to_s, updated_at: Time.now }
+          db[:identity_principals].insert_conflict(
+            target: %i[canonical_name kind],
+            update: { last_seen_at: now, updated_at: now }
           ).insert(
+            uuid:           SecureRandom.uuid,
             canonical_name: composite[:canonical_name],
             kind:           composite[:kind].to_s,
-            created_at:     Time.now,
-            updated_at:     Time.now
+            active:         true,
+            last_seen_at:   now,
+            created_at:     now,
+            updated_at:     now
           )
 
-          principal_row = Legion::Data.db[:principals].where(canonical_name: composite[:canonical_name]).first
+          principal_row = db[:identity_principals].where(
+            canonical_name: composite[:canonical_name], kind: composite[:kind].to_s
+          ).first
           principal_id = principal_row[:id] if principal_row
 
-          # upsert identities per provider alias
           composite[:aliases]&.each do |provider_name, identities|
+            provider_row = db[:identity_providers].where(name: provider_name.to_s).first
+            next unless provider_row
+
             Array(identities).each do |ident|
-              Legion::Data.db[:identities].insert_conflict(
-                target: %i[principal_id provider_name provider_identity],
-                update: { updated_at: Time.now }
+              db[:identities].insert_conflict(
+                target: %i[principal_id provider_id provider_identity_key],
+                update: { last_authenticated_at: now, updated_at: now }
               ).insert(
-                principal_id:      principal_id,
-                provider_name:     provider_name.to_s,
-                provider_identity: ident,
-                created_at:        Time.now,
-                updated_at:        Time.now
+                uuid:                  SecureRandom.uuid,
+                principal_id:          principal_id,
+                provider_id:           provider_row[:id],
+                provider_identity_key: ident,
+                active:                true,
+                last_authenticated_at: now,
+                created_at:            now,
+                updated_at:            now
               )
             end
           end
 
-          # insert audit log
-          Legion::Data.db[:identity_audit_log].insert(
-            principal_id:  principal_id,
-            event_type:    'identity.resolved',
-            provider_name: composite[:source].to_s,
-            trust_level:   composite[:trust]&.to_s,
-            detail:        Legion::JSON.dump(
+          db[:identity_audit_log].insert(
+            uuid:           SecureRandom.uuid,
+            principal_id:   principal_id,
+            event_type:     'identity.resolved',
+            provider_name:  composite[:source].to_s,
+            trust_level:    composite[:trust]&.to_s,
+            detail_payload: Legion::JSON.dump(
               {
                 source:     composite[:source],
                 trust:      composite[:trust],
@@ -374,9 +391,9 @@ module Legion
                 session_id: @session_id
               }
             ),
-            node_id:       composite[:node_id],
-            session_id:    @session_id,
-            created_at:    Time.now
+            node_ref:       composite[:node_id],
+            session_ref:    @session_id,
+            created_at:     now
           )
         rescue StandardError => e
           log_warn("DB persistence failed: #{e.message}")
@@ -406,18 +423,15 @@ module Legion
           end
 
           return unless defined?(Legion::Data) && Legion::Data.respond_to?(:connected?) && Legion::Data.connected?
-          return unless defined?(Legion::Data::Connection) &&
-                        Legion::Data::Connection.respond_to?(:adapter) &&
-                        Legion::Data::Connection.adapter == :postgres
 
-          # Audit the canonical change
-          old_row = Legion::Data.db[:principals].where(canonical_name: old_canonical).first
+          old_row = Legion::Data.db[:identity_principals].where(canonical_name: old_canonical).first
           Legion::Data.db[:identity_audit_log].insert(
-            principal_id:  old_row&.dig(:id),
-            event_type:    'identity.canonical_changed',
-            provider_name: '',
-            detail:        Legion::JSON.dump({ old: old_canonical, new: new_canonical }),
-            created_at:    Time.now
+            uuid:           SecureRandom.uuid,
+            principal_id:   old_row&.dig(:id),
+            event_type:     'identity.canonical_changed',
+            provider_name:  'resolver',
+            detail_payload: Legion::JSON.dump({ old: old_canonical, new: new_canonical }),
+            created_at:     Time.now
           )
         rescue StandardError => e
           log_warn("canonical change handling failed: #{e.message}")

--- a/lib/legion/task_outcome_observer.rb
+++ b/lib/legion/task_outcome_observer.rb
@@ -34,8 +34,10 @@ module Legion
       private
 
       def handle_outcome(payload, success:)
-        runner_class = payload[:runner_class].to_s
-        function = payload[:function].to_s
+        return unless observable_outcome?(payload)
+
+        runner_class = outcome_value(payload, :runner_class).to_s
+        function = outcome_value(payload, :function).to_s
         domain = derive_domain(runner_class)
 
         record_learning(domain: domain, success: success)
@@ -50,6 +52,18 @@ module Legion
         return 'unknown' unless last
 
         last.gsub(/([A-Z])/, '_\1').delete_prefix('_').downcase
+      end
+
+      def observable_outcome?(payload)
+        !outcome_value(payload, :task_id).to_s.strip.empty? &&
+          !outcome_value(payload, :runner_class).to_s.strip.empty? &&
+          !outcome_value(payload, :function).to_s.strip.empty?
+      end
+
+      def outcome_value(payload, key)
+        return unless payload.respond_to?(:[])
+
+        payload[key] || payload[key.to_s]
       end
 
       def record_learning(domain:, success:)

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.23'
+  VERSION = '1.9.24'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.27'
+  VERSION = '1.9.28'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.25'
+  VERSION = '1.9.26'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.26'
+  VERSION = '1.9.27'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.24'
+  VERSION = '1.9.25'
 end

--- a/spec/api/llm_inference_spec.rb
+++ b/spec/api/llm_inference_spec.rb
@@ -175,6 +175,28 @@ RSpec.describe 'POST /api/llm/inference' do
       end
     end
 
+    it 'does not pass tools when the request omits client tool definitions' do
+      received_kwargs = nil
+      pipeline_response = build_pipeline_response
+      stub_const('Legion::LLM::Inference::Request', Module.new do
+        define_singleton_method(:build) do |**kwargs|
+          received_kwargs = kwargs
+          :stubbed_request
+        end
+      end)
+
+      stub_const('Legion::LLM::Inference::Executor', Class.new do
+        define_method(:initialize) { |_req| nil }
+        define_method(:call) { pipeline_response }
+      end)
+
+      post '/api/llm/inference',
+           Legion::JSON.dump({ messages: [{ role: 'user', content: 'go' }] }),
+           { 'CONTENT_TYPE' => 'application/json' }
+
+      expect(received_kwargs).not_to have_key(:tools)
+    end
+
     it 'returns 400 when messages is not an array' do
       post '/api/llm/inference',
            Legion::JSON.dump({ messages: 'not an array' }),

--- a/spec/legion/extensions/catalog_available_spec.rb
+++ b/spec/legion/extensions/catalog_available_spec.rb
@@ -22,5 +22,11 @@ RSpec.describe Legion::Extensions::Catalog::Available do
     it 'does not advertise lex-llm-gateway' do
       expect(described_class.find('lex-llm-gateway')).to be_nil
     end
+
+    it 'does not advertise deprecated direct provider extensions' do
+      %w[lex-bedrock lex-claude lex-gemini lex-ollama lex-openai].each do |deprecated|
+        expect(described_class.find(deprecated)).to be_nil, "expected #{deprecated} to be removed from catalog"
+      end
+    end
   end
 end

--- a/spec/legion/extensions/catalog_available_spec.rb
+++ b/spec/legion/extensions/catalog_available_spec.rb
@@ -24,7 +24,15 @@ RSpec.describe Legion::Extensions::Catalog::Available do
     end
 
     it 'does not advertise deprecated direct provider extensions' do
-      %w[lex-bedrock lex-claude lex-gemini lex-ollama lex-openai].each do |deprecated|
+      %w[
+        lex-azure-ai
+        lex-bedrock
+        lex-claude
+        lex-foundry
+        lex-gemini
+        lex-ollama
+        lex-openai
+      ].each do |deprecated|
         expect(described_class.find(deprecated)).to be_nil, "expected #{deprecated} to be removed from catalog"
       end
     end

--- a/spec/legion/identity/middleware_spec.rb
+++ b/spec/legion/identity/middleware_spec.rb
@@ -144,6 +144,24 @@ RSpec.describe Legion::Identity::Middleware do
   describe 'when no auth is present and require_auth is false (default)' do
     let(:env) { env_for('/api/tasks') }
 
+    def stub_process_identity(canonical_name: 'matt@example.com', kind: :human, source: :system)
+      process = Module.new do
+        class << self
+          attr_accessor :canonical_name_value, :kind_value, :source_value
+
+          def canonical_name = @canonical_name_value
+          def kind = @kind_value
+          def source = @source_value
+          def resolved? = false
+        end
+      end
+      process.canonical_name_value = canonical_name
+      process.kind_value = kind
+      process.source_value = source
+
+      stub_const('Legion::Identity::Process', process)
+    end
+
     it 'sets a system principal' do
       captured = nil
       app = described_class.new(lambda { |e|
@@ -162,7 +180,9 @@ RSpec.describe Legion::Identity::Middleware do
       })
       app.call(env)
       principal = captured['legion.principal']
-      expected_canonical = if defined?(Legion::Identity::Process) && Legion::Identity::Process.resolved?
+      expected_canonical = if defined?(Legion::Identity::Process) &&
+                              Legion::Identity::Process.respond_to?(:canonical_name) &&
+                              Legion::Identity::Process.canonical_name.to_s != ''
                              Legion::Identity::Process.canonical_name
                            else
                              'system'
@@ -170,14 +190,38 @@ RSpec.describe Legion::Identity::Middleware do
       expect(principal.principal_id).to eq("system:#{expected_canonical}")
     end
 
-    it 'sets kind to :service' do
+    it 'uses the local process identity even when the process resolver is not formally resolved' do
+      stub_process_identity
+      captured = nil
+      app = described_class.new(lambda { |e|
+        captured = e
+        [200, {}, []]
+      })
+
+      app.call(env)
+
+      principal = captured['legion.principal']
+      expect(principal.principal_id).to eq('system:matt@example.com')
+      expect(principal.canonical_name).to eq('matt@example.com')
+      expect(principal.kind).to eq(:human)
+      expect(principal.source).to eq(:system)
+    end
+
+    it 'sets kind from the local process identity when available' do
       captured = nil
       app = described_class.new(lambda { |e|
         captured = e
         [200, {}, []]
       })
       app.call(env)
-      expect(captured['legion.principal'].kind).to eq(:service)
+      expected_kind = if defined?(Legion::Identity::Process) &&
+                         Legion::Identity::Process.respond_to?(:kind) &&
+                         Legion::Identity::Process.kind
+                        Legion::Identity::Process.kind
+                      else
+                        :service
+                      end
+      expect(captured['legion.principal'].kind).to eq(expected_kind)
     end
 
     it 'memoizes the system principal across calls' do

--- a/spec/legion/task_outcome_observer_spec.rb
+++ b/spec/legion/task_outcome_observer_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Legion::TaskOutcomeObserver do
     allow(Legion::Logging).to receive(:warn)
     # Clear event handlers between tests
     Legion::Events.instance_variable_set(:@listeners, Hash.new { |h, k| h[k] = [] })
+    described_class.instance_variable_set(:@meta_learning_client, nil)
+    described_class.instance_variable_set(:@learning_domain_map, nil)
   end
 
   describe '.setup' do
@@ -44,6 +46,21 @@ RSpec.describe Legion::TaskOutcomeObserver do
     it 'handles task.failed events' do
       payload = { task_id: 'def', runner_class: 'Legion::Extensions::Github::Runners::Issues', function: 'create' }
       expect { Legion::Events.emit('task.failed', **payload) }.not_to raise_error
+    end
+
+    it 'ignores internal runner completions without task ids' do
+      client = instance_double('meta_client', create_learning_domain: { id: 'dom-123' }, record_learning_episode: true)
+      client_class = Class.new
+      allow(client_class).to receive(:new).and_return(client)
+      stub_const('Legion::Extensions::Agentic::Learning::MetaLearning::Client', client_class)
+      stub_const('Legion::Apollo', Module.new { def self.ingest(**) = nil })
+      expect(Legion::Apollo).not_to receive(:ingest)
+
+      payload = { runner_class: 'Legion::Extensions::Mesh::Runners::Mesh', function: 'publish_gossip' }
+      Legion::Events.emit('task.completed', **payload)
+
+      expect(client).not_to have_received(:create_learning_domain)
+      expect(client).not_to have_received(:record_learning_episode)
     end
   end
 

--- a/spec/live/.rspec
+++ b/spec/live/.rspec
@@ -1,4 +1,4 @@
 --color
 --format documentation
---require spec_helper
+--require ./spec/live/spec_helper
 --default-path spec/live

--- a/spec/live/.rspec
+++ b/spec/live/.rspec
@@ -1,0 +1,4 @@
+--color
+--format documentation
+--require spec_helper
+--default-path spec/live

--- a/spec/live/README.md
+++ b/spec/live/README.md
@@ -1,0 +1,28 @@
+# Live Daemon Integration Tests
+
+Black-box HTTP tests against a running Legion daemon. No Legion code is loaded — just Faraday + RSpec using the parent LegionIO bundle.
+
+## Running
+
+Start the daemon first:
+```bash
+legionio start
+```
+
+Then run the suite from the LegionIO root:
+```bash
+bundle exec rspec --options spec/live/.rspec
+```
+
+To target a different host:
+```bash
+LEGION_API_URL=http://192.168.1.5:4567 bundle exec rspec --options spec/live/.rspec
+```
+
+## Adding specs
+
+Each spec file tests a logical API surface. Use the `get`/`post` helpers from `spec_helper.rb` — they handle JSON encoding/decoding and base URL resolution.
+
+## CI
+
+These specs are NOT included in the normal `bundle exec rspec` run and are excluded from GitHub Actions. They require a live daemon with real infrastructure (RabbitMQ, database, LLM providers, etc).

--- a/spec/live/api/apollo/status_spec.rb
+++ b/spec/live/api/apollo/status_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/apollo/status' do
+  subject(:response) { get('/apollo/status') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'includes available as a boolean' do
+    expect(response.body[:data][:available]).to be(true).or be(false)
+  end
+
+  it 'includes data_connected as a boolean' do
+    expect(response.body[:data][:data_connected]).to be(true).or be(false)
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/events/recent_spec.rb
+++ b/spec/live/api/events/recent_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/events/recent' do
+  subject(:response) { get('/events/recent') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'returns data as an array' do
+    expect(response.body[:data]).to be_an(Array)
+  end
+
+  it 'each event has required fields' do
+    skip 'no events recorded yet' if response.body[:data].empty?
+
+    entry = response.body[:data].first
+    expect(entry[:event]).to be_a(String)
+    expect(entry[:timestamp]).to be_a(String)
+    expect(entry[:status]).to be_a(String)
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/extension_catalog/available_spec.rb
+++ b/spec/live/api/extension_catalog/available_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/extension_catalog/available' do
+  subject(:response) { get('/extension_catalog/available') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'returns data as an array' do
+    expect(response.body[:data]).to be_an(Array)
+  end
+
+  it 'contains available extensions' do
+    expect(response.body[:data]).not_to be_empty
+  end
+
+  it 'each entry has name, category, and description' do
+    entry = response.body[:data].first
+    expect(entry[:name]).to be_a(String)
+    expect(entry[:category]).to be_a(String)
+    expect(entry[:description]).to be_a(String)
+  end
+
+  it 'includes known categories' do
+    categories = response.body[:data].map { |e| e[:category] }.uniq
+    expect(categories).to include('core')
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/extension_catalog/catalog_spec.rb
+++ b/spec/live/api/extension_catalog/catalog_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/extension_catalog' do
+  subject(:response) { get('/extension_catalog') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'returns data as an array' do
+    expect(response.body[:data]).to be_an(Array)
+  end
+
+  it 'contains at least one loaded extension' do
+    expect(response.body[:data]).not_to be_empty
+  end
+
+  it 'each extension has required fields' do
+    entry = response.body[:data].first
+    expect(entry[:name]).to be_a(String)
+    expect(entry[:state]).to be_a(String)
+    expect(entry[:active_version]).to be_a(String)
+  end
+
+  it 'each extension includes reload metadata' do
+    entry = response.body[:data].first
+    expect(entry).to have_key(:reload_state)
+    expect(entry).to have_key(:pending_reload)
+    expect(entry).to have_key(:hot_reloadable)
+  end
+
+  it 'each extension includes tools and routes arrays' do
+    entry = response.body[:data].first
+    expect(entry[:tools]).to be_an(Array)
+    expect(entry[:routes]).to be_an(Array)
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/extensions/list_spec.rb
+++ b/spec/live/api/extensions/list_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/extensions' do
+  subject(:response) { get('/extensions') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'returns loaded extensions as an array' do
+    expect(response.body[:data]).to be_an(Array)
+  end
+
+  it 'has at least one extension loaded' do
+    expect(response.body[:data]).not_to be_empty
+  end
+end

--- a/spec/live/api/gaia/buffer_spec.rb
+++ b/spec/live/api/gaia/buffer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/gaia/buffer' do
+  subject(:response) { get('/gaia/buffer') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'includes depth as an integer' do
+    expect(response.body[:data][:depth]).to be_a(Integer)
+  end
+
+  it 'includes empty as a boolean' do
+    expect(response.body[:data][:empty]).to be(true).or be(false)
+  end
+
+  it 'includes max_size as an integer' do
+    expect(response.body[:data][:max_size]).to be_a(Integer)
+    expect(response.body[:data][:max_size]).to be > 0
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/gaia/channels_spec.rb
+++ b/spec/live/api/gaia/channels_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/gaia/channels' do
+  subject(:response) { get('/gaia/channels') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'returns data with channels array and count' do
+    data = response.body[:data]
+    expect(data[:channels]).to be_an(Array)
+    expect(data[:count]).to be_a(Integer)
+  end
+
+  it 'count matches channels array length' do
+    data = response.body[:data]
+    expect(data[:count]).to eq(data[:channels].length)
+  end
+
+  it 'each channel has id, started, capabilities, and type' do
+    skip 'no channels configured' if response.body[:data][:channels].empty?
+
+    channel = response.body[:data][:channels].first
+    expect(channel[:id]).to be_a(String)
+    expect(channel[:started]).to be(true).or be(false)
+    expect(channel[:capabilities]).to be_an(Array)
+    expect(channel[:type]).to be_a(String)
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/gaia/sessions_spec.rb
+++ b/spec/live/api/gaia/sessions_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/gaia/sessions' do
+  subject(:response) { get('/gaia/sessions') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'includes count as an integer' do
+    expect(response.body[:data][:count]).to be_a(Integer)
+  end
+
+  it 'includes active as a boolean' do
+    expect(response.body[:data][:active]).to be(true).or be(false)
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/gaia/status_spec.rb
+++ b/spec/live/api/gaia/status_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/gaia/status' do
+  subject(:response) { get('/gaia/status') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'reports started status' do
+    expect(response.body[:data][:started]).to be(true).or be(false)
+  end
+
+  it 'includes the mode' do
+    expect(response.body[:data][:mode]).to be_a(String)
+  end
+
+  it 'includes buffer_depth as a number' do
+    expect(response.body[:data][:buffer_depth]).to be_a(Integer)
+  end
+
+  it 'includes active_channels as an array' do
+    expect(response.body[:data][:active_channels]).to be_an(Array)
+  end
+
+  it 'includes tick_count and tick_mode' do
+    expect(response.body[:data][:tick_count]).to be_a(Integer)
+    expect(response.body[:data][:tick_mode]).to be_a(String)
+  end
+
+  it 'includes sensory_buffer details' do
+    buffer = response.body[:data][:sensory_buffer]
+    expect(buffer).to be_a(Hash)
+    expect(buffer[:depth]).to be_a(Integer)
+    expect(buffer[:max_capacity]).to be_a(Integer)
+  end
+
+  it 'includes phase_list as an array' do
+    expect(response.body[:data][:phase_list]).to be_an(Array)
+    expect(response.body[:data][:phase_list]).not_to be_empty
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/health/health_spec.rb
+++ b/spec/live/api/health/health_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/health' do
+  subject(:response) { get('/health') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'includes data.status of ok' do
+    expect(response.body[:data][:status]).to eq('ok')
+  end
+
+  it 'includes a version string' do
+    expect(response.body[:data][:version]).to be_a(String)
+    expect(response.body[:data][:version]).to match(/\A\d+\.\d+\.\d+\z/)
+  end
+
+  it 'includes uptime_seconds as a number' do
+    expect(response.body[:data][:uptime_seconds]).to be_a(Numeric)
+    expect(response.body[:data][:uptime_seconds]).to be >= 0
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/health/ready_spec.rb
+++ b/spec/live/api/health/ready_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/ready' do
+  subject(:response) { get('/ready') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'reports ready as true' do
+    expect(response.body[:data][:ready]).to be true
+  end
+
+  it 'includes a components hash' do
+    components = response.body[:data][:components]
+    expect(components).to be_a(Hash)
+    expect(components).not_to be_empty
+  end
+
+  it 'has all core components marked as true' do
+    components = response.body[:data][:components]
+    %i[settings transport extensions api].each do |component|
+      expect(components[component]).to be(true), "expected #{component} to be true"
+    end
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/llm/providers_spec.rb
+++ b/spec/live/api/llm/providers_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/llm/providers' do
+  subject(:response) { get('/llm/providers') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'has a data key' do
+    expect(response.body).to include(:data)
+  end
+
+  it 'has data.providers as an array' do
+    expect(response.body[:data][:providers]).to be_an(Array)
+  end
+
+  it 'has data.summary.total >= 5' do
+    expect(response.body[:data][:summary][:total]).to be >= 5
+  end
+
+  it 'has data.summary.native >= 5' do
+    expect(response.body[:data][:summary][:native]).to be >= 5
+  end
+
+  it 'has data.summary.routing_enabled = true' do
+    expect(response.body[:data][:summary][:routing_enabled]).to be true
+  end
+end

--- a/spec/live/api/openapi/openapi_json_spec.rb
+++ b/spec/live/api/openapi/openapi_json_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/openapi.json' do
+  subject(:response) { get('/openapi.json') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'declares OpenAPI 3.1.0' do
+    expect(response.body[:openapi]).to eq('3.1.0')
+  end
+
+  it 'has info with title and version' do
+    expect(response.body[:info][:title]).to eq('LegionIO REST API')
+    expect(response.body[:info][:version]).not_to be_nil
+  end
+
+  it 'has paths' do
+    expect(response.body[:paths]).to be_a(Hash)
+    expect(response.body[:paths].size).to be > 0
+  end
+
+  it 'has components' do
+    expect(response.body[:components]).to be_a(Hash)
+  end
+
+  it 'has tags' do
+    expect(response.body[:tags]).to be_an(Array)
+    expect(response.body[:tags]).not_to be_empty
+  end
+
+  it 'has security schemes defined' do
+    expect(response.body[:security]).to be_an(Array)
+    expect(response.body[:security]).not_to be_empty
+  end
+end

--- a/spec/live/api/stats/stats_spec.rb
+++ b/spec/live/api/stats/stats_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/stats' do
+  subject(:response) { get('/stats') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'returns data as a hash' do
+    expect(response.body[:data]).to be_a(Hash)
+  end
+
+  it 'includes extensions stats' do
+    extensions = response.body[:data][:extensions]
+    expect(extensions).to be_a(Hash)
+    expect(extensions[:loaded]).to be_a(Integer)
+    expect(extensions[:running]).to be_a(Integer)
+    expect(extensions[:actors]).to be_a(Integer)
+  end
+
+  it 'includes transport stats' do
+    transport = response.body[:data][:transport]
+    expect(transport).to be_a(Hash)
+    expect(transport[:connected]).to be(true).or be(false)
+    expect(transport[:connector]).to be_a(String)
+  end
+
+  it 'includes cache stats' do
+    cache = response.body[:data][:cache]
+    expect(cache).to be_a(Hash)
+    expect(cache[:connected]).to be(true).or be(false)
+  end
+
+  it 'includes llm stats' do
+    llm = response.body[:data][:llm]
+    expect(llm).to be_a(Hash)
+    expect(llm[:started]).to be(true).or be(false)
+  end
+
+  it 'includes api stats' do
+    api = response.body[:data][:api]
+    expect(api).to be_a(Hash)
+    expect(api[:port]).to be_a(Integer)
+    expect(api[:routes]).to be_a(Integer)
+  end
+
+  it 'includes gaia stats' do
+    gaia = response.body[:data][:gaia]
+    expect(gaia).to be_a(Hash)
+    expect(gaia[:started]).to be(true).or be(false)
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/api/transport/transport_spec.rb
+++ b/spec/live/api/transport/transport_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/transport' do
+  subject(:response) { get('/transport') }
+
+  it 'returns 200' do
+    expect(response.status).to eq(200)
+  end
+
+  it 'reports connection status' do
+    data = response.body[:data]
+    expect(data[:connected]).to be(true).or be(false)
+  end
+
+  it 'includes session and channel open status' do
+    data = response.body[:data]
+    expect(data).to have_key(:session_open)
+    expect(data).to have_key(:channel_open)
+  end
+
+  it 'reports the connector type' do
+    data = response.body[:data]
+    expect(data[:connector]).to be_a(String)
+  end
+
+  it 'includes meta with timestamp and node' do
+    expect(response.body[:meta][:timestamp]).to be_a(String)
+    expect(response.body[:meta][:node]).to be_a(String)
+  end
+end

--- a/spec/live/spec_helper.rb
+++ b/spec/live/spec_helper.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'faraday'
+require 'faraday/net_http'
+require 'json'
+
+module LiveHelpers
+  def api(path = '')
+    base = ENV.fetch('LEGION_API_URL', 'http://localhost:4567')
+    "#{base}/api#{path}"
+  end
+
+  def client
+    @client ||= Faraday.new do |f|
+      f.request :json
+      f.response :json, parser_options: { symbolize_names: true }
+      f.adapter Faraday.default_adapter
+    end
+  end
+
+  def get(path)
+    client.get(api(path))
+  end
+
+  def post(path, body = {})
+    client.post(api(path), body)
+  end
+end
+
+RSpec.configure do |config|
+  config.include LiveHelpers
+
+  config.before(:suite) do
+    url = ENV.fetch('LEGION_API_URL', 'http://localhost:4567')
+    begin
+      resp = Faraday.get("#{url}/api/ready")
+      unless resp.status == 200
+        warn "Legion daemon at #{url} returned #{resp.status} on /api/ready"
+        abort 'Daemon not ready. Start it with: legionio start'
+      end
+    rescue Faraday::ConnectionFailed
+      abort "Cannot connect to Legion daemon at #{url}. Start it with: legionio start"
+    end
+  end
+
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_when_matching :focus
+  config.order = :defined
+end


### PR DESCRIPTION
## Summary

- Removes `lex-bedrock`, `lex-claude`, `lex-gemini`, `lex-ollama`, and `lex-openai` from `Extensions::Catalog::Available`
- These are superseded by their `lex-llm-*` counterparts (`lex-llm-bedrock`, `lex-llm-anthropic`, `lex-llm-gemini`, `lex-llm-ollama`, `lex-llm-openai`) which register with `Call::Registry` via `AutoRegistration` and participate in the legion-llm routing layer
- Adds a regression spec to prevent re-entry of deprecated names

## Test plan

- [ ] `bundle exec rspec spec/legion/extensions/catalog_available_spec.rb` — 3 examples, 0 failures
- [ ] Verify no deprecated extension names appear in `catalog/available.rb`