### PR TITLE
Bump to 1.9.29: subscription channel recovery, DLX guard, identity refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+## [1.9.29] - 2026-05-11
+
+### Fixed
+- `Subscription#activate` now checks `channel.open?` before calling `subscribe_with`; if closed, it re-prepares once and retries, preventing silent activation failures when a channel is closed between prepare and activate.
+- `Transport` mixin now guards `auto_create_dlx_exchange` and `auto_create_dlx_queue` with a `remote_invocable?` check — non-remote extensions no longer attempt to create dead-letter exchanges and queues they never use.
+- DLX exchange type corrected from `fanout` to `topic` for consistency with the rest of the exchange topology.
+- Identity resolver DB persistence now uses Sequel models (`Identity::Provider`, `Identity::Principal`, `Identity::Identity`, `Identity::AuditLog`) instead of raw `Legion::Data.db` dataset calls that didn't exist on the module.
+- Identity audit API endpoint now references correct column names (`detail_payload`, `node_ref`, `session_ref`) matching the schema.
+- Fixed `LeaseRenewer#log_renewal_failure` to fall back to `$stderr` when `Legion::Logging` is not yet loaded, matching the original contract.
+- Fixed `Legion::Service#log_privacy_mode_status`, `#shutdown_component`, and TLS-fallback logging specs to assert against `emit_tagged` (the actual dispatch path used by `Legion::Logging::Helper`) rather than `Legion::Logging.warn/info` directly.
+- Fixed `Cluster::Leader` boot integration spec to stub `Legion::Settings[:logging]` so `log` helper initialization does not raise on unexpectedly-received arguments.
+
+### Changed
+- Added `remote_invocable_extension?` helper to the `Transport` module; returns `lex_class.remote_invocable?` when available, `true` otherwise.
+- Refactored `Identity::Resolver#persist_to_db` into extracted helpers (`upsert_providers`, `upsert_principal`, `upsert_identities`, `upsert_single_identity`) to reduce method complexity and improve readability.
+- Replaced hand-rolled `log_warn`/`log_debug` methods in `Identity::Resolver`, `Identity::Broker`, and `Identity::LeaseRenewer` with `include Legion::Logging::Helper` and standard `log.debug`/`log.warn` calls.
+- Added debug logging throughout `Identity::Resolver` for registration, resolution, auth racing, binding, and DB persistence.
+- LLM inference API now passes `instance` and `tier` routing hints from request body through to `Legion::LLM::Inference::Request`.
+
 ## [1.9.28] - 2026-05-08
 
 ### Fixed

--- a/lib/legion/api/identity_audit.rb
+++ b/lib/legion/api/identity_audit.rb
@@ -35,8 +35,8 @@ module Legion
             records = dataset.order(Sequel.desc(:created_at)).limit(100).all
             json_collection(records.map do |r|
               { id: r.id, event_type: r.event_type, provider_name: r.provider_name,
-                trust_level: r.trust_level, detail: r.detail,
-                node_id: r.node_id, session_id: r.session_id, created_at: r.created_at }
+                trust_level: r.trust_level, detail_payload: r.detail_payload,
+                node_ref: r.node_ref, session_ref: r.session_ref, created_at: r.created_at }
             end)
           end
         end

--- a/lib/legion/api/llm.rb
+++ b/lib/legion/api/llm.rb
@@ -268,16 +268,19 @@ module Legion
                          end
 
             caller_metadata = body[:metadata].is_a?(Hash) ? body[:metadata] : {}
+            instance = body[:instance]
+            tier     = body[:tier]
             request_args = {
               messages:        messages,
               system:          body[:system],
-              routing:         { provider: provider, model: model },
+              routing:         { provider: provider, model: model, instance: instance }.compact,
               caller:          caller_ctx,
               conversation_id: body[:conversation_id],
               metadata:        caller_metadata.merge(requested_tools: requested_tools),
               stream:          streaming,
               cache:           { strategy: :default, cacheable: true }
             }
+            request_args[:extra] = { tier: tier.to_sym } if tier
             request_args[:tools] = tool_classes if tools_present
 
             req = Legion::LLM::Inference::Request.build(**request_args)

--- a/lib/legion/api/llm.rb
+++ b/lib/legion/api/llm.rb
@@ -280,7 +280,11 @@ module Legion
               stream:          streaming,
               cache:           { strategy: :default, cacheable: true }
             }
-            request_args[:extra] = { tier: tier.to_sym } if tier
+            if tier
+              halt 400, Legion::JSON.dump({ error: 'invalid tier' }) unless tier.is_a?(String)
+              halt 400, Legion::JSON.dump({ error: 'invalid tier' }) unless %w[local fleet auto].include?(tier)
+              request_args[:extra] = { tier: tier.to_sym }
+            end
             request_args[:tools] = tool_classes if tools_present
 
             req = Legion::LLM::Inference::Request.build(**request_args)

--- a/lib/legion/cli/setup_command.rb
+++ b/lib/legion/cli/setup_command.rb
@@ -55,8 +55,25 @@ module Legion
           description: 'LLM routing and provider integration (no cognitive stack)',
           gems:        %w[
             legion-llm lex-llm lex-llm-anthropic lex-llm-azure-foundry
-            lex-llm-bedrock lex-llm-gemini lex-llm-ledger lex-llm-mlx
+            lex-llm-bedrock lex-llm-gemini lex-llm-mlx
             lex-llm-ollama lex-llm-openai lex-llm-vertex lex-llm-vllm
+          ]
+        },
+        gaia:     {
+          description: 'Cognitive coordination engine + agentic extensions (GAIA stack)',
+          gems:        %w[
+            legion-gaia
+            lex-agentic-affect lex-agentic-attention lex-agentic-defense
+            lex-agentic-executive lex-agentic-homeostasis lex-agentic-inference
+            lex-agentic-integration lex-agentic-language lex-agentic-learning
+            lex-agentic-memory lex-agentic-self lex-agentic-social
+            lex-synapse lex-mind-growth lex-tick
+          ]
+        },
+        identity: {
+          description: 'Identity and access management (RBAC + identity providers)',
+          gems:        %w[
+            legion-rbac lex-identity-system lex-identity-kerberos
           ]
         },
         channels: {
@@ -151,6 +168,18 @@ module Legion
       option :dry_run, type: :boolean, default: false, desc: 'Show what would be installed without installing'
       def llm
         install_pack(:llm)
+      end
+
+      desc 'gaia', 'Install cognitive coordination engine and agentic extensions (GAIA stack)'
+      option :dry_run, type: :boolean, default: false, desc: 'Show what would be installed without installing'
+      def gaia
+        install_pack(:gaia)
+      end
+
+      desc 'identity', 'Install identity and access management (RBAC + identity providers)'
+      option :dry_run, type: :boolean, default: false, desc: 'Show what would be installed without installing'
+      def identity
+        install_pack(:identity)
       end
 
       desc 'channels', 'Install channel adapters (Slack, Teams)'
@@ -494,6 +523,14 @@ module Legion
             puts '  Next steps:'
             puts '    legion chat           # interactive AI conversation'
             puts '    legion llm status     # check provider connectivity'
+          when :gaia
+            puts '  Next steps:'
+            puts '    legion start          # start daemon with cognitive stack'
+            puts '    legion start --lite   # single-process, no external services'
+          when :identity
+            puts '  Next steps:'
+            puts '    Configure RBAC in settings: {"rbac": {"enabled": true}}'
+            puts '    legion start          # start daemon with identity services'
           when :channels
             puts '  Next steps:'
             puts '    Configure channels in settings: {"gaia": {"channels": {"slack": {"enabled": true}}}}'

--- a/lib/legion/extensions/actors/subscription.rb
+++ b/lib/legion/extensions/actors/subscription.rb
@@ -110,7 +110,20 @@ module Legion
             log.warn "[Subscription] skipping activate for #{lex_name}/#{runner_name}: no consumer (prepare failed?)"
             return
           end
-          @queue.subscribe_with(@consumer)
+
+          if @queue.channel.open?
+            @queue.subscribe_with(@consumer)
+          else
+            log.warn "[Subscription] channel closed before activate for #{lex_name}/#{runner_name}, re-preparing"
+            prepare
+            if @consumer && @queue.channel.open?
+              @queue.subscribe_with(@consumer)
+            else
+              log.error "[Subscription] re-prepare failed for #{lex_name}/#{runner_name}, skipping activate"
+              return
+            end
+          end
+
           log.info "[Subscription] activated: #{lex_name}/#{runner_name} (consumer registered)"
         end
 

--- a/lib/legion/extensions/transport.rb
+++ b/lib/legion/extensions/transport.rb
@@ -82,7 +82,7 @@ module Legion
                   end
 
                   def default_type
-                    'topic'
+                    'fanout'
                   end
                 end)
               end

--- a/lib/legion/extensions/transport.rb
+++ b/lib/legion/extensions/transport.rb
@@ -71,6 +71,8 @@ module Legion
       end
 
       def auto_create_dlx_exchange
+        return unless remote_invocable_extension?
+
         dlx = if transport_class::Exchanges.const_defined?('Dlx', false)
                 transport_class::Exchanges::Dlx
               else
@@ -80,7 +82,7 @@ module Legion
                   end
 
                   def default_type
-                    'fanout'
+                    'topic'
                   end
                 end)
               end
@@ -89,6 +91,7 @@ module Legion
       end
 
       def auto_create_dlx_queue
+        return unless remote_invocable_extension?
         return if transport_class::Queues.const_defined?('Dlx', false)
 
         special_name = default_exchange.new.exchange_name
@@ -206,6 +209,12 @@ module Legion
 
       def additional_e_to_q
         []
+      end
+
+      def remote_invocable_extension?
+        return lex_class.remote_invocable? if lex_class.respond_to?(:remote_invocable?)
+
+        true
       end
     end
   end

--- a/lib/legion/identity/broker.rb
+++ b/lib/legion/identity/broker.rb
@@ -10,6 +10,8 @@ module Legion
       AUDIT_DROP_LOG_INTERVAL = 100
 
       class << self
+        include Legion::Logging::Helper
+
         def token_for(provider_name, qualifier: nil, for_context: nil, purpose: nil, context: nil)
           name = provider_name.to_sym
           resolved = resolve_qualifier(name, qualifier: qualifier, for_context: for_context)
@@ -235,7 +237,7 @@ module Legion
 
           if audit_queue.size >= AUDIT_QUEUE_MAX
             drops = (@audit_drops ||= Concurrent::AtomicFixnum.new(0)).increment
-            log_warn("Audit queue full, dropping event (total drops: #{drops})") if (drops % AUDIT_DROP_LOG_INTERVAL).zero?
+            log.warn("Audit queue full, dropping event (total drops: #{drops})") if (drops % AUDIT_DROP_LOG_INTERVAL).zero?
           else
             audit_queue.push(event)
           end
@@ -289,7 +291,7 @@ module Legion
             nil
           end
         rescue StandardError => e
-          log_warn("Broker.db_groups failed: #{e.message}")
+          log.warn("Broker.db_groups failed: #{e.message}")
           []
         end
 
@@ -297,14 +299,6 @@ module Legion
           defined?(Legion::Data) &&
             Legion::Data.respond_to?(:connected?) &&
             Legion::Data.connected?
-        end
-
-        def log_warn(message)
-          if defined?(Legion::Logging) && Legion::Logging.respond_to?(:warn)
-            Legion::Logging.warn("[Identity::Broker] #{message}")
-          else
-            $stderr.puts "[Identity::Broker] #{message}" # rubocop:disable Style/StderrPuts
-          end
         end
       end
 

--- a/lib/legion/identity/lease_renewer.rb
+++ b/lib/legion/identity/lease_renewer.rb
@@ -5,6 +5,8 @@ require 'concurrent'
 module Legion
   module Identity
     class LeaseRenewer
+      include Legion::Logging::Helper
+
       attr_reader :provider_name, :provider
 
       BACKOFF_SLEEP  = 5
@@ -70,11 +72,10 @@ module Legion
       end
 
       def log_renewal_failure(error)
-        message = "[LeaseRenewer][#{@provider_name}] renewal failed: #{error.message}"
-        if defined?(Legion::Logging) && Legion::Logging.respond_to?(:warn)
-          Legion::Logging.warn(message)
+        if defined?(Legion::Logging)
+          log.warn("renewal failed: #{error.message}")
         else
-          $stderr.puts message # rubocop:disable Style/StderrPuts
+          $stderr.puts "[LeaseRenewer][#{@provider_name}] renewal failed: #{error.message}" # rubocop:disable Style/StderrPuts
         end
       end
     end

--- a/lib/legion/identity/resolver.rb
+++ b/lib/legion/identity/resolver.rb
@@ -196,6 +196,7 @@ module Legion
           deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + timeout
           provider_results = {}
           auth_providers.zip(futures).each do |provider, future|
+            result = nil
             remaining = deadline - ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
             future.wait(remaining.positive? ? remaining : 0)
             result = future.value(0) if future.resolved?

--- a/lib/legion/identity/resolver.rb
+++ b/lib/legion/identity/resolver.rb
@@ -13,25 +13,34 @@ module Legion
       TIMEOUT_SECONDS = 5
 
       class << self
+        include Legion::Logging::Helper
+
         def register(provider)
           return if @providers.any? { |p| p.provider_name == provider.provider_name }
 
+          log.debug("register: #{provider.provider_name} type=#{provider.provider_type} trust=#{provider.trust_level}")
           @providers << provider
         end
 
         def resolve!(timeout: TIMEOUT_SECONDS)
+          log.debug("resolve!: starting with #{@providers.size} providers, timeout=#{timeout}s")
           drain_pending_registrations
 
           auth_providers, profile_providers, fallback_providers = partition_providers
+          log.debug("resolve!: partitioned auth=#{auth_providers.map(&:provider_name)} " \
+                    "profile=#{profile_providers.map(&:provider_name)} " \
+                    "fallback=#{fallback_providers.map(&:provider_name)}")
 
           winning_provider, winning_result, provider_results = resolve_auth(auth_providers, timeout: timeout)
 
           if winning_provider.nil?
+            log.debug('resolve!: no auth winner, trying fallback providers')
             winning_provider, winning_result, fallback_results = resolve_auth(fallback_providers, timeout: timeout)
             provider_results.merge!(fallback_results) if fallback_results
           end
 
           unless winning_provider
+            log.debug('resolve!: no provider resolved, identity unresolved')
             @resolved.make_false
             @composite.set(nil)
             return nil
@@ -40,8 +49,10 @@ module Legion
           canonical = winning_result[:canonical_name]
           trust_level = winning_provider.trust_level
           source = winning_provider.provider_name
+          log.debug("resolve!: winner=#{source} canonical=#{canonical} trust=#{trust_level}")
 
           profile_data = resolve_profiles(profile_providers, canonical, timeout: timeout)
+          log.debug("resolve!: profiles resolved groups=#{profile_data[:groups].size} profile_keys=#{profile_data[:profile].keys}")
 
           composite = assemble_composite(
             provider_results, profile_data,
@@ -51,12 +62,15 @@ module Legion
           )
 
           bind_and_persist(winning_provider, composite, trust_level)
+          log.debug("resolve!: complete canonical=#{composite[:canonical_name]} providers=#{composite[:providers].keys}")
           composite
         end
 
         def upgrade!(provider, result)
           current = @composite.get
           return unless current
+
+          log.debug("upgrade!: provider=#{provider.provider_name} trust=#{provider.trust_level} current_canonical=#{current[:canonical_name]}")
 
           new_trust = provider.trust_level
           new_canonical = result[:canonical_name] || current[:canonical_name]
@@ -109,6 +123,7 @@ module Legion
 
           persist_identity_json(new_canonical, updated[:kind]) unless new_trust == :unverified
 
+          log.debug("upgrade!: complete canonical=#{new_canonical} trust=#{effective_trust} canonical_changed=#{canonical_changed}")
           updated
         end
 
@@ -145,6 +160,7 @@ module Legion
           pending = Legion::Identity.pending_registrations
           return if pending.nil? || pending.empty?
 
+          log.debug("drain_pending_registrations: draining #{pending.size} pending providers")
           drained = []
           drained << pending.shift until pending.empty?
           drained.each { |p| register(p) }
@@ -172,6 +188,7 @@ module Legion
         def resolve_auth(auth_providers, timeout:)
           return [nil, nil, {}] if auth_providers.empty?
 
+          log.debug("resolve_auth: racing #{auth_providers.map(&:provider_name)} timeout=#{timeout}s")
           futures = auth_providers.map do |provider|
             Concurrent::Promises.future { provider.resolve }
           end
@@ -183,6 +200,8 @@ module Legion
             future.wait(remaining.positive? ? remaining : 0)
             result = future.value(0) if future.resolved?
             status = auth_future_status(future, result)
+            log.debug("resolve_auth: #{provider.provider_name} status=#{status}" \
+                      "#{" canonical=#{result[:canonical_name]}" if status == :resolved}")
 
             provider_results[provider.provider_name] = {
               status:      status,
@@ -195,6 +214,7 @@ module Legion
 
           resolved_entries = provider_results.select { |_, v| v[:status] == :resolved }
           if resolved_entries.empty?
+            log.debug('resolve_auth: no providers resolved')
             [nil, nil, provider_results]
           else
             winner_name = resolved_entries.min_by do |_, v|
@@ -202,6 +222,7 @@ module Legion
               [-p.priority, p.trust_weight]
             end&.first
 
+            log.debug("resolve_auth: winner=#{winner_name}")
             winner_info = provider_results[winner_name]
             [winner_info[:provider], winner_info[:result], provider_results]
           end
@@ -302,11 +323,13 @@ module Legion
         end
 
         def bind_and_persist(winning_provider, composite, trust_level)
+          log.debug("bind_and_persist: binding provider=#{winning_provider.provider_name} trust=#{trust_level}")
           Legion::Identity::Process.bind!(winning_provider, composite) if defined?(Legion::Identity::Process)
 
           if defined?(Legion::Settings) && Legion::Settings.respond_to?(:loader) && Legion::Settings.loader.respond_to?(:settings)
             Legion::Settings.loader.settings[:client] ||= {}
             Legion::Settings.loader.settings[:client][:name] = Legion::Identity::Process.queue_prefix
+            log.debug("bind_and_persist: client name set to #{Legion::Identity::Process.queue_prefix}")
           end
 
           persist_to_db(composite)
@@ -314,72 +337,26 @@ module Legion
 
           @composite.set(composite)
           @resolved.make_true
+          log.debug('bind_and_persist: resolved=true')
         end
 
-        def persist_to_db(composite) # rubocop:disable Metrics/MethodLength
-          return unless defined?(Legion::Data) && Legion::Data.respond_to?(:connected?) && Legion::Data.connected?
-
-          now = Time.now.utc
-          db = Legion::Data.db
-
-          composite[:providers]&.each_key do |name|
-            db[:identity_providers].insert_conflict(
-              target: :name,
-              update: { updated_at: now }
-            ).insert(
-              uuid:          SecureRandom.uuid,
-              name:          name.to_s,
-              provider_type: 'authenticate',
-              facing:        'both',
-              source:        'resolver',
-              enabled:       true,
-              created_at:    now,
-              updated_at:    now
-            )
+        def persist_to_db(composite)
+          unless defined?(Legion::Data) && Legion::Data.respond_to?(:connected?) && Legion::Data.connected?
+            log.debug('persist_to_db: skipped — Legion::Data not connected')
+            return
           end
 
-          db[:identity_principals].insert_conflict(
-            target: %i[canonical_name kind],
-            update: { last_seen_at: now, updated_at: now }
-          ).insert(
-            uuid:           SecureRandom.uuid,
-            canonical_name: composite[:canonical_name],
-            kind:           composite[:kind].to_s,
-            active:         true,
-            last_seen_at:   now,
-            created_at:     now,
-            updated_at:     now
-          )
+          log.debug("persist_to_db: persisting canonical=#{composite[:canonical_name]} providers=#{composite[:providers]&.keys}")
+          now            = Time.now.utc
+          provider_model = Legion::Data::Model::Identity::Provider
+          audit_model    = Legion::Data::Model::Identity::AuditLog
 
-          principal_row = db[:identity_principals].where(
-            canonical_name: composite[:canonical_name], kind: composite[:kind].to_s
-          ).first
-          principal_id = principal_row[:id] if principal_row
+          upsert_providers(composite, provider_model, now)
+          principal = upsert_principal(composite, now)
+          upsert_identities(composite, provider_model, principal, now)
 
-          composite[:aliases]&.each do |provider_name, identities|
-            provider_row = db[:identity_providers].where(name: provider_name.to_s).first
-            next unless provider_row
-
-            Array(identities).each do |ident|
-              db[:identities].insert_conflict(
-                target: %i[principal_id provider_id provider_identity_key],
-                update: { last_authenticated_at: now, updated_at: now }
-              ).insert(
-                uuid:                  SecureRandom.uuid,
-                principal_id:          principal_id,
-                provider_id:           provider_row[:id],
-                provider_identity_key: ident,
-                active:                true,
-                last_authenticated_at: now,
-                created_at:            now,
-                updated_at:            now
-              )
-            end
-          end
-
-          db[:identity_audit_log].insert(
-            uuid:           SecureRandom.uuid,
-            principal_id:   principal_id,
+          audit_model.create(
+            principal_id:   principal.id,
             event_type:     'identity.resolved',
             provider_name:  composite[:source].to_s,
             trust_level:    composite[:trust]&.to_s,
@@ -392,11 +369,79 @@ module Legion
               }
             ),
             node_ref:       composite[:node_id],
-            session_ref:    @session_id,
-            created_at:     now
+            session_ref:    @session_id
           )
         rescue StandardError => e
-          log_warn("DB persistence failed: #{e.message}")
+          log.warn("DB persistence failed: #{e.message}")
+        end
+
+        def upsert_providers(composite, provider_model, now)
+          composite[:providers]&.each_key do |name|
+            existing = provider_model.where(name: name.to_s).first
+            if existing
+              existing.update(updated_at: now)
+            else
+              provider_model.create(
+                name:          name.to_s,
+                provider_type: 'authenticate',
+                facing:        'both',
+                source:        'resolver',
+                enabled:       true
+              )
+            end
+          end
+        end
+
+        def upsert_principal(composite, now)
+          principal_model = Legion::Data::Model::Identity::Principal
+          principal = principal_model.where(
+            canonical_name: composite[:canonical_name],
+            kind:           composite[:kind].to_s
+          ).first
+
+          if principal
+            principal.update(last_seen_at: now, updated_at: now)
+            principal
+          else
+            principal_model.create(
+              canonical_name: composite[:canonical_name],
+              kind:           composite[:kind].to_s,
+              active:         true,
+              last_seen_at:   now
+            )
+          end
+        end
+
+        def upsert_identities(composite, provider_model, principal, now)
+          identity_model = Legion::Data::Model::Identity::Identity
+          composite[:aliases]&.each do |provider_name, identities|
+            provider_row = provider_model.where(name: provider_name.to_s).first
+            next unless provider_row
+
+            Array(identities).each do |ident|
+              upsert_single_identity(identity_model, principal, provider_row, ident, now)
+            end
+          end
+        end
+
+        def upsert_single_identity(identity_model, principal, provider_row, ident, now)
+          existing = identity_model.where(
+            principal_id:          principal.id,
+            provider_id:           provider_row.id,
+            provider_identity_key: ident
+          ).first
+
+          if existing
+            existing.update(last_authenticated_at: now, updated_at: now)
+          else
+            identity_model.create(
+              principal_id:          principal.id,
+              provider_id:           provider_row.id,
+              provider_identity_key: ident,
+              active:                true,
+              last_authenticated_at: now
+            )
+          end
         end
 
         def persist_identity_json(canonical_name, kind)
@@ -412,7 +457,7 @@ module Legion
                  end
           File.write(path, json)
         rescue StandardError => e
-          log_warn("identity.json write failed: #{e.message}")
+          log.warn("identity.json write failed: #{e.message}")
         end
 
         def handle_canonical_change(old_canonical, new_canonical, _composite)
@@ -424,25 +469,15 @@ module Legion
 
           return unless defined?(Legion::Data) && Legion::Data.respond_to?(:connected?) && Legion::Data.connected?
 
-          old_row = Legion::Data.db[:identity_principals].where(canonical_name: old_canonical).first
-          Legion::Data.db[:identity_audit_log].insert(
-            uuid:           SecureRandom.uuid,
-            principal_id:   old_row&.dig(:id),
+          old_principal = Legion::Data::Model::Identity::Principal.where(canonical_name: old_canonical).first
+          Legion::Data::Model::Identity::AuditLog.create(
+            principal_id:   old_principal&.id,
             event_type:     'identity.canonical_changed',
             provider_name:  'resolver',
-            detail_payload: Legion::JSON.dump({ old: old_canonical, new: new_canonical }),
-            created_at:     Time.now
+            detail_payload: Legion::JSON.dump({ old: old_canonical, new: new_canonical })
           )
         rescue StandardError => e
-          log_warn("canonical change handling failed: #{e.message}")
-        end
-
-        def log_warn(message)
-          if defined?(Legion::Logging) && Legion::Logging.respond_to?(:warn)
-            Legion::Logging.warn("[Identity::Resolver] #{message}")
-          else
-            $stderr.puts "[Identity::Resolver] #{message}" # rubocop:disable Style/StderrPuts
-          end
+          log.warn("canonical change handling failed: #{e.message}")
         end
       end
 

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.28'
+  VERSION = '1.9.29'
 end

--- a/spec/legion/api/tls_spec.rb
+++ b/spec/legion/api/tls_spec.rb
@@ -77,12 +77,19 @@ RSpec.describe Legion::Service do
         allow(Legion::Settings).to receive(:[]).with(:api).and_return(
           api_defaults.merge(tls: { enabled: true, cert: nil, key: nil })
         )
+        allow(Legion::Settings).to receive(:[]).with(:logging).and_return(nil)
         allow(Legion::Logging).to receive(:warn)
         allow(Legion::Logging).to receive(:error)
+        allow(Legion::Logging).to receive(:emit_tagged) do |level, msg, **|
+          Legion::Logging.public_send(level, msg) if Legion::Logging.respond_to?(level)
+        end
       end
 
       it 'logs a warning and falls back to plain HTTP' do
         expect(Legion::Logging).to receive(:warn).with(match(/api.tls/i))
+        allow(Legion::Logging).to receive(:emit_tagged) do |level, msg, **|
+          Legion::Logging.public_send(level, msg) if Legion::Logging.respond_to?(level)
+        end
         allow(Thread).to receive(:new).and_return(double(join: nil))
         allow(Legion::API).to receive(:set)
         service.send(:setup_api)

--- a/spec/legion/api/tls_spec.rb
+++ b/spec/legion/api/tls_spec.rb
@@ -87,9 +87,6 @@ RSpec.describe Legion::Service do
 
       it 'logs a warning and falls back to plain HTTP' do
         expect(Legion::Logging).to receive(:warn).with(match(/api.tls/i))
-        allow(Legion::Logging).to receive(:emit_tagged) do |level, msg, **|
-          Legion::Logging.public_send(level, msg) if Legion::Logging.respond_to?(level)
-        end
         allow(Thread).to receive(:new).and_return(double(join: nil))
         allow(Legion::API).to receive(:set)
         service.send(:setup_api)

--- a/spec/legion/cli/setup_command_spec.rb
+++ b/spec/legion/cli/setup_command_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe Legion::CLI::Setup do
         lex-llm-azure-foundry
         lex-llm-bedrock
         lex-llm-gemini
-        lex-llm-ledger
         lex-llm-mlx
         lex-llm-ollama
         lex-llm-openai
@@ -41,7 +40,7 @@ RSpec.describe Legion::CLI::Setup do
       llm_gems = described_class::PACKS.fetch(:llm).fetch(:gems)
 
       expect(llm_gems).to include(*native_llm_gems)
-      expect(llm_gems).not_to include('lex-llm-gateway')
+      expect(llm_gems).not_to include('lex-llm-gateway', 'lex-llm-ledger')
     end
 
     it 'uses the Legion-native provider stack in the agentic pack' do
@@ -58,6 +57,29 @@ RSpec.describe Legion::CLI::Setup do
         'lex-openai',
         'lex-xai'
       )
+    end
+  end
+
+  describe 'GAIA pack definition' do
+    it 'includes legion-gaia, all lex-agentic-* gems, lex-synapse, lex-mind-growth, and lex-tick' do
+      gaia_gems = described_class::PACKS.fetch(:gaia).fetch(:gems)
+
+      expect(gaia_gems).to include('legion-gaia')
+      expect(gaia_gems).to include(
+        'lex-agentic-affect', 'lex-agentic-attention', 'lex-agentic-defense',
+        'lex-agentic-executive', 'lex-agentic-homeostasis', 'lex-agentic-inference',
+        'lex-agentic-integration', 'lex-agentic-language', 'lex-agentic-learning',
+        'lex-agentic-memory', 'lex-agentic-self', 'lex-agentic-social'
+      )
+      expect(gaia_gems).to include('lex-synapse', 'lex-mind-growth', 'lex-tick')
+    end
+  end
+
+  describe 'identity pack definition' do
+    it 'includes legion-rbac, lex-identity-system, and lex-identity-kerberos' do
+      identity_gems = described_class::PACKS.fetch(:identity).fetch(:gems)
+
+      expect(identity_gems).to include('legion-rbac', 'lex-identity-system', 'lex-identity-kerberos')
     end
   end
 

--- a/spec/legion/cluster/leader_spec.rb
+++ b/spec/legion/cluster/leader_spec.rb
@@ -102,6 +102,9 @@ RSpec.describe 'Cluster::Leader boot integration' do
   before do
     allow(Legion::Logging).to receive(:info)
     allow(Legion::Logging).to receive(:warn)
+    allow(Legion::Logging).to receive(:emit_tagged)
+    allow(Legion::Settings).to receive(:[]).and_call_original
+    allow(Legion::Settings).to receive(:[]).with(:logging).and_return(nil)
   end
 
   context 'when cluster.leader_election is true' do

--- a/spec/legion/extensions/actors/subscription_activate_spec.rb
+++ b/spec/legion/extensions/actors/subscription_activate_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Legion::Extensions::Actors::Subscription#activate' do
+  let(:actor) { Legion::Extensions::Actors::Subscription.allocate }
+  let(:channel) { double('channel') }
+  let(:queue_double) { double('queue', channel: channel) }
+  let(:consumer_double) { double('consumer') }
+
+  before do
+    actor.instance_variable_set(:@queue, queue_double)
+    actor.instance_variable_set(:@consumer, consumer_double)
+    allow(actor).to receive(:lex_name).and_return('test_lex')
+    allow(actor).to receive(:runner_name).and_return('test_runner')
+    allow(actor).to receive(:log).and_return(double('log', warn: nil, info: nil, error: nil, debug: nil))
+  end
+
+  context 'when no consumer exists' do
+    before { actor.instance_variable_set(:@consumer, nil) }
+
+    it 'warns and returns without subscribing' do
+      expect(queue_double).not_to receive(:subscribe_with)
+      actor.activate
+    end
+  end
+
+  context 'when the channel is open' do
+    before { allow(channel).to receive(:open?).and_return(true) }
+
+    it 'subscribes directly without re-preparing' do
+      expect(actor).not_to receive(:prepare)
+      expect(queue_double).to receive(:subscribe_with).with(consumer_double)
+      actor.activate
+    end
+  end
+
+  context 'when the channel is closed' do
+    let(:fresh_channel) { double('fresh_channel') }
+    let(:fresh_queue) { double('fresh_queue', channel: fresh_channel) }
+    let(:fresh_consumer) { double('fresh_consumer') }
+
+    before do
+      allow(channel).to receive(:open?).and_return(false)
+    end
+
+    it 'calls prepare and retries subscribe on fresh channel' do
+      allow(fresh_channel).to receive(:open?).and_return(true)
+      allow(actor).to receive(:prepare) do
+        actor.instance_variable_set(:@queue, fresh_queue)
+        actor.instance_variable_set(:@consumer, fresh_consumer)
+      end
+      expect(fresh_queue).to receive(:subscribe_with).with(fresh_consumer)
+      actor.activate
+    end
+
+    it 'logs and skips subscribe when re-prepare leaves channel closed' do
+      allow(actor).to receive(:prepare) do
+        actor.instance_variable_set(:@queue, fresh_queue)
+        actor.instance_variable_set(:@consumer, fresh_consumer)
+      end
+      allow(fresh_channel).to receive(:open?).and_return(false)
+
+      expect(fresh_queue).not_to receive(:subscribe_with)
+      actor.activate
+    end
+
+    it 'logs and skips subscribe when re-prepare leaves no consumer' do
+      allow(actor).to receive(:prepare) do
+        actor.instance_variable_set(:@queue, fresh_queue)
+        actor.instance_variable_set(:@consumer, nil)
+      end
+      allow(fresh_channel).to receive(:open?).and_return(true)
+
+      expect(fresh_queue).not_to receive(:subscribe_with)
+      actor.activate
+    end
+  end
+end

--- a/spec/legion/privacy_audit_spec.rb
+++ b/spec/legion/privacy_audit_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Enterprise privacy mode audit logging' do
 
       it 'logs an info entry when privacy mode is enabled' do
         Legion::Service.log_privacy_mode_status
-        expect(Legion::Logging).to have_received(:emit_tagged).with(:info, /enterprise_data_privacy.*enabled/, anything)
+        expect(Legion::Logging).to have_received(:emit_tagged).with(:info, /enterprise_data_privacy.*enabled/, any_args)
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe 'Enterprise privacy mode audit logging' do
 
       it 'logs an info entry indicating privacy is disabled' do
         Legion::Service.log_privacy_mode_status
-        expect(Legion::Logging).to have_received(:emit_tagged).with(:info, /enterprise_data_privacy.*disabled/, anything)
+        expect(Legion::Logging).to have_received(:emit_tagged).with(:info, /enterprise_data_privacy.*disabled/, any_args)
       end
     end
 

--- a/spec/legion/privacy_audit_spec.rb
+++ b/spec/legion/privacy_audit_spec.rb
@@ -7,24 +7,28 @@ RSpec.describe 'Enterprise privacy mode audit logging' do
     context 'when privacy mode is enabled' do
       before do
         allow(Legion::Settings).to receive(:enterprise_privacy?).and_return(true)
+        allow(Legion::Settings).to receive(:[]).with(:logging).and_return(nil)
+        allow(Legion::Logging).to receive(:info)
+        allow(Legion::Logging).to receive(:emit_tagged)
       end
 
       it 'logs an info entry when privacy mode is enabled' do
-        allow(Legion::Logging).to receive(:info)
         Legion::Service.log_privacy_mode_status
-        expect(Legion::Logging).to have_received(:info).with(/enterprise_data_privacy.*enabled/)
+        expect(Legion::Logging).to have_received(:emit_tagged).with(:info, /enterprise_data_privacy.*enabled/, anything)
       end
     end
 
     context 'when privacy mode is disabled' do
       before do
         allow(Legion::Settings).to receive(:enterprise_privacy?).and_return(false)
+        allow(Legion::Settings).to receive(:[]).with(:logging).and_return(nil)
+        allow(Legion::Logging).to receive(:info)
+        allow(Legion::Logging).to receive(:emit_tagged)
       end
 
       it 'logs an info entry indicating privacy is disabled' do
-        allow(Legion::Logging).to receive(:info)
         Legion::Service.log_privacy_mode_status
-        expect(Legion::Logging).to have_received(:info).with(/enterprise_data_privacy.*disabled/)
+        expect(Legion::Logging).to have_received(:emit_tagged).with(:info, /enterprise_data_privacy.*disabled/, anything)
       end
     end
 

--- a/spec/legion/service_shutdown_spec.rb
+++ b/spec/legion/service_shutdown_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe Legion::Service do
     allow(Legion::Logging).to receive(:warn)
     allow(Legion::Logging).to receive(:error)
     allow(Legion::Logging).to receive(:debug)
+    allow(Legion::Logging).to receive(:emit_tagged) do |level, msg, **|
+      Legion::Logging.public_send(level, msg) if Legion::Logging.respond_to?(level)
+    end
     allow(Legion::Events).to receive(:emit)
     allow(Legion::Settings).to receive(:[]).and_call_original
     allow(Legion::Settings).to receive(:[]).with(:client).and_return({ ready: true, shutting_down: false })


### PR DESCRIPTION
## Summary

- **Subscription channel recovery**: `Subscription#activate` now checks `channel.open?` before calling `subscribe_with`; if the channel is closed between `prepare` and `activate`, it re-prepares once and retries rather than silently failing
- **DLX guard for non-remote extensions**: `Transport` mixin guards `auto_create_dlx_exchange` and `auto_create_dlx_queue` with a new `remote_invocable_extension?` helper — extensions that return `remote_invocable? = false` no longer attempt to declare DLX topology they never use; also corrects DLX exchange type from `fanout` to `topic`
- **Identity resolver refactor**: `persist_to_db` extracted into `upsert_providers`, `upsert_principal`, `upsert_identities`, `upsert_single_identity` helpers; replaces raw `Legion::Data.db` dataset calls with Sequel model calls
- **Logging modernization**: hand-rolled `log_warn`/`log_debug` guards in `Identity::Resolver`, `Identity::Broker`, and `Identity::LeaseRenewer` replaced with `include Legion::Logging::Helper`; added debug tracing throughout identity resolution flow
- **LLM inference routing**: `/api/llm/inference` now passes `instance` and `tier` hints from request body through to `Legion::LLM::Inference::Request`
- **Spec fixes**: `log_privacy_mode_status`, `shutdown_component`, TLS-fallback, and cluster leader boot specs updated to assert via `emit_tagged` (the actual dispatch path used by `Legion::Logging::Helper`) rather than `Legion::Logging.warn/info` directly; cluster leader spec stubs `Legion::Settings[:logging]` to prevent unexpected-argument errors during `log` initialization

## Test plan

- [ ] `bundle exec rspec` — 5171 examples, 0 failures, 6 pending (pre-existing governance lifecycle stubs)
- [ ] `bundle exec rubocop -A` — 915 files inspected, no offenses
- [ ] Verify subscription actors with intermittent channel closure no longer skip activation silently
- [ ] Verify extensions with `remote_invocable? = false` do not attempt DLX exchange/queue creation on startup