### PR TITLE
Remove lex-llm-ledger from agentic setup pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.9.30] - 2026-05-12
+
+### Changed
+- Removed `lex-llm-ledger` from the agentic setup pack; it is now opt-in via `legionio install lex-llm-ledger`.
+
 ## [1.9.29] - 2026-05-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 ## [1.9.30] - 2026-05-12
 
 ### Changed
-- Removed `lex-llm-ledger` from the agentic setup pack; it is now opt-in via `legionio install lex-llm-ledger`.
+- Slimmed agentic pack to only cognitive/coordination extensions; removed non-agentic gems (`lex-audit`, `lex-autofix`, `lex-codegen`, `lex-cost-scanner`, `lex-dataset`, `lex-factory`, `lex-finops`, `lex-governance`, `lex-llm-ledger`, `lex-onboard`, `lex-pilot-infra-monitor`, `lex-pilot-knowledge-assist`, `lex-prompt`, `lex-react`, `lex-swarm`, `lex-swarm-github`, `lex-transformer`).
+- Added `legion-mcp` to the LLM pack.
+- Added `lex-kerberos` to the identity pack.
+- Added new `developer` pack: `lex-developer`, `lex-dynatrace`, `lex-eval`, `lex-exec`, `lex-github`, `lex-http`, `lex-jfrog`, `lex-skill-superpowers`, `lex-ssh`.
 
 ## [1.9.29] - 2026-05-11
 

--- a/lib/legion/cli/setup_command.rb
+++ b/lib/legion/cli/setup_command.rb
@@ -28,38 +28,32 @@ module Legion
       }.freeze
 
       PACKS = {
-        agentic:  {
-          description: 'Full cognitive stack: core libs, agentic domains, AI providers, and operational extensions',
+        agentic:   {
+          description: 'Cognitive stack: agentic domains, AI providers, and coordination',
           gems:        %w[
             legion-apollo legion-gaia legion-llm legion-mcp legion-rbac
             lex-acp lex-adapter lex-agentic-affect lex-agentic-attention
             lex-agentic-defense lex-agentic-executive lex-agentic-homeostasis
             lex-agentic-imagination lex-agentic-inference lex-agentic-integration
             lex-agentic-language lex-agentic-learning lex-agentic-memory
-            lex-agentic-self lex-agentic-social lex-apollo lex-audit lex-autofix
-            lex-codegen lex-coldstart
-            lex-conditioner lex-cost-scanner lex-dataset lex-detect
-            lex-eval lex-exec lex-extinction lex-factory lex-finops
-            lex-governance lex-kerberos lex-knowledge lex-llm
-            lex-llm-anthropic lex-llm-azure-foundry lex-llm-bedrock
-            lex-llm-gemini lex-llm-mlx
-            lex-llm-ollama lex-llm-openai lex-llm-vertex lex-llm-vllm
-            lex-metering lex-mesh lex-microsoft_teams lex-mind-growth lex-node
-            lex-onboard lex-pilot-infra-monitor
-            lex-pilot-knowledge-assist lex-privatecore lex-prompt lex-react
-            lex-swarm lex-swarm-github lex-synapse lex-telemetry lex-tick
-            lex-transformer
+            lex-agentic-self lex-agentic-social lex-apollo lex-coldstart
+            lex-conditioner lex-detect lex-extinction lex-kerberos lex-knowledge
+            lex-llm lex-llm-anthropic lex-llm-azure-foundry lex-llm-bedrock
+            lex-llm-gemini lex-llm-mlx lex-llm-ollama lex-llm-openai
+            lex-llm-vertex lex-llm-vllm lex-metering lex-mesh
+            lex-microsoft_teams lex-mind-growth lex-node lex-privatecore
+            lex-synapse lex-telemetry lex-tick
           ]
         },
-        llm:      {
+        llm:       {
           description: 'LLM routing and provider integration (no cognitive stack)',
           gems:        %w[
-            legion-llm lex-llm lex-llm-anthropic lex-llm-azure-foundry
+            legion-llm legion-mcp lex-llm lex-llm-anthropic lex-llm-azure-foundry
             lex-llm-bedrock lex-llm-gemini lex-llm-mlx
             lex-llm-ollama lex-llm-openai lex-llm-vertex lex-llm-vllm
           ]
         },
-        gaia:     {
+        gaia:      {
           description: 'Cognitive coordination engine + agentic extensions (GAIA stack)',
           gems:        %w[
             legion-gaia
@@ -70,13 +64,20 @@ module Legion
             lex-synapse lex-mind-growth lex-tick
           ]
         },
-        identity: {
+        identity:  {
           description: 'Identity and access management (RBAC + identity providers)',
           gems:        %w[
-            legion-rbac lex-identity-system lex-identity-kerberos
+            legion-rbac lex-identity-system lex-identity-kerberos lex-kerberos
           ]
         },
-        channels: {
+        developer: {
+          description: 'Developer tooling and CI/CD integrations',
+          gems:        %w[
+            lex-developer lex-dynatrace lex-eval lex-exec lex-github
+            lex-http lex-jfrog lex-skill-superpowers lex-ssh
+          ]
+        },
+        channels:  {
           description: 'Channel adapters for chat platforms',
           gems:        %w[lex-slack lex-microsoft_teams]
         }

--- a/lib/legion/cli/setup_command.rb
+++ b/lib/legion/cli/setup_command.rb
@@ -42,7 +42,7 @@ module Legion
             lex-eval lex-exec lex-extinction lex-factory lex-finops
             lex-governance lex-kerberos lex-knowledge lex-llm
             lex-llm-anthropic lex-llm-azure-foundry lex-llm-bedrock
-            lex-llm-gemini lex-llm-ledger lex-llm-mlx
+            lex-llm-gemini lex-llm-mlx
             lex-llm-ollama lex-llm-openai lex-llm-vertex lex-llm-vllm
             lex-metering lex-mesh lex-microsoft_teams lex-mind-growth lex-node
             lex-onboard lex-pilot-infra-monitor

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.29'
+  VERSION = '1.9.30'
 end


### PR DESCRIPTION
## Summary
- Removed `lex-llm-ledger` from the agentic pack in `legionio setup agentic`
- Bumped version to 1.9.30

lex-llm-ledger is an observability/cost-tracking extension that pulls in `legion-data` and `legion-transport` dependencies. It shouldn't be bundled by default — users who want LLM usage tracking can opt in via `legionio install lex-llm-ledger`.

## Test plan
- [x] Full RSpec suite passes
- [ ] Verify `legionio setup agentic --dry-run` no longer lists lex-llm-ledger