### PR TITLE
Strip RubyLLM from CLI chat tools, migrate to Legion::Tools::Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.9.33] - 2026-05-15
+
+### Added
+- `Legion::Identity::Process` stores and exposes `db_principal_id` and `db_identity_id` integer PKs — present in `EMPTY_STATE`, persisted through `bind!`, and included in `identity_hash`. Both default to nil until an identity provider populates them.
+
 ## [1.9.32] - 2026-05-14
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [1.9.32] - 2026-05-14
+
+### Removed
+- Removed `gem 'ruby_llm'` dependency from Gemfile; all 40 CLI chat tools now use `Legion::Tools::Base` natively.
+
+### Changed
+- Migrated all 40 CLI chat tool classes from `RubyLLM::Tool` to `Legion::Tools::Base`:
+  - `param` DSL replaced with `input_schema` (JSON Schema hash)
+  - `def execute` instance method replaced with `def self.call` class method
+  - Explicit `tool_name 'legion.<snake_case>'` added to each tool
+  - Private instance helpers converted to class methods
+- Updated `tool_registry.rb`: removed `require 'ruby_llm'` and `begin/rescue LoadError` guard.
+- Updated `extension_tool_loader.rb`: `klass < RubyLLM::Tool` changed to `klass < Legion::Tools::Base`.
+- Updated `generate_command.rb` tool template to emit `Legion::Tools::Base` with `input_schema` and `def self.call`.
+- `Permissions::Gate` now prepends on the singleton class to intercept `self.call` correctly.
+
 ## [1.9.31] - 2026-05-14
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,5 @@ group :test do
   gem 'rubocop'
   gem 'rubocop-legion'
   gem 'rubocop-rspec'
-  gem 'ruby_llm'
   gem 'simplecov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,36 +8,39 @@ gem 'pg'
 gem 'kramdown', '>= 2.0'
 gem 'mysql2'
 
+gem 'legion-data', path: '../legion-data' if File.exist?(File.expand_path('../legion-data', __dir__))
+gem 'legion-logging', path: '../legion-logging' if File.exist?(File.expand_path('../legion-logging', __dir__))
+gem 'legion-settings', path: '../legion-settings' if File.exist?(File.expand_path('../legion-settings', __dir__))
+
+gem 'legion-apollo', path: '../legion-apollo' if File.exist?(File.expand_path('../legion-apollo', __dir__))
+gem 'legion-gaia', path: '../legion-gaia' if File.exist?(File.expand_path('../legion-gaia', __dir__))
+gem 'legion-llm', path: '../legion-llm' if File.exist?(File.expand_path('../legion-llm', __dir__))
+gem 'legion-mcp', path: '../legion-mcp' if File.exist?(File.expand_path('../legion-mcp', __dir__))
+gem 'legion-tty', path: '../legion-tty' if File.exist?(File.expand_path('../legion-tty', __dir__))
+
+gem 'lex-apollo', path: '../extensions/lex-apollo' if File.exist?(File.expand_path('../extensions/lex-apollo', __dir__))
+
+gem 'lex-kerberos', path: '../extensions-identity/lex-kerberos'
+
+gem 'lex-llm', path: '../extensions-ai/lex-llm' if File.exist?(File.expand_path('../extensions-ai/lex-llm', __dir__))
+gem 'lex-llm-ledger', path: '../extensions-ai/lex-llm-ledger' if File.exist?(File.expand_path('../extensions-ai/lex-llm-ledger', __dir__))
+
+if File.exist?(File.expand_path('../extensions-identity/lex-identity-entra', __dir__))
+  gem 'lex-identity-entra', path: '../extensions-identity/lex-identity-entra'
+end
+if File.exist?(File.expand_path('../extensions-identity/lex-identity-kerberos', __dir__))
+  gem 'lex-identity-kerberos', path: '../extensions-identity/lex-identity-kerberos'
+end
+if File.exist?(File.expand_path('../extensions-identity/lex-identity-system', __dir__))
+  gem 'lex-identity-system', path: '../extensions-identity/lex-identity-system'
+end
+
+%w[anthropic azure-foundry bedrock gemini mlx ollama openai vertex vllm].each do |provider|
+  provider_path = "../extensions-ai/lex-llm-#{provider}"
+  gem "lex-llm-#{provider}", path: provider_path if File.exist?(File.expand_path(provider_path, __dir__))
+end
+
 group :test do
-  gem 'legion-data', path: '../legion-data' if File.exist?(File.expand_path('../legion-data', __dir__))
-  gem 'legion-logging', path: '../legion-logging' if File.exist?(File.expand_path('../legion-logging', __dir__))
-  gem 'legion-settings', path: '../legion-settings' if File.exist?(File.expand_path('../legion-settings', __dir__))
-
-  gem 'legion-apollo', path: '../legion-apollo' if File.exist?(File.expand_path('../legion-apollo', __dir__))
-  gem 'legion-gaia', path: '../legion-gaia' if File.exist?(File.expand_path('../legion-gaia', __dir__))
-  gem 'legion-llm', path: '../legion-llm' if File.exist?(File.expand_path('../legion-llm', __dir__))
-  gem 'legion-mcp', path: '../legion-mcp' if File.exist?(File.expand_path('../legion-mcp', __dir__))
-  gem 'legion-tty', path: '../legion-tty' if File.exist?(File.expand_path('../legion-tty', __dir__))
-
-  gem 'lex-apollo', path: '../extensions/lex-apollo' if File.exist?(File.expand_path('../extensions/lex-apollo', __dir__))
-  gem 'lex-llm', path: '../extensions-ai/lex-llm' if File.exist?(File.expand_path('../extensions-ai/lex-llm', __dir__))
-  gem 'lex-llm-ledger', path: '../extensions-ai/lex-llm-ledger' if File.exist?(File.expand_path('../extensions-ai/lex-llm-ledger', __dir__))
-
-  if File.exist?(File.expand_path('../extensions-identity/lex-identity-entra', __dir__))
-    gem 'lex-identity-entra', path: '../extensions-identity/lex-identity-entra'
-  end
-  if File.exist?(File.expand_path('../extensions-identity/lex-identity-kerberos', __dir__))
-    gem 'lex-identity-kerberos', path: '../extensions-identity/lex-identity-kerberos'
-  end
-  if File.exist?(File.expand_path('../extensions-identity/lex-identity-system', __dir__))
-    gem 'lex-identity-system', path: '../extensions-identity/lex-identity-system'
-  end
-
-  %w[anthropic azure-foundry bedrock gemini mlx ollama openai vertex vllm].each do |provider|
-    provider_path = "../extensions-ai/lex-llm-#{provider}"
-    gem "lex-llm-#{provider}", path: provider_path if File.exist?(File.expand_path(provider_path, __dir__))
-  end
-
   gem 'faraday'
   gem 'faraday-net_http'
   gem 'graphql'

--- a/Gemfile
+++ b/Gemfile
@@ -8,39 +8,36 @@ gem 'pg'
 gem 'kramdown', '>= 2.0'
 gem 'mysql2'
 
-gem 'legion-data', path: '../legion-data' if File.exist?(File.expand_path('../legion-data', __dir__))
-gem 'legion-logging', path: '../legion-logging' if File.exist?(File.expand_path('../legion-logging', __dir__))
-gem 'legion-settings', path: '../legion-settings' if File.exist?(File.expand_path('../legion-settings', __dir__))
-
-gem 'legion-apollo', path: '../legion-apollo' if File.exist?(File.expand_path('../legion-apollo', __dir__))
-gem 'legion-gaia', path: '../legion-gaia' if File.exist?(File.expand_path('../legion-gaia', __dir__))
-gem 'legion-llm', path: '../legion-llm' if File.exist?(File.expand_path('../legion-llm', __dir__))
-gem 'legion-mcp', path: '../legion-mcp' if File.exist?(File.expand_path('../legion-mcp', __dir__))
-gem 'legion-tty', path: '../legion-tty' if File.exist?(File.expand_path('../legion-tty', __dir__))
-
-gem 'lex-apollo', path: '../extensions/lex-apollo' if File.exist?(File.expand_path('../extensions/lex-apollo', __dir__))
-
-gem 'lex-kerberos', path: '../extensions-identity/lex-kerberos'
-
-gem 'lex-llm', path: '../extensions-ai/lex-llm' if File.exist?(File.expand_path('../extensions-ai/lex-llm', __dir__))
-gem 'lex-llm-ledger', path: '../extensions-ai/lex-llm-ledger' if File.exist?(File.expand_path('../extensions-ai/lex-llm-ledger', __dir__))
-
-if File.exist?(File.expand_path('../extensions-identity/lex-identity-entra', __dir__))
-  gem 'lex-identity-entra', path: '../extensions-identity/lex-identity-entra'
-end
-if File.exist?(File.expand_path('../extensions-identity/lex-identity-kerberos', __dir__))
-  gem 'lex-identity-kerberos', path: '../extensions-identity/lex-identity-kerberos'
-end
-if File.exist?(File.expand_path('../extensions-identity/lex-identity-system', __dir__))
-  gem 'lex-identity-system', path: '../extensions-identity/lex-identity-system'
-end
-
-%w[anthropic azure-foundry bedrock gemini mlx ollama openai vertex vllm].each do |provider|
-  provider_path = "../extensions-ai/lex-llm-#{provider}"
-  gem "lex-llm-#{provider}", path: provider_path if File.exist?(File.expand_path(provider_path, __dir__))
-end
-
 group :test do
+  gem 'legion-data', path: '../legion-data' if File.exist?(File.expand_path('../legion-data', __dir__))
+  gem 'legion-logging', path: '../legion-logging' if File.exist?(File.expand_path('../legion-logging', __dir__))
+  gem 'legion-settings', path: '../legion-settings' if File.exist?(File.expand_path('../legion-settings', __dir__))
+
+  gem 'legion-apollo', path: '../legion-apollo' if File.exist?(File.expand_path('../legion-apollo', __dir__))
+  gem 'legion-gaia', path: '../legion-gaia' if File.exist?(File.expand_path('../legion-gaia', __dir__))
+  gem 'legion-llm', path: '../legion-llm' if File.exist?(File.expand_path('../legion-llm', __dir__))
+  gem 'legion-mcp', path: '../legion-mcp' if File.exist?(File.expand_path('../legion-mcp', __dir__))
+  gem 'legion-tty', path: '../legion-tty' if File.exist?(File.expand_path('../legion-tty', __dir__))
+
+  gem 'lex-apollo', path: '../extensions/lex-apollo' if File.exist?(File.expand_path('../extensions/lex-apollo', __dir__))
+  gem 'lex-llm', path: '../extensions-ai/lex-llm' if File.exist?(File.expand_path('../extensions-ai/lex-llm', __dir__))
+  gem 'lex-llm-ledger', path: '../extensions-ai/lex-llm-ledger' if File.exist?(File.expand_path('../extensions-ai/lex-llm-ledger', __dir__))
+
+  if File.exist?(File.expand_path('../extensions-identity/lex-identity-entra', __dir__))
+    gem 'lex-identity-entra', path: '../extensions-identity/lex-identity-entra'
+  end
+  if File.exist?(File.expand_path('../extensions-identity/lex-identity-kerberos', __dir__))
+    gem 'lex-identity-kerberos', path: '../extensions-identity/lex-identity-kerberos'
+  end
+  if File.exist?(File.expand_path('../extensions-identity/lex-identity-system', __dir__))
+    gem 'lex-identity-system', path: '../extensions-identity/lex-identity-system'
+  end
+
+  %w[anthropic azure-foundry bedrock gemini mlx ollama openai vertex vllm].each do |provider|
+    provider_path = "../extensions-ai/lex-llm-#{provider}"
+    gem "lex-llm-#{provider}", path: provider_path if File.exist?(File.expand_path(provider_path, __dir__))
+  end
+
   gem 'faraday'
   gem 'faraday-net_http'
   gem 'graphql'

--- a/lib/legion/cli/chat/extension_tool_loader.rb
+++ b/lib/legion/cli/chat/extension_tool_loader.rb
@@ -24,7 +24,7 @@ module Legion
           def collect_tool_classes(tools_module)
             tools_module.constants.filter_map do |const_name|
               klass = tools_module.const_get(const_name)
-              klass if klass.is_a?(Class) && klass < RubyLLM::Tool
+              klass if klass.is_a?(Class) && klass < Legion::Tools::Base
             end
           end
 

--- a/lib/legion/cli/chat/permissions.rb
+++ b/lib/legion/cli/chat/permissions.rb
@@ -58,16 +58,15 @@ module Legion
           def apply!(tool_classes)
             tool_classes.each do |klass|
               tier = tier_for(klass)
-              klass.prepend(Gate) unless tier == :read
+              klass.singleton_class.prepend(Gate) unless tier == :read
             end
           end
         end
 
         module Gate
-          def call(args)
-            normalized = normalize_args(args)
-            desc = permission_description(normalized)
-            return 'Tool execution denied by user.' unless Permissions.confirm?(desc)
+          def call(**args)
+            desc = permission_description(args)
+            return error_response('Tool execution denied by user.') unless Permissions.confirm?(desc)
 
             super
           end
@@ -75,11 +74,11 @@ module Legion
           private
 
           def permission_description(args)
-            tier = Permissions.tier_for(self.class)
+            tier = Permissions.tier_for(self)
             case tier
             when :write
               path = args[:path] || '(unknown)'
-              action = self.class.name.split('::').last.gsub(/([a-z])([A-Z])/, '\1 \2')
+              action = name.split('::').last.gsub(/([a-z])([A-Z])/, '\1 \2')
               "#{action}: #{path}"
             when :shell
               "Run command: #{args[:command]}"

--- a/lib/legion/cli/chat/tool_registry.rb
+++ b/lib/legion/cli/chat/tool_registry.rb
@@ -2,52 +2,46 @@
 
 require 'legion/cli/chat_command'
 
-begin
-  require 'ruby_llm'
-
-  require 'legion/cli/chat/tools/read_file'
-  require 'legion/cli/chat/tools/write_file'
-  require 'legion/cli/chat/tools/edit_file'
-  require 'legion/cli/chat/tools/search_files'
-  require 'legion/cli/chat/tools/search_content'
-  require 'legion/cli/chat/tools/run_command'
-  require 'legion/cli/chat/tools/save_memory'
-  require 'legion/cli/chat/tools/search_memory'
-  require 'legion/cli/chat/tools/web_search'
-  require 'legion/cli/chat/tools/spawn_agent'
-  require 'legion/cli/chat/tools/search_traces'
-  require 'legion/cli/chat/tools/query_knowledge'
-  require 'legion/cli/chat/tools/ingest_knowledge'
-  require 'legion/cli/chat/tools/consolidate_memory'
-  require 'legion/cli/chat/tools/relate_knowledge'
-  require 'legion/cli/chat/tools/knowledge_maintenance'
-  require 'legion/cli/chat/tools/knowledge_stats'
-  require 'legion/cli/chat/tools/summarize_traces'
-  require 'legion/cli/chat/tools/list_extensions'
-  require 'legion/cli/chat/tools/manage_tasks'
-  require 'legion/cli/chat/tools/system_status'
-  require 'legion/cli/chat/tools/view_events'
-  require 'legion/cli/chat/tools/cost_summary'
-  require 'legion/cli/chat/tools/reflect'
-  require 'legion/cli/chat/tools/manage_schedules'
-  require 'legion/cli/chat/tools/worker_status'
-  require 'legion/cli/chat/tools/detect_anomalies'
-  require 'legion/cli/chat/tools/view_trends'
-  require 'legion/cli/chat/tools/trigger_dream'
-  require 'legion/cli/chat/tools/generate_insights'
-  require 'legion/cli/chat/tools/budget_status'
-  require 'legion/cli/chat/tools/provider_health'
-  require 'legion/cli/chat/tools/model_comparison'
-  require 'legion/cli/chat/tools/shadow_eval_status'
-  require 'legion/cli/chat/tools/entity_extract'
-  require 'legion/cli/chat/tools/arbitrage_status'
-  require 'legion/cli/chat/tools/escalation_status'
-  require 'legion/cli/chat/tools/graph_explore'
-  require 'legion/cli/chat/tools/scheduling_status'
-  require 'legion/cli/chat/tools/memory_status'
-rescue LoadError => e
-  Legion::Logging.debug("ToolRegistry ruby_llm not available, chat tools will not be registered: #{e.message}") if defined?(Legion::Logging)
-end
+require 'legion/cli/chat/tools/read_file'
+require 'legion/cli/chat/tools/write_file'
+require 'legion/cli/chat/tools/edit_file'
+require 'legion/cli/chat/tools/search_files'
+require 'legion/cli/chat/tools/search_content'
+require 'legion/cli/chat/tools/run_command'
+require 'legion/cli/chat/tools/save_memory'
+require 'legion/cli/chat/tools/search_memory'
+require 'legion/cli/chat/tools/web_search'
+require 'legion/cli/chat/tools/spawn_agent'
+require 'legion/cli/chat/tools/search_traces'
+require 'legion/cli/chat/tools/query_knowledge'
+require 'legion/cli/chat/tools/ingest_knowledge'
+require 'legion/cli/chat/tools/consolidate_memory'
+require 'legion/cli/chat/tools/relate_knowledge'
+require 'legion/cli/chat/tools/knowledge_maintenance'
+require 'legion/cli/chat/tools/knowledge_stats'
+require 'legion/cli/chat/tools/summarize_traces'
+require 'legion/cli/chat/tools/list_extensions'
+require 'legion/cli/chat/tools/manage_tasks'
+require 'legion/cli/chat/tools/system_status'
+require 'legion/cli/chat/tools/view_events'
+require 'legion/cli/chat/tools/cost_summary'
+require 'legion/cli/chat/tools/reflect'
+require 'legion/cli/chat/tools/manage_schedules'
+require 'legion/cli/chat/tools/worker_status'
+require 'legion/cli/chat/tools/detect_anomalies'
+require 'legion/cli/chat/tools/view_trends'
+require 'legion/cli/chat/tools/trigger_dream'
+require 'legion/cli/chat/tools/generate_insights'
+require 'legion/cli/chat/tools/budget_status'
+require 'legion/cli/chat/tools/provider_health'
+require 'legion/cli/chat/tools/model_comparison'
+require 'legion/cli/chat/tools/shadow_eval_status'
+require 'legion/cli/chat/tools/entity_extract'
+require 'legion/cli/chat/tools/arbitrage_status'
+require 'legion/cli/chat/tools/escalation_status'
+require 'legion/cli/chat/tools/graph_explore'
+require 'legion/cli/chat/tools/scheduling_status'
+require 'legion/cli/chat/tools/memory_status'
 
 require 'legion/cli/chat/permissions'
 
@@ -55,54 +49,50 @@ module Legion
   module CLI
     class Chat
       module ToolRegistry
-        BUILTIN_TOOLS = if defined?(Tools::ReadFile)
-                          [
-                            Tools::ReadFile,
-                            Tools::WriteFile,
-                            Tools::EditFile,
-                            Tools::SearchFiles,
-                            Tools::SearchContent,
-                            Tools::RunCommand,
-                            Tools::SaveMemory,
-                            Tools::SearchMemory,
-                            Tools::WebSearch,
-                            Tools::SpawnAgent,
-                            Tools::SearchTraces,
-                            Tools::QueryKnowledge,
-                            Tools::IngestKnowledge,
-                            Tools::ConsolidateMemory,
-                            Tools::RelateKnowledge,
-                            Tools::KnowledgeMaintenance,
-                            Tools::KnowledgeStats,
-                            Tools::SummarizeTraces,
-                            Tools::ListExtensions,
-                            Tools::ManageTasks,
-                            Tools::SystemStatus,
-                            Tools::ViewEvents,
-                            Tools::CostSummary,
-                            Tools::Reflect,
-                            Tools::ManageSchedules,
-                            Tools::WorkerStatus,
-                            Tools::DetectAnomalies,
-                            Tools::ViewTrends,
-                            Tools::TriggerDream,
-                            Tools::GenerateInsights,
-                            Tools::BudgetStatus,
-                            Tools::ProviderHealth,
-                            Tools::ModelComparison,
-                            Tools::ShadowEvalStatus,
-                            Tools::EntityExtract,
-                            Tools::ArbitrageStatus,
-                            Tools::EscalationStatus,
-                            Tools::GraphExplore,
-                            Tools::SchedulingStatus,
-                            Tools::MemoryStatus
-                          ].freeze
-                        else
-                          [].freeze
-                        end
+        BUILTIN_TOOLS = [
+          Tools::ReadFile,
+          Tools::WriteFile,
+          Tools::EditFile,
+          Tools::SearchFiles,
+          Tools::SearchContent,
+          Tools::RunCommand,
+          Tools::SaveMemory,
+          Tools::SearchMemory,
+          Tools::WebSearch,
+          Tools::SpawnAgent,
+          Tools::SearchTraces,
+          Tools::QueryKnowledge,
+          Tools::IngestKnowledge,
+          Tools::ConsolidateMemory,
+          Tools::RelateKnowledge,
+          Tools::KnowledgeMaintenance,
+          Tools::KnowledgeStats,
+          Tools::SummarizeTraces,
+          Tools::ListExtensions,
+          Tools::ManageTasks,
+          Tools::SystemStatus,
+          Tools::ViewEvents,
+          Tools::CostSummary,
+          Tools::Reflect,
+          Tools::ManageSchedules,
+          Tools::WorkerStatus,
+          Tools::DetectAnomalies,
+          Tools::ViewTrends,
+          Tools::TriggerDream,
+          Tools::GenerateInsights,
+          Tools::BudgetStatus,
+          Tools::ProviderHealth,
+          Tools::ModelComparison,
+          Tools::ShadowEvalStatus,
+          Tools::EntityExtract,
+          Tools::ArbitrageStatus,
+          Tools::EscalationStatus,
+          Tools::GraphExplore,
+          Tools::SchedulingStatus,
+          Tools::MemoryStatus
+        ].freeze
 
-        Permissions.apply!(BUILTIN_TOOLS) unless BUILTIN_TOOLS.empty?
+        Permissions.apply!(BUILTIN_TOOLS)
 
         def self.builtin_tools
           BUILTIN_TOOLS.dup

--- a/lib/legion/cli/chat/tools/arbitrage_status.rb
+++ b/lib/legion/cli/chat/tools/arbitrage_status.rb
@@ -4,17 +4,20 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class ArbitrageStatus < RubyLLM::Tool
+        class ArbitrageStatus < Legion::Tools::Base
+          tool_name 'legion.arbitrage_status'
           description 'Show LLM cost arbitrage status: model pricing table, cheapest model per capability tier'
-
-          param :capability,
-                type:     :string,
-                desc:     'Capability tier to check: basic, moderate, or reasoning (default: show all)',
-                required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           capability: { type: 'string', description: 'Capability tier to check: basic, moderate, or reasoning (default: show all)' }
+                         },
+                         required:   []
+                       })
 
           TIERS = %i[basic moderate reasoning].freeze
 
-          def execute(capability: nil)
+          def self.call(capability: nil)
             return 'LLM arbitrage module not available.' unless arbitrage_available?
 
             if capability
@@ -24,13 +27,11 @@ module Legion
             end
           end
 
-          private
-
-          def arbitrage_available?
+          def self.arbitrage_available?
             defined?(Legion::LLM::Arbitrage)
           end
 
-          def format_overview
+          def self.format_overview
             arb = Legion::LLM::Arbitrage
             lines = ["LLM Cost Arbitrage\n"]
             lines << format('  Enabled: %<v>s', v: arb.enabled? ? 'YES' : 'no')
@@ -56,7 +57,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_tier(tier)
+          def self.format_tier(tier)
             arb = Legion::LLM::Arbitrage
             return format('Invalid tier: %<t>s. Use: %<valid>s', t: tier, valid: TIERS.join(', ')) unless TIERS.include?(tier)
 

--- a/lib/legion/cli/chat/tools/budget_status.rb
+++ b/lib/legion/cli/chat/tools/budget_status.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
-
 begin
   require 'legion/cli/chat_command'
 rescue LoadError
@@ -12,15 +10,20 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class BudgetStatus < RubyLLM::Tool
+        class BudgetStatus < Legion::Tools::Base
+          tool_name 'legion.budget_status'
           description 'Check the current LLM session cost budget status. Shows how much has been spent, ' \
                       'remaining budget, and whether the budget guard is enforcing limits. Works locally ' \
                       'without needing the Legion daemon. Use this when the user asks about spending or budget.'
-          param :action, type:     'string',
-                         desc:     'Action: "status" (default), "summary" (cost breakdown by model)',
-                         required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action: { type: 'string', description: 'Action: "status" (default), "summary" (cost breakdown by model)' }
+                         },
+                         required:   []
+                       })
 
-          def execute(action: 'status')
+          def self.call(action: 'status')
             return 'Legion::LLM not available.' unless llm_available?
 
             case action.to_s
@@ -32,9 +35,7 @@ module Legion
             "Error checking budget: #{e.message}"
           end
 
-          private
-
-          def format_status
+          def self.format_status
             guard = budget_guard_status
             tracker = cost_summary
             lines = ["Session Budget Status:\n"]
@@ -49,7 +50,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_summary
+          def self.format_summary
             tracker = cost_summary
             return 'No LLM requests recorded this session.' if tracker[:total_requests].zero?
 
@@ -63,7 +64,7 @@ module Legion
             lines.join("\n")
           end
 
-          def append_model_breakdown(lines, by_model)
+          def self.append_model_breakdown(lines, by_model)
             return unless by_model&.any?
 
             lines << "\n  By Model:"
@@ -73,31 +74,31 @@ module Legion
             end
           end
 
-          def budget_guard_status
+          def self.budget_guard_status
             return { enforcing: false, budget_usd: 0.0, ratio: 0.0 } unless budget_guard_available?
 
             Legion::LLM::Hooks::BudgetGuard.status
           end
 
-          def cost_summary
+          def self.cost_summary
             return empty_summary unless cost_tracker_available?
 
             Legion::LLM::CostTracker.summary
           end
 
-          def budget_guard_available?
+          def self.budget_guard_available?
             defined?(Legion::LLM::Hooks::BudgetGuard)
           end
 
-          def cost_tracker_available?
+          def self.cost_tracker_available?
             defined?(Legion::LLM::CostTracker)
           end
 
-          def llm_available?
+          def self.llm_available?
             defined?(Legion::LLM)
           end
 
-          def empty_summary
+          def self.empty_summary
             { total_cost_usd: 0.0, total_requests: 0, total_input_tokens: 0, total_output_tokens: 0, by_model: {} }
           end
         end

--- a/lib/legion/cli/chat/tools/consolidate_memory.rb
+++ b/lib/legion/cli/chat/tools/consolidate_memory.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
-
 begin
   require 'legion/cli/chat_command'
   require 'legion/cli/chat/memory_store'
@@ -13,12 +11,19 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class ConsolidateMemory < RubyLLM::Tool
+        class ConsolidateMemory < Legion::Tools::Base
+          tool_name 'legion.consolidate_memory'
           description 'Consolidate and organize memory entries by removing duplicates, merging related items, ' \
                       'and creating cleaner summaries. Use this when memory has grown cluttered or has redundant entries. ' \
                       'Pass scope "project" or "global" to target the right memory file.'
-          param :scope, type: 'string', desc: 'Memory scope: "project" or "global" (default: project)'
-          param :dry_run, type: 'string', desc: 'Set to "true" to preview without writing (default: false)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           scope:   { type: 'string', description: 'Memory scope: "project" or "global" (default: project)' },
+                           dry_run: { type: 'string', description: 'Set to "true" to preview without writing (default: false)' }
+                         },
+                         required:   []
+                       })
 
           CONSOLIDATION_PROMPT = <<~PROMPT
             You are a memory consolidation engine. Given a list of memory entries, produce a cleaned-up version that:
@@ -34,7 +39,7 @@ module Legion
             Do NOT add headers, explanations, or commentary.
           PROMPT
 
-          def execute(scope: 'project', dry_run: nil)
+          def self.call(scope: 'project', dry_run: nil)
             dry_run = dry_run.to_s == 'true'
             scope_sym = scope.to_s == 'global' ? :global : :project
 
@@ -60,9 +65,7 @@ module Legion
             "Error consolidating memory: #{e.message}"
           end
 
-          private
-
-          def consolidate_entries(entries)
+          def self.consolidate_entries(entries)
             return nil unless defined?(Legion::LLM) && Legion::LLM.respond_to?(:chat_direct)
 
             numbered = entries.map.with_index(1) { |e, i| "#{i}. #{e}" }.join("\n")
@@ -72,7 +75,7 @@ module Legion
             response.content
           end
 
-          def parse_consolidated(text)
+          def self.parse_consolidated(text)
             text.lines
                 .map(&:strip)
                 .select { |line| line.start_with?('- ') }
@@ -80,7 +83,7 @@ module Legion
                 .reject(&:empty?)
           end
 
-          def write_consolidated(entries, scope_sym)
+          def self.write_consolidated(entries, scope_sym)
             path = scope_sym == :global ? MemoryStore.global_path : MemoryStore.project_path
             header = scope_sym == :global ? "# Global Memory\n" : "# Project Memory\n"
             timestamp = Time.now.strftime('%Y-%m-%d %H:%M')

--- a/lib/legion/cli/chat/tools/cost_summary.rb
+++ b/lib/legion/cli/chat/tools/cost_summary.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,20 +13,25 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class CostSummary < RubyLLM::Tool
+        class CostSummary < Legion::Tools::Base
+          tool_name 'legion.cost_summary'
           description 'Get cost and token usage summary from the running Legion daemon. Shows spending ' \
                       'for today, this week, and this month, plus top cost consumers by worker. ' \
                       'Use this to monitor LLM spending and identify expensive operations.'
-          param :action, type:     'string',
-                         desc:     'Action: "summary" (default), "top" (top consumers), or "worker" (specific worker)',
-                         required: false
-          param :worker_id, type: 'string', desc: 'Worker ID (required for "worker" action)', required: false
-          param :limit, type: 'integer', desc: 'Number of top consumers to show (default: 5)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action:    { type: 'string', description: 'Action: "summary" (default), "top" (top consumers), or "worker" (specific worker)' },
+                           worker_id: { type: 'string', description: 'Worker ID (required for "worker" action)' },
+                           limit:     { type: 'integer', description: 'Number of top consumers to show (default: 5)' }
+                         },
+                         required:   []
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(action: 'summary', worker_id: nil, limit: 5)
+          def self.call(action: 'summary', worker_id: nil, limit: 5)
             case action.to_s
             when 'top'
               handle_top(limit.to_i.clamp(1, 20))
@@ -45,9 +49,7 @@ module Legion
             "Error fetching cost data: #{e.message}"
           end
 
-          private
-
-          def handle_summary
+          def self.handle_summary
             data = api_get('/api/costs/summary?period=month')
             return "API error: #{data[:error]}" if data[:error]
 
@@ -60,7 +62,7 @@ module Legion
             lines.join("\n")
           end
 
-          def handle_top(limit)
+          def self.handle_top(limit)
             data = api_get('/api/workers')
             return "API error: #{data[:error]}" if data[:error]
 
@@ -77,7 +79,7 @@ module Legion
             lines.join("\n")
           end
 
-          def handle_worker(worker_id)
+          def self.handle_worker(worker_id)
             data = api_get("/api/workers/#{worker_id}/value")
             return "API error: #{data[:error]}" if data[:error]
 
@@ -91,7 +93,7 @@ module Legion
             lines.join("\n")
           end
 
-          def fetch_worker_cost(worker_id)
+          def self.fetch_worker_cost(worker_id)
             data = api_get("/api/workers/#{worker_id}/value")
             data = data[:data] || data
             (data[:total_cost_usd] || 0).to_f
@@ -99,7 +101,7 @@ module Legion
             0.0
           end
 
-          def api_get(path)
+          def self.api_get(path)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 2
@@ -108,7 +110,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/detect_anomalies.rb
+++ b/lib/legion/cli/chat/tools/detect_anomalies.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,18 +13,23 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class DetectAnomalies < RubyLLM::Tool
+        class DetectAnomalies < Legion::Tools::Base
+          tool_name 'legion.detect_anomalies'
           description 'Detect anomalies in recent task execution metrics by comparing the last hour against ' \
                       'the previous 23-hour baseline. Reports cost spikes, latency increases, and failure rate ' \
                       'changes. Use this proactively to check system health or when investigating issues.'
-          param :threshold, type:     'number',
-                            desc:     'Anomaly detection threshold multiplier (default: 2.0, higher = less sensitive)',
-                            required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           threshold: { type: 'number', description: 'Anomaly detection threshold multiplier (default: 2.0, higher = less sensitive)' }
+                         },
+                         required:   []
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(threshold: 2.0)
+          def self.call(threshold: 2.0)
             data = api_get("/api/traces/anomalies?threshold=#{threshold.to_f}")
             return "API error: #{data[:error][:message]}" if data[:error]
 
@@ -37,9 +41,7 @@ module Legion
             "Error detecting anomalies: #{e.message}"
           end
 
-          private
-
-          def format_report(data)
+          def self.format_report(data)
             anomalies = data[:anomalies] || []
             lines = ["Anomaly Report (threshold: #{data[:threshold] || '2.0'}x)\n"]
             lines << "  Recent period:   #{data[:recent_period] || 'last 1 hour'} (#{data[:recent_count] || 0} records)"
@@ -60,7 +62,7 @@ module Legion
             lines.join("\n")
           end
 
-          def api_get(path)
+          def self.api_get(path)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 2
@@ -69,7 +71,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/edit_file.rb
+++ b/lib/legion/cli/chat/tools/edit_file.rb
@@ -1,25 +1,31 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'legion/cli/chat_command'
 
 module Legion
   module CLI
     class Chat
       module Tools
-        class EditFile < RubyLLM::Tool
+        class EditFile < Legion::Tools::Base
+          tool_name 'legion.edit_file'
           description 'Edit a file using either string replacement (old_text → new_text) or ' \
                       'line-number replacement (start_line/end_line → new_text). ' \
                       'String mode requires an exact unique match. ' \
                       'Line mode replaces lines start_line..end_line (1-based, inclusive); ' \
                       'omit end_line to replace a single line.'
-          param :path,       type: 'string',  desc: 'Path to the file to edit'
-          param :new_text,   type: 'string',  desc: 'The replacement text'
-          param :old_text,   type: 'string',  desc: 'The exact text to find and replace (string mode)'
-          param :start_line, type: 'integer', desc: 'First line to replace, 1-based (line mode)'
-          param :end_line,   type: 'integer', desc: 'Last line to replace, 1-based inclusive (line mode; defaults to start_line)'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           path:       { type: 'string', description: 'Path to the file to edit' },
+                           new_text:   { type: 'string', description: 'The replacement text' },
+                           old_text:   { type: 'string', description: 'The exact text to find and replace (string mode)' },
+                           start_line: { type: 'integer', description: 'First line to replace, 1-based (line mode)' },
+                           end_line:   { type: 'integer', description: 'Last line to replace, 1-based inclusive (line mode; defaults to start_line)' }
+                         },
+                         required:   %w[path new_text]
+                       })
 
-          def execute(path:, new_text:, old_text: nil, start_line: nil, end_line: nil)
+          def self.call(path:, new_text:, old_text: nil, start_line: nil, end_line: nil)
             expanded = File.expand_path(path)
             return "Error: file not found: #{path}" unless File.exist?(expanded)
 
@@ -37,9 +43,7 @@ module Legion
             "Error editing #{path}: #{e.message}"
           end
 
-          private
-
-          def string_replace(expanded, old_text, new_text)
+          def self.string_replace(expanded, old_text, new_text)
             content = File.read(expanded, encoding: 'utf-8')
             occurrences = content.scan(old_text).length
 
@@ -51,7 +55,7 @@ module Legion
             "Replaced 1 occurrence in #{expanded}"
           end
 
-          def line_replace(expanded, new_text, start_line, end_line)
+          def self.line_replace(expanded, new_text, start_line, end_line)
             lines = File.readlines(expanded, encoding: 'utf-8')
             total = lines.length
 

--- a/lib/legion/cli/chat/tools/entity_extract.rb
+++ b/lib/legion/cli/chat/tools/entity_extract.rb
@@ -4,25 +4,21 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class EntityExtract < RubyLLM::Tool
+        class EntityExtract < Legion::Tools::Base
+          tool_name 'legion.entity_extract'
           description 'Extract named entities (people, services, repos, concepts) from text using Apollo'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           text:           { type: 'string', description: 'Text to extract entities from' },
+                           entity_types:   { type:        'string',
+                                             description: 'Comma-separated entity types to extract (default: person,service,repository,concept)' },
+                           min_confidence: { type: 'number', description: 'Minimum confidence threshold 0.0-1.0 (default: 0.7)' }
+                         },
+                         required:   ['text']
+                       })
 
-          param :text,
-                type:     :string,
-                desc:     'Text to extract entities from',
-                required: true
-
-          param :entity_types,
-                type:     :string,
-                desc:     'Comma-separated entity types to extract (default: person,service,repository,concept)',
-                required: false
-
-          param :min_confidence,
-                type:     :number,
-                desc:     'Minimum confidence threshold 0.0-1.0 (default: 0.7)',
-                required: false
-
-          def execute(text:, entity_types: nil, min_confidence: 0.7)
+          def self.call(text:, entity_types: nil, min_confidence: 0.7)
             return 'Apollo entity extractor not available.' unless extractor_available?
 
             types = parse_types(entity_types)
@@ -30,19 +26,17 @@ module Legion
             format_result(result)
           end
 
-          private
-
-          def extractor_available?
+          def self.extractor_available?
             defined?(Legion::Extensions::Apollo::Runners::EntityExtractor)
           end
 
-          def parse_types(types_str)
+          def self.parse_types(types_str)
             return nil if types_str.nil? || types_str.strip.empty?
 
             types_str.split(',').map(&:strip)
           end
 
-          def run_extraction(text, types, min_confidence)
+          def self.run_extraction(text, types, min_confidence)
             extractor = Object.new.extend(Legion::Extensions::Apollo::Runners::EntityExtractor)
             extractor.extract_entities(
               text:           text,
@@ -51,7 +45,7 @@ module Legion
             )
           end
 
-          def format_result(result)
+          def self.format_result(result)
             return format('Entity extraction failed: %<err>s', err: result[:error] || 'unknown error') unless result[:success]
 
             entities = result[:entities]

--- a/lib/legion/cli/chat/tools/escalation_status.rb
+++ b/lib/legion/cli/chat/tools/escalation_status.rb
@@ -4,15 +4,18 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class EscalationStatus < RubyLLM::Tool
+        class EscalationStatus < Legion::Tools::Base
+          tool_name 'legion.escalation_status'
           description 'Show model escalation history: how often cheaper models get upgraded to more capable ones'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action: { type: 'string', description: 'Action: "summary" (default) or "rate" (escalation frequency)' }
+                         },
+                         required:   []
+                       })
 
-          param :action,
-                type:     :string,
-                desc:     'Action: "summary" (default) or "rate" (escalation frequency)',
-                required: false
-
-          def execute(action: 'summary')
+          def self.call(action: 'summary')
             return 'Escalation tracker not available.' unless tracker_available?
 
             case action.to_s
@@ -21,13 +24,11 @@ module Legion
             end
           end
 
-          private
-
-          def tracker_available?
+          def self.tracker_available?
             defined?(Legion::LLM::EscalationTracker)
           end
 
-          def format_summary
+          def self.format_summary
             s = Legion::LLM::EscalationTracker.summary
             lines = ["Model Escalation Summary:\n"]
             lines << format('  Total Escalations: %<v>d', v: s[:total_escalations])
@@ -65,7 +66,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_rate
+          def self.format_rate
             rate = Legion::LLM::EscalationTracker.escalation_rate
             format('Escalation Rate: %<c>d escalations in the last %<m>d minutes',
                    c: rate[:count], m: rate[:window_seconds] / 60)

--- a/lib/legion/cli/chat/tools/generate_insights.rb
+++ b/lib/legion/cli/chat/tools/generate_insights.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,15 +13,17 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class GenerateInsights < RubyLLM::Tool
+        class GenerateInsights < Legion::Tools::Base
+          tool_name 'legion.generate_insights'
           description 'Generate a comprehensive system insights report by combining anomaly detection, trend analysis, ' \
                       'worker health, and knowledge stats into a single actionable summary. Use this for periodic ' \
                       'health reviews or when you want a high-level overview of system behavior.'
+          input_schema({ type: 'object', properties: {}, required: [] })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute
+          def self.call
             sections = gather_sections
             return 'Legion daemon not running (cannot reach API).' if sections.values.all?(&:nil?)
 
@@ -34,9 +35,7 @@ module Legion
             "Error generating insights: #{e.message}"
           end
 
-          private
-
-          def gather_sections
+          def self.gather_sections
             {
               health:     safe_fetch('/api/health'),
               anomalies:  safe_fetch('/api/traces/anomalies'),
@@ -49,13 +48,13 @@ module Legion
             }
           end
 
-          def safe_fetch(path)
+          def self.safe_fetch(path)
             api_get(path)
           rescue StandardError
             nil
           end
 
-          def format_insights(sections)
+          def self.format_insights(sections)
             lines = ["System Insights Report\n"]
             lines << format_health(sections[:health])
             lines << format_anomaly_section(sections[:anomalies])
@@ -69,14 +68,14 @@ module Legion
             lines.compact.join("\n\n")
           end
 
-          def format_health(data)
+          def self.format_health(data)
             return nil unless data
 
             d = data[:data] || data
             "Health: #{d[:status] || 'unknown'} | Version: #{d[:version] || '?'}"
           end
 
-          def format_anomaly_section(data)
+          def self.format_anomaly_section(data)
             return nil unless data
 
             d = data[:data] || data
@@ -89,7 +88,7 @@ module Legion
             end
           end
 
-          def format_trend_section(data)
+          def self.format_trend_section(data)
             return nil unless data
 
             d = data[:data] || data
@@ -104,7 +103,7 @@ module Legion
             "Trend (24h): Volume #{vol_change} | Cost #{cost_change}"
           end
 
-          def format_apollo_section(data)
+          def self.format_apollo_section(data)
             return nil unless data
 
             d = data[:data] || data
@@ -114,7 +113,7 @@ module Legion
               "Confidence: #{d[:avg_confidence] || 0}"
           end
 
-          def format_worker_section(data)
+          def self.format_worker_section(data)
             return nil unless data
 
             workers = data[:data] || []
@@ -125,7 +124,7 @@ module Legion
             "Workers: #{active}/#{workers.size} active"
           end
 
-          def format_graph_section(data)
+          def self.format_graph_section(data)
             return nil unless data
 
             d = data[:data] || data
@@ -138,7 +137,7 @@ module Legion
             "Graph: #{domains} domains | #{relations} relations | #{disputed} disputed"
           end
 
-          def format_scheduling_section(data)
+          def self.format_scheduling_section(data)
             return nil unless data
 
             peak = data[:peak_hours] ? 'PEAK' : 'off-peak'
@@ -147,7 +146,7 @@ module Legion
             "Scheduling: #{peak} | Batch queue: #{batch_size}"
           end
 
-          def format_llm_section(data)
+          def self.format_llm_section(data)
             return nil unless data
 
             parts = []
@@ -158,7 +157,7 @@ module Legion
             "LLM: #{parts.join(' | ')}"
           end
 
-          def scheduling_status
+          def self.scheduling_status
             result = {}
             if defined?(Legion::LLM::Scheduling)
               s = Legion::LLM::Scheduling.status
@@ -171,7 +170,7 @@ module Legion
             nil
           end
 
-          def llm_status
+          def self.llm_status
             result = {}
             if defined?(Legion::LLM::EscalationTracker)
               s = Legion::LLM::EscalationTracker.summary
@@ -187,7 +186,7 @@ module Legion
             nil
           end
 
-          def recommendations(sections)
+          def self.recommendations(sections)
             recs = []
             add_anomaly_recs(recs, sections[:anomalies])
             add_trend_recs(recs, sections[:trend])
@@ -196,7 +195,7 @@ module Legion
             "Recommendations:\n#{recs.map { |r| "  * #{r}" }.join("\n")}"
           end
 
-          def add_anomaly_recs(recs, data)
+          def self.add_anomaly_recs(recs, data)
             return unless data
 
             anomalies = (data[:data] || data)[:anomalies] || []
@@ -212,7 +211,7 @@ module Legion
             end
           end
 
-          def add_trend_recs(recs, data)
+          def self.add_trend_recs(recs, data)
             return unless data
 
             buckets = (data[:data] || data)[:buckets] || []
@@ -225,7 +224,7 @@ module Legion
             recs << 'No recent activity detected — verify daemon extensions are running'
           end
 
-          def percent_change(first_val, last_val)
+          def self.percent_change(first_val, last_val)
             f = (first_val || 0).to_f
             l = (last_val || 0).to_f
             return 'stable' if f.zero? && l.zero?
@@ -241,7 +240,7 @@ module Legion
             end
           end
 
-          def api_get(path)
+          def self.api_get(path)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 2
@@ -250,7 +249,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/graph_explore.rb
+++ b/lib/legion/cli/chat/tools/graph_explore.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,22 +13,23 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class GraphExplore < RubyLLM::Tool
+        class GraphExplore < Legion::Tools::Base
+          tool_name 'legion.graph_explore'
           description 'Explore the Apollo knowledge graph topology: view domains, agent expertise, ' \
                       'relation types, and disputed entries. Use this to understand the structure ' \
                       'and health of the knowledge graph beyond basic stats.'
-
-          param :action,
-                type:     :string,
-                desc:     'Action: "topology" (domain/agent/relation overview), ' \
-                          '"expertise" (agent proficiency per domain), ' \
-                          '"disputed" (show disputed entries)',
-                required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action: { type: 'string', description: 'Action: "topology" (domain/agent/relation overview), ' }
+                         },
+                         required:   []
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(action: 'topology')
+          def self.call(action: 'topology')
             case action.to_s
             when 'expertise' then format_expertise
             when 'disputed'  then format_disputed
@@ -42,9 +42,7 @@ module Legion
             "Error exploring knowledge graph: #{e.message}"
           end
 
-          private
-
-          def format_topology
+          def self.format_topology
             data = fetch_json('/api/apollo/graph')
             return "Apollo error: #{data[:error]}" if data[:error]
 
@@ -75,7 +73,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_expertise
+          def self.format_expertise
             data = fetch_json('/api/apollo/expertise')
             return "Apollo error: #{data[:error]}" if data[:error]
 
@@ -96,7 +94,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_disputed
+          def self.format_disputed
             data = fetch_json('/api/apollo/query', method: :post,
                                                    body:   { status: ['disputed'], limit: 20, query: '*',
                                                            min_confidence: 0.0 })
@@ -117,7 +115,7 @@ module Legion
             lines.join("\n")
           end
 
-          def fetch_json(path, method: :get, body: nil)
+          def self.fetch_json(path, method: :get, body: nil)
             uri = URI("http://#{DEFAULT_HOST}:#{apollo_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 3
@@ -135,7 +133,7 @@ module Legion
             parsed[:data] || parsed
           end
 
-          def apollo_port
+          def self.apollo_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT
@@ -143,12 +141,12 @@ module Legion
             DEFAULT_PORT
           end
 
-          def proficiency_bar(value)
+          def self.proficiency_bar(value)
             filled = (value * 10).round.clamp(0, 10)
             ('#' * filled) + ('-' * (10 - filled))
           end
 
-          def truncate(text, max)
+          def self.truncate(text, max)
             return '' if text.nil?
 
             text.length > max ? "#{text[0...max]}..." : text

--- a/lib/legion/cli/chat/tools/ingest_knowledge.rb
+++ b/lib/legion/cli/chat/tools/ingest_knowledge.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,21 +13,27 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class IngestKnowledge < RubyLLM::Tool
+        class IngestKnowledge < Legion::Tools::Base
+          tool_name 'legion.ingest_knowledge'
           description 'Save a fact, observation, or concept to the Apollo knowledge graph for long-term retention. ' \
                       'Use this when the user shares important information, when you discover a project convention, ' \
                       'or when a key decision is made that should be remembered across sessions.'
-          param :content, type: 'string', desc: 'The knowledge to store (a clear, concise statement)'
-          param :content_type, type: 'string',
-                desc: 'Type: fact, observation, concept, procedure, decision (default: observation)', required: false
-          param :tags, type: 'string', desc: 'Comma-separated tags for categorization (optional)', required: false
-          param :knowledge_domain, type: 'string', desc: 'Domain category (optional)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           content:          { type: 'string', description: 'The knowledge to store (a clear, concise statement)' },
+                           content_type:     { type: 'string', description: 'Type: fact, observation, concept, procedure, decision (default: observation)' },
+                           tags:             { type: 'string', description: 'Comma-separated tags for categorization (optional)' },
+                           knowledge_domain: { type: 'string', description: 'Domain category (optional)' }
+                         },
+                         required:   ['content']
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
           VALID_TYPES = %w[fact observation concept procedure decision].freeze
 
-          def execute(content:, content_type: nil, tags: nil, knowledge_domain: nil)
+          def self.call(content:, content_type: nil, tags: nil, knowledge_domain: nil)
             content_type = sanitize_type(content_type)
             tag_list = parse_tags(tags)
 
@@ -50,20 +55,18 @@ module Legion
             "Error saving to knowledge graph: #{e.message}"
           end
 
-          private
-
-          def sanitize_type(content_type)
+          def self.sanitize_type(content_type)
             type = (content_type || 'observation').to_s.downcase
             VALID_TYPES.include?(type) ? type : 'observation'
           end
 
-          def parse_tags(tags)
+          def self.parse_tags(tags)
             return [] unless tags.is_a?(String) && !tags.empty?
 
             tags.split(',').map(&:strip).reject(&:empty?)
           end
 
-          def apollo_ingest(content:, content_type:, tags:, knowledge_domain:)
+          def self.apollo_ingest(content:, content_type:, tags:, knowledge_domain:)
             body = {
               content:        content,
               content_type:   content_type,
@@ -84,7 +87,7 @@ module Legion
             parsed[:data] || parsed
           end
 
-          def apollo_port
+          def self.apollo_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/knowledge_maintenance.rb
+++ b/lib/legion/cli/chat/tools/knowledge_maintenance.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,18 +13,25 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class KnowledgeMaintenance < RubyLLM::Tool
+        class KnowledgeMaintenance < Legion::Tools::Base
+          tool_name 'legion.knowledge_maintenance'
           description 'Run maintenance operations on the Apollo knowledge graph. ' \
                       'Use decay_cycle to reduce confidence of old or uncorroborated entries over time. ' \
                       'Use corroboration to cross-verify entries and boost confidence of mutually supporting facts.'
-          param :action, type: 'string',
-                         desc: 'Maintenance action: "decay_cycle" (age-based confidence decay) or "corroboration" (cross-verify entries)'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action: { type:        'string',
+                                     description: 'Maintenance action: "decay_cycle" (age-based confidence decay) or "corroboration" (cross-verify entries)' }
+                         },
+                         required:   ['action']
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
           VALID_ACTIONS = %w[decay_cycle corroboration].freeze
 
-          def execute(action:)
+          def self.call(action:)
             action = action.to_s.strip
             return "Invalid action: #{action}. Must be one of: #{VALID_ACTIONS.join(', ')}" unless VALID_ACTIONS.include?(action)
 
@@ -40,9 +46,7 @@ module Legion
             "Error running maintenance: #{e.message}"
           end
 
-          private
-
-          def run_maintenance(action)
+          def self.run_maintenance(action)
             uri = URI("http://#{DEFAULT_HOST}:#{apollo_port}/api/apollo/maintenance")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 3
@@ -54,7 +58,7 @@ module Legion
             parsed[:data] || parsed
           end
 
-          def apollo_port
+          def self.apollo_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT
@@ -62,7 +66,7 @@ module Legion
             DEFAULT_PORT
           end
 
-          def format_result(action, data)
+          def self.format_result(action, data)
             case action
             when 'decay_cycle'
               format_decay_result(data)
@@ -73,7 +77,7 @@ module Legion
             end
           end
 
-          def format_decay_result(data)
+          def self.format_decay_result(data)
             decayed = data[:decayed_count] || data[:decayed] || 0
             removed = data[:removed_count] || data[:removed] || 0
             header = "Decay cycle complete:\n"
@@ -83,7 +87,7 @@ module Legion
             header
           end
 
-          def format_corroboration_result(data)
+          def self.format_corroboration_result(data)
             checked = data[:checked_count] || data[:checked] || 0
             boosted = data[:boosted_count] || data[:boosted] || 0
             header = "Corroboration check complete:\n"

--- a/lib/legion/cli/chat/tools/knowledge_stats.rb
+++ b/lib/legion/cli/chat/tools/knowledge_stats.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,15 +13,17 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class KnowledgeStats < RubyLLM::Tool
+        class KnowledgeStats < Legion::Tools::Base
+          tool_name 'legion.knowledge_stats'
           description 'Get statistics about the Apollo knowledge graph including total entries, ' \
                       'breakdowns by status and content type, recent activity, and average confidence. ' \
                       'Use this to understand the current state of the knowledge base.'
+          input_schema({ type: 'object', properties: {}, required: [] })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute
+          def self.call
             data = fetch_stats
             return "Apollo error: #{data[:error]}" if data[:error]
 
@@ -34,9 +35,7 @@ module Legion
             "Error fetching knowledge stats: #{e.message}"
           end
 
-          private
-
-          def fetch_stats
+          def self.fetch_stats
             uri = URI("http://#{DEFAULT_HOST}:#{apollo_port}/api/apollo/stats")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 3
@@ -46,7 +45,7 @@ module Legion
             parsed[:data] || parsed
           end
 
-          def apollo_port
+          def self.apollo_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT
@@ -54,7 +53,7 @@ module Legion
             DEFAULT_PORT
           end
 
-          def format_stats(data)
+          def self.format_stats(data)
             lines = ["Apollo Knowledge Graph Statistics:\n"]
             lines << "  Total entries: #{data[:total_entries] || 0}"
             lines << "  Recent (24h): #{data[:recent_24h] || 0}"
@@ -66,7 +65,7 @@ module Legion
             lines.compact.join("\n")
           end
 
-          def format_breakdown(title, hash)
+          def self.format_breakdown(title, hash)
             return nil if hash.nil? || hash.empty?
 
             parts = hash.map { |key, count| "    #{key}: #{count}" }

--- a/lib/legion/cli/chat/tools/list_extensions.rb
+++ b/lib/legion/cli/chat/tools/list_extensions.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,19 +13,24 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class ListExtensions < RubyLLM::Tool
+        class ListExtensions < Legion::Tools::Base
+          tool_name 'legion.list_extensions'
           description 'List loaded Legion extensions and their runners/functions. ' \
                       'Use this to discover what capabilities are available, what extensions are active, ' \
                       'and what tasks can be triggered through the framework.'
-          param :extension_name, type: 'string',
-                                 desc: 'Show runners for a specific extension by name (e.g. lex-node)', required: false
-          param :state, type: 'string',
-                        desc: 'Filter by state (e.g. "running"). Default: all', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           extension_name: { type: 'string', description: 'Show runners for a specific extension by name (e.g. lex-node)' },
+                           state:          { type: 'string', description: 'Filter by state (e.g. "running"). Default: all' }
+                         },
+                         required:   []
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(extension_name: nil, state: nil)
+          def self.call(extension_name: nil, state: nil)
             if extension_name
               fetch_extension_detail(extension_name)
             else
@@ -39,9 +43,7 @@ module Legion
             "Error listing extensions: #{e.message}"
           end
 
-          private
-
-          def fetch_extension_list(state)
+          def self.fetch_extension_list(state)
             path = '/api/extension_catalog'
             path += "?state=#{state}" if state
             data = api_get(path)
@@ -54,7 +56,7 @@ module Legion
             format_list(extensions)
           end
 
-          def fetch_extension_detail(name)
+          def self.fetch_extension_detail(name)
             ext_data = api_get("/api/extension_catalog/#{name}")
             return "API error: #{ext_data[:error]}" if ext_data[:error]
 
@@ -66,7 +68,7 @@ module Legion
             format_detail(ext_data[:data] || ext_data, runners)
           end
 
-          def format_list(extensions)
+          def self.format_list(extensions)
             lines = ["Loaded Extensions (#{extensions.size}):\n"]
             extensions.each do |ext|
               lines << "  #{ext[:name]} (#{ext[:state]})"
@@ -74,7 +76,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_detail(ext, runners)
+          def self.format_detail(ext, runners)
             lines = ["Extension: #{ext[:name]}\n"]
             lines << "  State: #{ext[:state]}"
             lines << "  Version: #{ext[:version]}" if ext[:version]
@@ -91,7 +93,7 @@ module Legion
             lines.join("\n")
           end
 
-          def api_get(path)
+          def self.api_get(path)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 3
@@ -100,7 +102,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/manage_schedules.rb
+++ b/lib/legion/cli/chat/tools/manage_schedules.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,22 +13,27 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class ManageSchedules < RubyLLM::Tool
+        class ManageSchedules < Legion::Tools::Base
+          tool_name 'legion.manage_schedules'
           description 'Manage scheduled tasks on the running Legion daemon. List active schedules, ' \
                       'show schedule details, view run logs, or create new cron/interval schedules. ' \
                       'Use this to automate recurring tasks.'
-          param :action, type:     'string',
-                         desc:     'Action: "list", "show", "logs", or "create"',
-                         required: true
-          param :schedule_id, type: 'string', desc: 'Schedule ID (for show/logs)', required: false
-          param :function_id, type: 'string', desc: 'Function ID to schedule (for create)', required: false
-          param :cron, type: 'string', desc: 'Cron expression (for create, e.g. "0 * * * *")', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action:      { type: 'string', description: 'Action: "list", "show", "logs", or "create"' },
+                           schedule_id: { type: 'string', description: 'Schedule ID (for show/logs)' },
+                           function_id: { type: 'string', description: 'Function ID to schedule (for create)' },
+                           cron:        { type: 'string', description: 'Cron expression (for create, e.g. "0 * * * *")' }
+                         },
+                         required:   ['action']
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
           VALID_ACTIONS = %w[list show logs create].freeze
 
-          def execute(action:, **)
+          def self.call(action:, **)
             action = action.to_s.strip
             return "Invalid action: #{action}. Use: #{VALID_ACTIONS.join(', ')}" unless VALID_ACTIONS.include?(action)
 
@@ -41,9 +45,7 @@ module Legion
             "Error managing schedules: #{e.message}"
           end
 
-          private
-
-          def handle_list(**)
+          def self.handle_list(**)
             data = api_get('/api/schedules')
             entries = extract_collection(data)
             return 'No schedules found.' if entries.empty?
@@ -58,7 +60,7 @@ module Legion
             lines.join("\n")
           end
 
-          def handle_show(schedule_id: nil, **)
+          def self.handle_show(schedule_id: nil, **)
             return 'schedule_id is required for the "show" action.' unless schedule_id
 
             data = api_get("/api/schedules/#{schedule_id}")
@@ -70,7 +72,7 @@ module Legion
             lines.join("\n")
           end
 
-          def handle_logs(schedule_id: nil, **)
+          def self.handle_logs(schedule_id: nil, **)
             return 'schedule_id is required for the "logs" action.' unless schedule_id
 
             data = api_get("/api/schedules/#{schedule_id}/logs")
@@ -84,7 +86,7 @@ module Legion
             lines.join("\n")
           end
 
-          def handle_create(function_id: nil, cron: nil, **)
+          def self.handle_create(function_id: nil, cron: nil, **)
             return 'function_id is required for the "create" action.' unless function_id
             return 'cron expression is required for the "create" action.' unless cron
 
@@ -95,13 +97,13 @@ module Legion
             "Schedule created (id: #{s[:id]}, cron: #{cron}, function: #{function_id})"
           end
 
-          def extract_collection(data)
+          def self.extract_collection(data)
             entries = data[:data] || data
             entries = [entries] if entries.is_a?(Hash) && !entries.key?(:error)
             Array(entries).reject { |e| e.is_a?(Hash) && e.key?(:error) }
           end
 
-          def api_get(path)
+          def self.api_get(path)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 2
@@ -110,7 +112,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_post(path, body)
+          def self.api_post(path, body)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 2
@@ -121,7 +123,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/manage_tasks.rb
+++ b/lib/legion/cli/chat/tools/manage_tasks.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,37 +13,31 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class ManageTasks < RubyLLM::Tool
+        class ManageTasks < Legion::Tools::Base
+          tool_name 'legion.manage_tasks'
           description 'Interact with the Legion task system. List recent tasks, show task details ' \
                       'with metering data, view task logs, or trigger new tasks through the Ingress pipeline. ' \
                       'Use this to monitor job execution, check task status, and invoke extension runners.'
-          param :action, type:     'string',
-                         desc:     'Action to perform: "list", "show", "logs", or "trigger"',
-                         required: true
-          param :task_id, type:     'integer',
-                          desc:     'Task ID (required for "show" and "logs")',
-                          required: false
-          param :runner_class, type:     'string',
-                               desc:     'Full runner class name for "trigger" (e.g. "Legion::Extensions::Node::Runners::Info")',
-                               required: false
-          param :function, type:     'string',
-                           desc:     'Function name for "trigger" (e.g. "execute")',
-                           required: false
-          param :payload, type:     'string',
-                          desc:     'JSON payload for "trigger" action (optional)',
-                          required: false
-          param :status, type:     'string',
-                         desc:     'Filter tasks by status for "list" (e.g. "completed", "failed", "pending")',
-                         required: false
-          param :limit, type:     'integer',
-                        desc:     'Max results for "list" (default: 10)',
-                        required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action:       { type: 'string', description: 'Action to perform: "list", "show", "logs", or "trigger"' },
+                           task_id:      { type: 'integer', description: 'Task ID (required for "show" and "logs")' },
+                           runner_class: { type:        'string',
+                                           description: 'Full runner class name for "trigger" (e.g. "Legion::Extensions::Node::Runners::Info")' },
+                           function:     { type: 'string', description: 'Function name for "trigger" (e.g. "execute")' },
+                           payload:      { type: 'string', description: 'JSON payload for "trigger" action (optional)' },
+                           status:       { type: 'string', description: 'Filter tasks by status for "list" (e.g. "completed", "failed", "pending")' },
+                           limit:        { type: 'integer', description: 'Max results for "list" (default: 10)' }
+                         },
+                         required:   ['action']
+                       })
 
           VALID_ACTIONS = %w[list show logs trigger].freeze
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(action:, **)
+          def self.call(action:, **)
             action = action.to_s.strip
             return "Invalid action: #{action}. Use: #{VALID_ACTIONS.join(', ')}" unless VALID_ACTIONS.include?(action)
 
@@ -56,9 +49,7 @@ module Legion
             "Error managing tasks: #{e.message}"
           end
 
-          private
-
-          def handle_list(status: nil, limit: nil, **)
+          def self.handle_list(status: nil, limit: nil, **)
             path = '/api/tasks'
             params = []
             params << "status=#{status}" if status
@@ -75,7 +66,7 @@ module Legion
             format_task_list(tasks)
           end
 
-          def handle_show(task_id: nil, **)
+          def self.handle_show(task_id: nil, **)
             return 'task_id is required for "show"' unless task_id
 
             data = api_get("/api/tasks/#{task_id}")
@@ -85,7 +76,7 @@ module Legion
             format_task_detail(task)
           end
 
-          def handle_logs(task_id: nil, **)
+          def self.handle_logs(task_id: nil, **)
             return 'task_id is required for "logs"' unless task_id
 
             data = api_get("/api/tasks/#{task_id}/logs")
@@ -98,7 +89,7 @@ module Legion
             format_task_logs(task_id, logs)
           end
 
-          def handle_trigger(runner_class: nil, function: nil, payload: nil, **)
+          def self.handle_trigger(runner_class: nil, function: nil, payload: nil, **)
             return 'runner_class is required for "trigger"' unless runner_class
             return 'function is required for "trigger"' unless function
 
@@ -112,7 +103,7 @@ module Legion
             "Task triggered successfully.\n  Task ID: #{result[:task_id]}\n  Runner: #{runner_class}\n  Function: #{function}"
           end
 
-          def format_task_list(tasks)
+          def self.format_task_list(tasks)
             lines = ["Recent Tasks (#{tasks.size}):\n"]
             tasks.each do |t|
               status_str = t[:status] || 'unknown'
@@ -121,7 +112,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_task_detail(task)
+          def self.format_task_detail(task)
             lines = ["Task ##{task[:id]}\n"]
             lines << "  Status: #{task[:status]}"
             lines << "  Runner: #{task[:runner_class]}"
@@ -143,7 +134,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_task_logs(task_id, logs)
+          def self.format_task_logs(task_id, logs)
             lines = ["Logs for Task ##{task_id} (#{logs.size} entries):\n"]
             logs.each do |log|
               ts = log[:created_at] || log[:timestamp]
@@ -152,7 +143,7 @@ module Legion
             lines.join("\n")
           end
 
-          def api_get(path)
+          def self.api_get(path)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 3
@@ -161,7 +152,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_post(path, body)
+          def self.api_post(path, body)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 3
@@ -172,7 +163,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/memory_status.rb
+++ b/lib/legion/cli/chat/tools/memory_status.rb
@@ -4,17 +4,19 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class MemoryStatus < RubyLLM::Tool
+        class MemoryStatus < Legion::Tools::Base
+          tool_name 'legion.memory_status'
           description 'Show persistent memory status: project and global memory entries, ' \
                       'Apollo knowledge store stats, and session history overview'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action: { type: 'string', description: 'Action: "overview" (default), "memories" (local memory detail), ' }
+                         },
+                         required:   []
+                       })
 
-          param :action,
-                type:     :string,
-                desc:     'Action: "overview" (default), "memories" (local memory detail), ' \
-                          '"apollo" (knowledge graph stats), "sessions" (saved session list)',
-                required: false
-
-          def execute(action: 'overview')
+          def self.call(action: 'overview')
             case action.to_s
             when 'memories' then format_memories
             when 'apollo'   then format_apollo
@@ -23,9 +25,7 @@ module Legion
             end
           end
 
-          private
-
-          def format_overview
+          def self.format_overview
             lines = ["Memory & Knowledge Overview:\n"]
 
             mem = memory_stats
@@ -45,7 +45,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_memories
+          def self.format_memories
             require 'legion/cli/chat/memory_store'
             lines = ["Persistent Memory Detail:\n"]
 
@@ -73,7 +73,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_apollo
+          def self.format_apollo
             stats = apollo_stats
             return 'Apollo knowledge store is not available.' unless stats
 
@@ -96,7 +96,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_sessions
+          def self.format_sessions
             require 'legion/cli/chat/session_store'
             sessions = Chat::SessionStore.list
             return 'No saved sessions found.' if sessions.empty?
@@ -113,7 +113,7 @@ module Legion
             lines.join("\n")
           end
 
-          def memory_stats
+          def self.memory_stats
             require 'legion/cli/chat/memory_store'
             {
               project: Chat::MemoryStore.list(scope: :project).size,
@@ -123,7 +123,7 @@ module Legion
             { project: 0, global: 0 }
           end
 
-          def apollo_stats
+          def self.apollo_stats
             return nil unless apollo_available?
 
             data = safe_fetch('/api/apollo/stats')
@@ -134,18 +134,18 @@ module Legion
             nil
           end
 
-          def session_list
+          def self.session_list
             require 'legion/cli/chat/session_store'
             Chat::SessionStore.list
           rescue StandardError
             []
           end
 
-          def apollo_available?
+          def self.apollo_available?
             defined?(Legion::Data)
           end
 
-          def safe_fetch(path)
+          def self.safe_fetch(path)
             require 'net/http'
             uri = URI("http://127.0.0.1:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
@@ -159,15 +159,15 @@ module Legion
             nil
           end
 
-          def api_port
+          def self.api_port
             (defined?(Legion::Settings) && Legion::Settings[:api] && Legion::Settings[:api][:port]) || 4567
           end
 
-          def truncate(str, max)
+          def self.truncate(str, max)
             str.length > max ? "#{str[0, max]}..." : str
           end
 
-          def time_ago(time)
+          def self.time_ago(time)
             return '?' unless time
 
             seconds = Time.now - time

--- a/lib/legion/cli/chat/tools/model_comparison.rb
+++ b/lib/legion/cli/chat/tools/model_comparison.rb
@@ -4,20 +4,19 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class ModelComparison < RubyLLM::Tool
+        class ModelComparison < Legion::Tools::Base
+          tool_name 'legion.model_comparison'
           description 'Compare LLM model pricing and capabilities side-by-side'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           models: { type: 'string', description: 'Comma-separated model names to compare (blank = show all known models)' },
+                           tokens: { type: 'integer', description: 'Hypothetical token count for cost projection (default: 1000)' }
+                         },
+                         required:   []
+                       })
 
-          param :models,
-                type:     :string,
-                desc:     'Comma-separated model names to compare (blank = show all known models)',
-                required: false
-
-          param :tokens,
-                type:     :integer,
-                desc:     'Hypothetical token count for cost projection (default: 1000)',
-                required: false
-
-          def execute(models: nil, tokens: 1000)
+          def self.call(models: nil, tokens: 1000)
             pricing = load_pricing
             selected = filter_models(pricing, models)
             return 'No matching models found.' if selected.empty?
@@ -25,16 +24,14 @@ module Legion
             format_comparison(selected, tokens.to_i)
           end
 
-          private
-
-          def load_pricing
+          def self.load_pricing
             base = cost_tracker_pricing
             return base unless base.empty?
 
             default_pricing
           end
 
-          def cost_tracker_pricing
+          def self.cost_tracker_pricing
             return {} unless defined?(Legion::LLM::CostTracker)
 
             Legion::LLM::CostTracker::DEFAULT_PRICING.transform_values do |v|
@@ -45,7 +42,7 @@ module Legion
             {}
           end
 
-          def default_pricing
+          def self.default_pricing
             {
               'claude-sonnet-4-6' => { input: 3.0,  output: 15.0 },
               'claude-haiku-4-5'  => { input: 0.80, output: 4.0  },
@@ -55,14 +52,14 @@ module Legion
             }
           end
 
-          def filter_models(pricing, models_str)
+          def self.filter_models(pricing, models_str)
             return pricing if models_str.nil? || models_str.strip.empty?
 
             names = models_str.split(',').map(&:strip).map(&:downcase)
             pricing.select { |k, _| names.any? { |n| k.downcase.include?(n) } }
           end
 
-          def format_comparison(selected, tokens)
+          def self.format_comparison(selected, tokens)
             lines = ["Model Comparison (per 1M tokens pricing):\n"]
             lines << '  Model                        Input/$   Output/$    Est. Cost'
             lines << "  #{'—' * 59}"
@@ -88,7 +85,7 @@ module Legion
             lines.join("\n")
           end
 
-          def estimate_cost(price, tokens)
+          def self.estimate_cost(price, tokens)
             ((tokens * price[:input] / 1_000_000.0) + (tokens * price[:output] / 1_000_000.0)).round(6)
           end
         end

--- a/lib/legion/cli/chat/tools/provider_health.rb
+++ b/lib/legion/cli/chat/tools/provider_health.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
-
 begin
   require 'legion/cli/chat_command'
 rescue LoadError
@@ -12,13 +10,20 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class ProviderHealth < RubyLLM::Tool
+        class ProviderHealth < Legion::Tools::Base
+          tool_name 'legion.provider_health'
           description 'Check the health status of configured LLM providers. Shows circuit breaker state, ' \
                       'routing adjustments, and overall availability. Use this when the user asks about ' \
                       'provider status, LLM health, or routing problems.'
-          param :provider, type: 'string', desc: 'Specific provider to check (optional)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           provider: { type: 'string', description: 'Specific provider to check (optional)' }
+                         },
+                         required:   []
+                       })
 
-          def execute(provider: nil)
+          def self.call(provider: nil)
             return 'LLM provider inventory not available.' unless provider_stats_available?
 
             if provider
@@ -31,9 +36,7 @@ module Legion
             "Error checking provider health: #{e.message}"
           end
 
-          private
-
-          def format_report
+          def self.format_report
             report = provider_health_report
             return "Router not available: #{report[:error]}" if report.is_a?(Hash) && report[:error]
             return 'No providers configured.' if report.empty?
@@ -46,7 +49,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_detail(provider)
+          def self.format_detail(provider)
             entry = provider_detail(provider)
             return "Router not available: #{entry[:error]}" if entry[:error]
             return "Provider not found: #{provider}" if entry.empty?
@@ -58,13 +61,13 @@ module Legion
             lines.join("\n")
           end
 
-          def format_circuit_summary(summary)
+          def self.format_circuit_summary(summary)
             format('  Circuits: %<closed>d closed, %<open>d open, %<half>d half-open (of %<total>d)',
                    closed: summary[:closed], open: summary[:open],
                    half: summary[:half_open], total: summary[:total])
           end
 
-          def format_entry(entry)
+          def self.format_entry(entry)
             icon = entry[:healthy] ? '+' : '!'
             suffix = +''
             suffix << " offerings=#{entry[:offerings]}" if entry.key?(:offerings)
@@ -74,19 +77,19 @@ module Legion
                    circuit: entry[:circuit], adj: entry[:adjustment], suffix: suffix)
           end
 
-          def provider_stats_available?
+          def self.provider_stats_available?
             native_provider_stats_available?
           end
 
-          def native_provider_stats_available?
+          def self.native_provider_stats_available?
             defined?(Legion::LLM::Inventory) && Legion::LLM::Inventory.respond_to?(:providers)
           end
 
-          def provider_health_report
+          def self.provider_health_report
             native_provider_health_report
           end
 
-          def native_provider_health_report
+          def self.native_provider_health_report
             groups = Legion::LLM::Inventory.providers
             return [] unless groups.respond_to?(:map)
 
@@ -110,7 +113,7 @@ module Legion
             end
           end
 
-          def provider_circuit_summary(report)
+          def self.provider_circuit_summary(report)
             circuits = report.map { |entry| entry[:circuit].to_s }
             {
               total:     report.size,
@@ -120,12 +123,12 @@ module Legion
             }
           end
 
-          def provider_detail(provider)
+          def self.provider_detail(provider)
             provider_name = provider.to_s
             provider_health_report.find { |entry| entry[:provider] == provider_name } || {}
           end
 
-          def offering_value(offering, key)
+          def self.offering_value(offering, key)
             return unless offering.respond_to?(:[])
 
             offering[key] || offering[key.to_s]

--- a/lib/legion/cli/chat/tools/query_knowledge.rb
+++ b/lib/legion/cli/chat/tools/query_knowledge.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,18 +13,25 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class QueryKnowledge < RubyLLM::Tool
+        class QueryKnowledge < Legion::Tools::Base
+          tool_name 'legion.query_knowledge'
           description 'Query the Apollo knowledge graph for facts, observations, concepts, and procedures. ' \
                       'Use this when the user asks about known facts, project knowledge, system behavior, ' \
                       'or anything that may have been ingested into the knowledge base.'
-          param :query, type: 'string', desc: 'Natural language search query'
-          param :domain, type: 'string', desc: 'Filter by knowledge domain (optional)', required: false
-          param :limit, type: 'integer', desc: 'Max results (default: 10)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           query:  { type: 'string', description: 'Natural language search query' },
+                           domain: { type: 'string', description: 'Filter by knowledge domain (optional)' },
+                           limit:  { type: 'integer', description: 'Max results (default: 10)' }
+                         },
+                         required:   ['query']
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(query:, domain: nil, limit: nil)
+          def self.call(query:, domain: nil, limit: nil)
             limit = (limit || 10).clamp(1, 50)
             data = apollo_query(query: query, domain: domain, limit: limit)
 
@@ -40,9 +46,7 @@ module Legion
             "Error querying knowledge graph: #{e.message}"
           end
 
-          private
-
-          def apollo_query(query:, domain:, limit:)
+          def self.apollo_query(query:, domain:, limit:)
             body = { query: query, limit: limit, status: %w[confirmed candidate] }
             body[:domain] = domain if domain
 
@@ -57,7 +61,7 @@ module Legion
             parsed[:data] || parsed
           end
 
-          def apollo_port
+          def self.apollo_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT
@@ -65,7 +69,7 @@ module Legion
             DEFAULT_PORT
           end
 
-          def format_entries(entries)
+          def self.format_entries(entries)
             parts = entries.map.with_index(1) do |entry, idx|
               confidence = entry[:confidence] ? " (confidence: #{entry[:confidence]})" : ''
               tags = entry[:tags]&.any? ? " [#{entry[:tags].join(', ')}]" : ''

--- a/lib/legion/cli/chat/tools/read_file.rb
+++ b/lib/legion/cli/chat/tools/read_file.rb
@@ -1,19 +1,25 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'legion/cli/chat_command'
 
 module Legion
   module CLI
     class Chat
       module Tools
-        class ReadFile < RubyLLM::Tool
+        class ReadFile < Legion::Tools::Base
+          tool_name 'legion.read_file'
           description 'Read the contents of a file. Returns the file content with line numbers.'
-          param :path, type: 'string', desc: 'Absolute or relative path to the file'
-          param :offset, type: 'integer', desc: 'Line number to start reading from (1-based)', required: false
-          param :limit, type: 'integer', desc: 'Maximum number of lines to read', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           path:   { type: 'string', description: 'Absolute or relative path to the file' },
+                           offset: { type: 'integer', description: 'Line number to start reading from (1-based)' },
+                           limit:  { type: 'integer', description: 'Maximum number of lines to read' }
+                         },
+                         required:   ['path']
+                       })
 
-          def execute(path:, offset: nil, limit: nil)
+          def self.call(path:, offset: nil, limit: nil)
             expanded = File.expand_path(path)
             return "Error: file not found: #{path}" unless File.exist?(expanded)
             return "Error: path is a directory: #{path}" if File.directory?(expanded)

--- a/lib/legion/cli/chat/tools/reflect.rb
+++ b/lib/legion/cli/chat/tools/reflect.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,14 +13,20 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class Reflect < RubyLLM::Tool
+        class Reflect < Legion::Tools::Base
+          tool_name 'legion.reflect'
           description 'Reflect on the current conversation to extract useful knowledge, patterns, or decisions ' \
                       'worth remembering. Analyzes the provided text and ingests key learnings into the Apollo ' \
                       'knowledge graph and project memory. Use after completing a task or when you notice ' \
                       'something worth preserving for future sessions.'
-          param :text, type: 'string', desc: 'Text to reflect on (conversation excerpt, decision rationale, or lesson learned)'
-          param :domain, type: 'string', desc: 'Knowledge domain (e.g., "architecture", "debugging", "patterns")',
-                         required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           text:   { type: 'string', description: 'Text to reflect on (conversation excerpt, decision rationale, or lesson learned)' },
+                           domain: { type: 'string', description: 'Knowledge domain (e.g., "architecture", "debugging", "patterns")' }
+                         },
+                         required:   ['text']
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
@@ -41,7 +46,7 @@ module Legion
             Return ONLY the entries, no headers or commentary.
           PROMPT
 
-          def execute(text:, domain: nil)
+          def self.call(text:, domain: nil)
             entries = extract_entries(text)
             return 'No actionable knowledge found to reflect on.' if entries.empty?
 
@@ -52,9 +57,7 @@ module Legion
             "Error during reflection: #{e.message}"
           end
 
-          private
-
-          def extract_entries(text)
+          def self.extract_entries(text)
             return [text] unless llm_available?
 
             response = Legion::LLM.chat_direct(
@@ -66,7 +69,7 @@ module Legion
             [text]
           end
 
-          def parse_entries(content)
+          def self.parse_entries(content)
             content.lines
                    .map(&:strip)
                    .select { |line| line.start_with?('- ') }
@@ -75,7 +78,7 @@ module Legion
                    .first(5)
           end
 
-          def ingest_entries(entries, domain)
+          def self.ingest_entries(entries, domain)
             results = { apollo: 0, memory: 0 }
             entries.each do |entry|
               results[:apollo] += 1 if ingest_to_apollo(entry, domain)
@@ -84,7 +87,7 @@ module Legion
             results
           end
 
-          def ingest_to_apollo(content, domain)
+          def self.ingest_to_apollo(content, domain)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}/api/apollo/ingest")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 2
@@ -104,7 +107,7 @@ module Legion
             false
           end
 
-          def save_to_memory(entry)
+          def self.save_to_memory(entry)
             require 'legion/cli/chat/memory_store'
             MemoryStore.add(entry, scope: :project)
             true
@@ -112,7 +115,7 @@ module Legion
             false
           end
 
-          def format_results(entries, results)
+          def self.format_results(entries, results)
             lines = ["Reflected on #{entries.size} knowledge entries:\n"]
             entries.each_with_index { |e, i| lines << "  #{i + 1}. #{e}" }
             lines << ''
@@ -120,11 +123,11 @@ module Legion
             lines.join("\n")
           end
 
-          def llm_available?
+          def self.llm_available?
             defined?(Legion::LLM) && Legion::LLM.respond_to?(:chat_direct)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/relate_knowledge.rb
+++ b/lib/legion/cli/chat/tools/relate_knowledge.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,19 +13,26 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class RelateKnowledge < RubyLLM::Tool
+        class RelateKnowledge < Legion::Tools::Base
+          tool_name 'legion.relate_knowledge'
           description 'Find related knowledge entries in the Apollo knowledge graph. ' \
                       'Use this to discover connections between concepts, find supporting or contradicting facts, ' \
                       'or explore the knowledge neighborhood of a specific entry.'
-          param :entry_id, type: 'integer', desc: 'The ID of the knowledge entry to find relations for'
-          param :relation_types, type: 'string',
-                desc: 'Comma-separated relation types to filter (supports, contradicts, related, derived_from)', required: false
-          param :depth, type: 'integer', desc: 'Depth of relation traversal (1-3, default: 2)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           entry_id:       { type: 'integer', description: 'The ID of the knowledge entry to find relations for' },
+                           relation_types: { type:        'string',
+                                             description: 'Comma-separated relation types to filter (supports, contradicts, related, derived_from)' },
+                           depth:          { type: 'integer', description: 'Depth of relation traversal (1-3, default: 2)' }
+                         },
+                         required:   ['entry_id']
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(entry_id:, relation_types: nil, depth: nil)
+          def self.call(entry_id:, relation_types: nil, depth: nil)
             depth = (depth || 2).clamp(1, 3)
             params = { depth: depth }
             params[:relation_types] = relation_types if relation_types
@@ -45,9 +51,7 @@ module Legion
             "Error finding related entries: #{e.message}"
           end
 
-          private
-
-          def apollo_related(entry_id, params)
+          def self.apollo_related(entry_id, params)
             query_string = params.map { |k, v| "#{k}=#{v}" }.join('&')
             path = "/api/apollo/entries/#{entry_id}/related"
             path += "?#{query_string}" unless query_string.empty?
@@ -61,7 +65,7 @@ module Legion
             parsed[:data] || parsed
           end
 
-          def apollo_port
+          def self.apollo_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT
@@ -69,7 +73,7 @@ module Legion
             DEFAULT_PORT
           end
 
-          def format_related(entry_id, entries, depth)
+          def self.format_related(entry_id, entries, depth)
             header = "Related entries for ##{entry_id} (depth: #{depth}, found: #{entries.size}):\n\n"
             parts = entries.map.with_index(1) do |entry, idx|
               relation = entry[:relation_type] ? " [#{entry[:relation_type]}]" : ''

--- a/lib/legion/cli/chat/tools/run_command.rb
+++ b/lib/legion/cli/chat/tools/run_command.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'legion/cli/chat_command'
 require 'open3'
 require 'timeout'
@@ -9,13 +8,20 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class RunCommand < RubyLLM::Tool
+        class RunCommand < Legion::Tools::Base
+          tool_name 'legion.run_command'
           description 'Execute a shell command and return its output. Use for running tests, builds, git commands, etc.'
-          param :command, type: 'string', desc: 'The shell command to execute'
-          param :timeout, type: 'integer', desc: 'Timeout in seconds (default: 120)', required: false
-          param :working_directory, type: 'string', desc: 'Working directory (default: current dir)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           command:           { type: 'string', description: 'The shell command to execute' },
+                           timeout:           { type: 'integer', description: 'Timeout in seconds (default: 120)' },
+                           working_directory: { type: 'string', description: 'Working directory (default: current dir)' }
+                         },
+                         required:   ['command']
+                       })
 
-          def execute(command:, timeout: 120, working_directory: nil)
+          def self.call(command:, timeout: 120, working_directory: nil)
             dir = working_directory ? File.expand_path(working_directory) : Dir.pwd
 
             if sandbox_enabled? && sandbox_available?
@@ -25,19 +31,17 @@ module Legion
             end
           end
 
-          private
-
-          def sandbox_enabled?
+          def self.sandbox_enabled?
             Legion::Settings.dig(:chat, :sandboxed_commands, :enabled) == true
           rescue StandardError
             false
           end
 
-          def sandbox_available?
+          def self.sandbox_available?
             defined?(Legion::Extensions::Exec::Runners::Shell)
           end
 
-          def execute_sandboxed(command:, timeout:, dir:)
+          def self.execute_sandboxed(command:, timeout:, dir:)
             timeout_ms = timeout * 1000
             result = Legion::Extensions::Exec::Runners::Shell.execute(
               command: command, cwd: dir, timeout: timeout_ms
@@ -56,7 +60,7 @@ module Legion
             "Error executing command: #{e.message}"
           end
 
-          def execute_direct(command:, timeout:, dir:)
+          def self.execute_direct(command:, timeout:, dir:)
             stdout, stderr, status = Open3.popen3(command, chdir: dir) do |stdin, out, err, wait_thr|
               stdin.close
               out_reader = Thread.new { out.read }
@@ -80,7 +84,7 @@ module Legion
             "Error executing command: #{e.message}"
           end
 
-          def format_output(command, stdout, stderr, exit_code)
+          def self.format_output(command, stdout, stderr, exit_code)
             output = String.new
             output << "$ #{command}\n"
             output << stdout.to_s unless stdout.to_s.empty?

--- a/lib/legion/cli/chat/tools/save_memory.rb
+++ b/lib/legion/cli/chat/tools/save_memory.rb
@@ -1,24 +1,30 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'legion/cli/chat_command'
 
 module Legion
   module CLI
     class Chat
       module Tools
-        class SaveMemory < RubyLLM::Tool
+        class SaveMemory < Legion::Tools::Base
+          tool_name 'legion.save_memory'
           description 'Save important information to persistent memory for future sessions. ' \
                       'Also ingests into the Apollo knowledge graph when available for semantic search. ' \
                       'Use this when you learn something important about the project, user preferences, ' \
                       'key decisions, or recurring patterns that should be remembered.'
-          param :text, type: 'string', desc: 'The information to remember'
-          param :scope, type: 'string', desc: 'Memory scope: "project" (default) or "global"', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           text:  { type: 'string', description: 'The information to remember' },
+                           scope: { type: 'string', description: 'Memory scope: "project" (default) or "global"' }
+                         },
+                         required:   ['text']
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(text:, scope: 'project')
+          def self.call(text:, scope: 'project')
             require 'legion/cli/chat/memory_store'
             sym_scope = scope.to_s == 'global' ? :global : :project
             path = MemoryStore.add(text, scope: sym_scope)
@@ -32,9 +38,7 @@ module Legion
             "Error saving memory: #{e.message}"
           end
 
-          private
-
-          def ingest_to_apollo(text, scope)
+          def self.ingest_to_apollo(text, scope)
             require 'net/http'
             require 'json'
 
@@ -45,7 +49,6 @@ module Legion
             request = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
             request.body = ::JSON.generate({
                                              content: text,
-                                             type:    'memory',
                                              source:  "chat:#{scope}",
                                              tags:    ['memory', scope.to_s]
                                            })
@@ -59,7 +62,7 @@ module Legion
             nil
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/scheduling_status.rb
+++ b/lib/legion/cli/chat/tools/scheduling_status.rb
@@ -4,16 +4,19 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class SchedulingStatus < RubyLLM::Tool
+        class SchedulingStatus < Legion::Tools::Base
+          tool_name 'legion.scheduling_status'
           description 'Show LLM scheduling and batch queue status: peak/off-peak state, ' \
                       'batch queue depth, and scheduling configuration'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action: { type: 'string', description: 'Action: "overview" (default), "scheduling" (peak/off-peak detail), "batch" (queue detail)' }
+                         },
+                         required:   []
+                       })
 
-          param :action,
-                type:     :string,
-                desc:     'Action: "overview" (default), "scheduling" (peak/off-peak detail), "batch" (queue detail)',
-                required: false
-
-          def execute(action: 'overview')
+          def self.call(action: 'overview')
             case action.to_s
             when 'scheduling' then format_scheduling
             when 'batch'      then format_batch
@@ -21,9 +24,7 @@ module Legion
             end
           end
 
-          private
-
-          def format_overview
+          def self.format_overview
             lines = ["LLM Scheduling & Batch Overview:\n"]
 
             if scheduling_available?
@@ -49,7 +50,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_scheduling
+          def self.format_scheduling
             return 'Scheduling module not available.' unless scheduling_available?
 
             s = Legion::LLM::Scheduling.status
@@ -63,7 +64,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_batch
+          def self.format_batch
             return 'Batch module not available.' unless batch_available?
 
             b = Legion::LLM::Batch.status
@@ -86,11 +87,11 @@ module Legion
             lines.join("\n")
           end
 
-          def scheduling_available?
+          def self.scheduling_available?
             defined?(Legion::LLM::Scheduling)
           end
 
-          def batch_available?
+          def self.batch_available?
             defined?(Legion::LLM::Batch)
           end
         end

--- a/lib/legion/cli/chat/tools/search_content.rb
+++ b/lib/legion/cli/chat/tools/search_content.rb
@@ -1,19 +1,25 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'legion/cli/chat_command'
 
 module Legion
   module CLI
     class Chat
       module Tools
-        class SearchContent < RubyLLM::Tool
+        class SearchContent < Legion::Tools::Base
+          tool_name 'legion.search_content'
           description 'Search file contents for a regex pattern. Returns matching lines with context.'
-          param :pattern, type: 'string', desc: 'Regex pattern to search for'
-          param :directory, type: 'string', desc: 'Directory to search in (default: current dir)', required: false
-          param :glob, type: 'string', desc: 'File glob filter (e.g., "*.rb")', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           pattern:   { type: 'string', description: 'Regex pattern to search for' },
+                           directory: { type: 'string', description: 'Directory to search in (default: current dir)' },
+                           glob:      { type: 'string', description: 'File glob filter (e.g., "*.rb")' }
+                         },
+                         required:   ['pattern']
+                       })
 
-          def execute(pattern:, directory: nil, glob: nil) # rubocop:disable Metrics/CyclomaticComplexity
+          def self.call(pattern:, directory: nil, glob: nil) # rubocop:disable Metrics/CyclomaticComplexity
             dir = File.expand_path(directory || Dir.pwd)
             return "Error: directory not found: #{dir}" unless Dir.exist?(dir)
 

--- a/lib/legion/cli/chat/tools/search_files.rb
+++ b/lib/legion/cli/chat/tools/search_files.rb
@@ -1,18 +1,24 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'legion/cli/chat_command'
 
 module Legion
   module CLI
     class Chat
       module Tools
-        class SearchFiles < RubyLLM::Tool
+        class SearchFiles < Legion::Tools::Base
+          tool_name 'legion.search_files'
           description 'Find files matching a glob pattern. Returns matching file paths.'
-          param :pattern, type: 'string', desc: 'Glob pattern (e.g., "**/*.rb", "src/**/*.ts")'
-          param :directory, type: 'string', desc: 'Directory to search in (default: current dir)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           pattern:   { type: 'string', description: 'Glob pattern (e.g., "**/*.rb", "src/**/*.ts")' },
+                           directory: { type: 'string', description: 'Directory to search in (default: current dir)' }
+                         },
+                         required:   ['pattern']
+                       })
 
-          def execute(pattern:, directory: nil)
+          def self.call(pattern:, directory: nil)
             dir = File.expand_path(directory || Dir.pwd)
             return "Error: directory not found: #{dir}" unless Dir.exist?(dir)
 

--- a/lib/legion/cli/chat/tools/search_memory.rb
+++ b/lib/legion/cli/chat/tools/search_memory.rb
@@ -1,22 +1,28 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'legion/cli/chat_command'
 
 module Legion
   module CLI
     class Chat
       module Tools
-        class SearchMemory < RubyLLM::Tool
+        class SearchMemory < Legion::Tools::Base
+          tool_name 'legion.search_memory'
           description 'Search persistent memory and the Apollo knowledge graph for previously saved information. ' \
                       'Returns matching memory entries (substring match) and related Apollo knowledge entries when available. ' \
                       'Use this to recall project conventions, user preferences, past decisions, or learned facts.'
-          param :query, type: 'string', desc: 'Search text (case-insensitive substring match for memory, semantic for Apollo)'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           query: { type: 'string', description: 'Search text (case-insensitive substring match for memory, semantic for Apollo)' }
+                         },
+                         required:   ['query']
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(query:)
+          def self.call(query:)
             require 'legion/cli/chat/memory_store'
             sections = []
 
@@ -40,9 +46,7 @@ module Legion
             "Error searching memory: #{e.message}"
           end
 
-          private
-
-          def search_apollo(query)
+          def self.search_apollo(query)
             require 'net/http'
             require 'json'
 
@@ -59,7 +63,7 @@ module Legion
             nil
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/search_traces.rb
+++ b/lib/legion/cli/chat/tools/search_traces.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'json'
 
 begin
@@ -13,15 +12,22 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class SearchTraces < RubyLLM::Tool
+        class SearchTraces < Legion::Tools::Base
+          tool_name 'legion.search_traces'
           description 'Search cognitive memory traces for information from Teams messages, conversations, ' \
                       'meetings, people, and other ingested data. Use this when the user asks about what ' \
                       'someone said, conversation topics, meeting details, or any previously observed context.'
-          param :query, type: 'string', desc: 'Natural language search query (e.g., "what did Bob say about deployment")'
-          param :person, type: 'string', desc: 'Filter by person name (matches peer:Name domain tags)', required: false
-          param :domain, type: 'string', desc: 'Filter by domain tag (e.g., "teams", "meeting", "conversation")', required: false
-          param :trace_type, type: 'string', desc: 'Filter by trace type: episodic, semantic, sensory, identity', required: false
-          param :limit, type: 'integer', desc: 'Max results to return (default: 20)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           query:      { type: 'string', description: 'Natural language search query (e.g., "what did Bob say about deployment")' },
+                           person:     { type: 'string', description: 'Filter by person name (matches peer:Name domain tags)' },
+                           domain:     { type: 'string', description: 'Filter by domain tag (e.g., "teams", "meeting", "conversation")' },
+                           trace_type: { type: 'string', description: 'Filter by trace type: episodic, semantic, sensory, identity' },
+                           limit:      { type: 'integer', description: 'Max results to return (default: 20)' }
+                         },
+                         required:   ['query']
+                       })
 
           STRUCTURED_FIELDS = [
             ['Person', 'displayName', :displayName, 'peer', :peer],
@@ -31,7 +37,7 @@ module Legion
             ['Job', 'jobTitle', :jobTitle]
           ].freeze
 
-          def execute(query:, person: nil, domain: nil, trace_type: nil, limit: nil, **) # rubocop:disable Metrics/ParameterLists
+          def self.call(query:, person: nil, domain: nil, trace_type: nil, limit: nil, **) # rubocop:disable Metrics/ParameterLists
             return 'Memory trace system not available (lex-agentic-memory not loaded).' unless trace_store_available?
 
             limit = (limit || 20).clamp(1, 50)
@@ -48,25 +54,23 @@ module Legion
             "Error searching traces: #{e.message}"
           end
 
-          private
-
-          def trace_store_available?
+          def self.trace_store_available?
             load_trace_gem unless defined?(Legion::Extensions::Agentic::Memory::Trace)
             defined?(Legion::Extensions::Agentic::Memory::Trace) &&
               Legion::Extensions::Agentic::Memory::Trace.respond_to?(:shared_store)
           end
 
-          def load_trace_gem
+          def self.load_trace_gem
             require 'legion/extensions/agentic/memory/trace'
           rescue LoadError
             nil
           end
 
-          def store
+          def self.store
             Legion::Extensions::Agentic::Memory::Trace.shared_store
           end
 
-          def collect_traces(person:, domain:, trace_type:, limit:)
+          def self.collect_traces(person:, domain:, trace_type:, limit:)
             if person
               candidates = []
               name_variants = person_name_variants(person)
@@ -92,7 +96,7 @@ module Legion
             store.all_traces(min_strength: 0.01).sort_by { |t| -t[:strength] }.first(limit)
           end
 
-          def rank_by_query(traces:, query:)
+          def self.rank_by_query(traces:, query:)
             keywords = query.downcase.split(/\s+/).reject { |w| w.length < 3 }
             return traces if keywords.empty?
 
@@ -109,7 +113,7 @@ module Legion
             scored.sort_by { |s| -s[:score] }.map { |s| s[:trace] }
           end
 
-          def extract_searchable_text(trace)
+          def self.extract_searchable_text(trace)
             payload = trace[:content_payload] || trace[:content]
             text = case payload
                    when String
@@ -127,7 +131,7 @@ module Legion
             text.downcase
           end
 
-          def flatten_to_text(obj)
+          def self.flatten_to_text(obj)
             case obj
             when Hash
               obj.values.map { |v| flatten_to_text(v) }.join(' ')
@@ -138,7 +142,7 @@ module Legion
             end
           end
 
-          def compute_score(text:, keywords:, trace:)
+          def self.compute_score(text:, keywords:, trace:)
             keyword_hits = keywords.count { |kw| text.include?(kw) }
             return 0.0 if keyword_hits.zero?
 
@@ -149,14 +153,14 @@ module Legion
             (keyword_ratio * 10.0) + (strength_bonus * 2.0) + (recency_bonus * 3.0)
           end
 
-          def recency_score(created_at)
+          def self.recency_score(created_at)
             return 0.0 unless created_at.is_a?(Time)
 
             age_hours = (Time.now.utc - created_at) / 3600.0
             1.0 / (1.0 + (age_hours / 24.0))
           end
 
-          def format_results(traces)
+          def self.format_results(traces)
             parts = traces.map.with_index(1) do |trace, idx|
               payload = trace[:content_payload] || trace[:content]
               content = format_payload(payload)
@@ -169,14 +173,14 @@ module Legion
             "Found #{traces.size} matching traces:\n\n#{parts.join("\n\n")}"
           end
 
-          def format_payload(payload)
+          def self.format_payload(payload)
             data = parse_payload(payload)
             return truncate(data, 300) if data.is_a?(String)
 
             format_structured(data)
           end
 
-          def parse_payload(payload)
+          def self.parse_payload(payload)
             case payload
             when String
               ::JSON.parse(payload)
@@ -189,7 +193,7 @@ module Legion
             payload
           end
 
-          def format_structured(data)
+          def self.format_structured(data)
             parts = STRUCTURED_FIELDS.filter_map do |label, *keys|
               val = keys.lazy.filter_map { |k| data[k] }.first
               "#{label}: #{val}" if val
@@ -200,11 +204,11 @@ module Legion
             truncate(flatten_to_text(data), 300)
           end
 
-          def truncate(text, max)
+          def self.truncate(text, max)
             text.length > max ? "#{text[0..(max - 3)]}..." : text
           end
 
-          def format_age(created_at)
+          def self.format_age(created_at)
             return 'age unknown' unless created_at.is_a?(Time)
 
             seconds = Time.now.utc - created_at
@@ -217,7 +221,7 @@ module Legion
             end
           end
 
-          def person_name_variants(name)
+          def self.person_name_variants(name)
             parts = name.strip.split(/[\s,]+/).reject(&:empty?)
             variants = [name]
 
@@ -235,7 +239,7 @@ module Legion
             variants.uniq
           end
 
-          def fuzzy_person_search(person, limit: 60)
+          def self.fuzzy_person_search(person, limit: 60)
             needle = person.downcase
             parts = needle.split(/[\s,]+/).reject(&:empty?)
 

--- a/lib/legion/cli/chat/tools/shadow_eval_status.rb
+++ b/lib/legion/cli/chat/tools/shadow_eval_status.rb
@@ -4,15 +4,18 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class ShadowEvalStatus < RubyLLM::Tool
+        class ShadowEvalStatus < Legion::Tools::Base
+          tool_name 'legion.shadow_eval_status'
           description 'Show shadow evaluation results comparing primary vs cheaper models'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action: { type: 'string', description: 'Action: "summary" (default) or "history" (recent evaluations)' }
+                         },
+                         required:   []
+                       })
 
-          param :action,
-                type:     :string,
-                desc:     'Action: "summary" (default) or "history" (recent evaluations)',
-                required: false
-
-          def execute(action: 'summary')
+          def self.call(action: 'summary')
             return 'Shadow evaluation not available.' unless shadow_available?
 
             case action.to_s
@@ -21,13 +24,11 @@ module Legion
             end
           end
 
-          private
-
-          def shadow_available?
+          def self.shadow_available?
             defined?(Legion::LLM::ShadowEval)
           end
 
-          def format_summary
+          def self.format_summary
             s = Legion::LLM::ShadowEval.summary
             lines = ["Shadow Evaluation Summary:\n"]
             lines << format('  Evaluations:      %<v>d', v: s[:total_evaluations])
@@ -54,7 +55,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_history
+          def self.format_history
             entries = Legion::LLM::ShadowEval.history
             return 'No shadow evaluation history.' if entries.empty?
 
@@ -74,7 +75,7 @@ module Legion
             lines.join("\n")
           end
 
-          def truncate(str, max)
+          def self.truncate(str, max)
             str.length > max ? "#{str[0, max - 1]}~" : str
           end
         end

--- a/lib/legion/cli/chat/tools/spawn_agent.rb
+++ b/lib/legion/cli/chat/tools/spawn_agent.rb
@@ -1,20 +1,26 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'legion/cli/chat_command'
 
 module Legion
   module CLI
     class Chat
       module Tools
-        class SpawnAgent < RubyLLM::Tool
+        class SpawnAgent < Legion::Tools::Base
+          tool_name 'legion.spawn_agent'
           description 'Spawn a background subagent to work on a task independently. ' \
                       'The subagent runs in a separate process with its own context. ' \
                       'Results are injected back into the conversation when complete.'
-          param :task, type: 'string', desc: 'The task description for the subagent'
-          param :model, type: 'string', desc: 'Model to use (optional, inherits parent)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           task:  { type: 'string', description: 'The task description for the subagent' },
+                           model: { type: 'string', description: 'Model to use (optional, inherits parent)' }
+                         },
+                         required:   ['task']
+                       })
 
-          def execute(task:, model: nil)
+          def self.call(task:, model: nil)
             require 'legion/cli/chat/subagent'
             result = Subagent.spawn(
               task:        task,
@@ -32,9 +38,7 @@ module Legion
             "Error spawning subagent: #{e.message}"
           end
 
-          private
-
-          def notify_complete(agent_id, result)
+          def self.notify_complete(agent_id, result)
             # Result is available via Subagent.running or injected by the REPL loop
             output = result[:output] || result[:error] || 'No output'
             warn "\n  [subagent #{agent_id}] Complete: #{output.lines.first&.strip}"

--- a/lib/legion/cli/chat/tools/summarize_traces.rb
+++ b/lib/legion/cli/chat/tools/summarize_traces.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
-
 begin
   require 'legion/cli/chat_command'
 rescue LoadError
@@ -12,13 +10,20 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class SummarizeTraces < RubyLLM::Tool
+        class SummarizeTraces < Legion::Tools::Base
+          tool_name 'legion.summarize_traces'
           description 'Get aggregate statistics from the metering database: total records, token usage, cost, ' \
                       'latency, status breakdown, and top extensions/workers. Use natural language queries like ' \
                       '"failed tasks today" or "most expensive calls this week".'
-          param :query, type: 'string', desc: 'Natural language query describing what to summarize'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           query: { type: 'string', description: 'Natural language query describing what to summarize' }
+                         },
+                         required:   ['query']
+                       })
 
-          def execute(query:)
+          def self.call(query:)
             require 'legion/trace_search'
             result = Legion::TraceSearch.summarize(query)
             return "Error: #{result[:error]}" if result[:error]
@@ -31,9 +36,7 @@ module Legion
             "Error summarizing traces: #{e.message}"
           end
 
-          private
-
-          def format_summary(data)
+          def self.format_summary(data)
             lines = ["Trace Summary (#{data[:total_records]} records):\n"]
             lines << "  Tokens: #{data[:total_tokens_in]} in / #{data[:total_tokens_out]} out"
             lines << "  Cost: $#{data[:total_cost]}"
@@ -47,20 +50,20 @@ module Legion
             lines.compact.join("\n")
           end
 
-          def format_time_range(range)
+          def self.format_time_range(range)
             return nil unless range && (range[:from] || range[:to])
 
             "  Time range: #{range[:from] || '?'} to #{range[:to] || '?'}"
           end
 
-          def format_status_counts(counts)
+          def self.format_status_counts(counts)
             return nil if counts.nil? || counts.empty?
 
             parts = counts.map { |status, count| "#{status}: #{count}" }
             "  Status: #{parts.join(', ')}"
           end
 
-          def format_top(title, items, key)
+          def self.format_top(title, items, key)
             return nil if items.nil? || items.empty?
 
             parts = items.map { |item| "#{item[key]} (#{item[:count]})" }

--- a/lib/legion/cli/chat/tools/system_status.rb
+++ b/lib/legion/cli/chat/tools/system_status.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,15 +13,17 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class SystemStatus < RubyLLM::Tool
+        class SystemStatus < Legion::Tools::Base
+          tool_name 'legion.system_status'
           description 'Check the health and status of the Legion daemon. Shows component readiness ' \
                       '(settings, crypt, transport, cache, data, gaia, extensions, api), ' \
                       'extension count, uptime, and version info. Use this to diagnose issues or verify the system is healthy.'
+          input_schema({ type: 'object', properties: {}, required: [] })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute
+          def self.call
             health = fetch_health
             ready = fetch_ready
             format_status(health, ready)
@@ -33,9 +34,7 @@ module Legion
             "Error checking system status: #{e.message}"
           end
 
-          private
-
-          def fetch_health
+          def self.fetch_health
             api_get('/api/health')
           rescue Errno::ECONNREFUSED
             raise
@@ -44,7 +43,7 @@ module Legion
             nil
           end
 
-          def fetch_ready
+          def self.fetch_ready
             api_get('/api/ready')
           rescue Errno::ECONNREFUSED
             raise
@@ -53,7 +52,7 @@ module Legion
             nil
           end
 
-          def format_status(health, ready)
+          def self.format_status(health, ready)
             lines = ["Legion System Status\n"]
 
             if health
@@ -84,7 +83,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_uptime(seconds)
+          def self.format_uptime(seconds)
             return 'unknown' unless seconds
 
             seconds = seconds.to_i
@@ -99,7 +98,7 @@ module Legion
             parts.join(' ')
           end
 
-          def api_get(path)
+          def self.api_get(path)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 2
@@ -108,7 +107,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/trigger_dream.rb
+++ b/lib/legion/cli/chat/tools/trigger_dream.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,13 +13,18 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class TriggerDream < RubyLLM::Tool
+        class TriggerDream < Legion::Tools::Base
+          tool_name 'legion.trigger_dream'
           description 'Trigger or view dream cycles on the running Legion daemon. Dream cycles consolidate ' \
                       'memory traces, detect contradictions, walk associations, and promote knowledge to Apollo. ' \
                       'Use action "trigger" to start a new cycle, or "journal" to view the most recent dream report.'
-          param :action, type:     'string',
-                         desc:     'Action: "trigger" (default) to run dream cycle, "journal" to view latest dream report',
-                         required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action: { type: 'string', description: 'Action: "trigger" (default) to run dream cycle, "journal" to view latest dream report' }
+                         },
+                         required:   []
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
@@ -28,7 +32,7 @@ module Legion
           DREAM_RUNNER = 'Legion::Extensions::Agentic::Imagination::Dream::Runners::DreamCycle'
           DREAM_FUNCTION = 'execute_dream_cycle'
 
-          def execute(action: 'trigger')
+          def self.call(action: 'trigger')
             case action.to_s
             when 'journal' then handle_journal
             else handle_trigger
@@ -40,9 +44,7 @@ module Legion
             "Error: #{e.message}"
           end
 
-          private
-
-          def handle_trigger
+          def self.handle_trigger
             body = ::JSON.generate({
                                      runner_class:  DREAM_RUNNER,
                                      function:      DREAM_FUNCTION,
@@ -56,7 +58,7 @@ module Legion
             "Dream trigger failed: #{response.dig(:error, :message) || 'unknown error'}"
           end
 
-          def handle_journal
+          def self.handle_journal
             journal_path = find_latest_journal
             return 'No dream journal entries found.' unless journal_path
 
@@ -64,12 +66,12 @@ module Legion
             truncate(content, 2000)
           end
 
-          def find_latest_journal
+          def self.find_latest_journal
             paths = dream_log_dirs.flat_map { |dir| Dir.glob(File.join(dir, 'dream-*.md')) }
             paths.last
           end
 
-          def dream_log_dirs
+          def self.dream_log_dirs
             dirs = []
             dirs << File.expand_path('logs/dreams', gem_path) if gem_path
             dirs << File.expand_path('.legion/dreams', Dir.pwd)
@@ -77,23 +79,23 @@ module Legion
             dirs.select { |d| Dir.exist?(d) }
           end
 
-          def gem_path
+          def self.gem_path
             spec = Gem::Specification.find_by_name('lex-agentic-imagination')
             spec&.gem_dir
           rescue Gem::MissingSpecError
             nil
           end
 
-          def format_task_id(response)
+          def self.format_task_id(response)
             task_id = response.dig(:data, :task_id) || response.dig(:data, :id)
             task_id ? "Task ID: #{task_id}" : ''
           end
 
-          def truncate(text, max)
+          def self.truncate(text, max)
             text.length > max ? "#{text[0..(max - 4)]}..." : text
           end
 
-          def api_post(path, body)
+          def self.api_post(path, body)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 5
@@ -104,7 +106,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/view_events.rb
+++ b/lib/legion/cli/chat/tools/view_events.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,18 +13,23 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class ViewEvents < RubyLLM::Tool
+        class ViewEvents < Legion::Tools::Base
+          tool_name 'legion.view_events'
           description 'View recent events from the Legion event bus. Shows system events like task completions, ' \
                       'extension lifecycle, runner failures, worker state changes, and alerts. ' \
                       'Use this to understand what is happening in the running daemon right now.'
-          param :count, type:     'integer',
-                        desc:     'Number of recent events to fetch (default: 15, max: 100)',
-                        required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           count: { type: 'integer', description: 'Number of recent events to fetch (default: 15, max: 100)' }
+                         },
+                         required:   []
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(count: 15)
+          def self.call(count: 15)
             count = count.to_i.clamp(1, 100)
             data = api_get("/api/events/recent?count=#{count}")
             return "API error: #{data[:error]}" if data[:error]
@@ -42,9 +46,7 @@ module Legion
             "Error fetching events: #{e.message}"
           end
 
-          private
-
-          def format_events(events)
+          def self.format_events(events)
             lines = ["Recent Events (#{events.size}):\n"]
             events.each do |ev|
               name = ev[:event] || ev['event'] || 'unknown'
@@ -57,7 +59,7 @@ module Legion
             lines.join("\n")
           end
 
-          def extract_detail(event)
+          def self.extract_detail(event)
             parts = []
             %i[extension worker_id status severity message rule].each do |key|
               val = event[key] || event[key.to_s]
@@ -66,7 +68,7 @@ module Legion
             parts.empty? ? nil : parts.join(', ')
           end
 
-          def api_get(path)
+          def self.api_get(path)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 2
@@ -75,7 +77,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/view_trends.rb
+++ b/lib/legion/cli/chat/tools/view_trends.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,21 +13,24 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class ViewTrends < RubyLLM::Tool
+        class ViewTrends < Legion::Tools::Base
+          tool_name 'legion.view_trends'
           description 'Show metric trends over time: cost, latency, volume, and failure rates bucketed into ' \
                       'time intervals. Use this to understand how system behavior changes over hours or days. ' \
                       'Ask "how are costs trending?" or "show me latency trends for the last 6 hours".'
-          param :hours, type:     'integer',
-                        desc:     'Time range in hours (default: 24, max: 168)',
-                        required: false
-          param :buckets, type:     'integer',
-                          desc:     'Number of time buckets (default: 12, max: 48)',
-                          required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           hours:   { type: 'integer', description: 'Time range in hours (default: 24, max: 168)' },
+                           buckets: { type: 'integer', description: 'Number of time buckets (default: 12, max: 48)' }
+                         },
+                         required:   []
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(hours: 24, buckets: 12)
+          def self.call(hours: 24, buckets: 12)
             hours = hours.to_i.clamp(1, 168)
             buckets = buckets.to_i.clamp(2, 48)
 
@@ -43,9 +45,7 @@ module Legion
             "Error fetching trends: #{e.message}"
           end
 
-          private
-
-          def format_trend(data)
+          def self.format_trend(data)
             trend_buckets = data[:buckets] || []
             return 'No trend data available.' if trend_buckets.empty?
 
@@ -69,7 +69,7 @@ module Legion
             lines.join("\n")
           end
 
-          def format_time(iso_str)
+          def self.format_time(iso_str)
             return iso_str unless iso_str.is_a?(String)
 
             Time.parse(iso_str).strftime('%m/%d %H:%M')
@@ -77,7 +77,7 @@ module Legion
             iso_str
           end
 
-          def summarize_direction(trend_buckets)
+          def self.summarize_direction(trend_buckets)
             return '' if trend_buckets.size < 2
 
             first_half = trend_buckets[0...(trend_buckets.size / 2)]
@@ -91,14 +91,14 @@ module Legion
             "  Direction: #{directions.join(' | ')}"
           end
 
-          def avg_metric(buckets, key)
+          def self.avg_metric(buckets, key)
             values = buckets.map { |b| (b[key] || 0).to_f }
             return 0.0 if values.empty?
 
             values.sum / values.size
           end
 
-          def direction_label(name, first_avg, second_avg)
+          def self.direction_label(name, first_avg, second_avg)
             return "#{name}: stable" if first_avg.zero? && second_avg.zero?
             return "#{name}: rising" if first_avg.zero?
 
@@ -113,7 +113,7 @@ module Legion
             "#{name}: #{arrow} (#{'+' if change.positive?}#{change}%)"
           end
 
-          def api_get(path)
+          def self.api_get(path)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 2
@@ -122,7 +122,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/web_search.rb
+++ b/lib/legion/cli/chat/tools/web_search.rb
@@ -1,19 +1,25 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'legion/cli/chat_command'
 
 module Legion
   module CLI
     class Chat
       module Tools
-        class WebSearch < RubyLLM::Tool
+        class WebSearch < Legion::Tools::Base
+          tool_name 'legion.web_search'
           description 'Search the web for information. Returns titles, URLs, and snippets from search results, ' \
                       'plus the full content of the top result.'
-          param :query, type: 'string', desc: 'The search query'
-          param :max_results, type: 'integer', desc: 'Maximum number of results (default 5)', required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           query:       { type: 'string', description: 'The search query' },
+                           max_results: { type: 'integer', description: 'Maximum number of results (default 5)' }
+                         },
+                         required:   ['query']
+                       })
 
-          def execute(query:, max_results: 5)
+          def self.call(query:, max_results: 5)
             require 'legion/cli/chat/web_search'
             results = Chat::WebSearch.search(query, max_results: max_results)
 

--- a/lib/legion/cli/chat/tools/worker_status.rb
+++ b/lib/legion/cli/chat/tools/worker_status.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'net/http'
 require 'json'
 
@@ -14,21 +13,25 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class WorkerStatus < RubyLLM::Tool
+        class WorkerStatus < Legion::Tools::Base
+          tool_name 'legion.worker_status'
           description 'View digital worker status on the running Legion daemon. List all workers, ' \
                       'show details for a specific worker, or check worker health. Digital workers ' \
                       'are AI-as-labor entities with lifecycle states, risk tiers, and cost tracking.'
-          param :action, type:     'string',
-                         desc:     'Action: "list" (default), "show", or "health"',
-                         required: false
-          param :worker_id, type: 'string', desc: 'Worker ID (for show action)', required: false
-          param :status_filter, type: 'string', desc: 'Filter by lifecycle state (active/paused/retired)',
-                                required: false
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           action:        { type: 'string', description: 'Action: "list" (default), "show", or "health"' },
+                           worker_id:     { type: 'string', description: 'Worker ID (for show action)' },
+                           status_filter: { type: 'string', description: 'Filter by lifecycle state (active/paused/retired)' }
+                         },
+                         required:   []
+                       })
 
           DEFAULT_PORT = 4567
           DEFAULT_HOST = '127.0.0.1'
 
-          def execute(action: 'list', worker_id: nil, status_filter: nil)
+          def self.call(action: 'list', worker_id: nil, status_filter: nil)
             case action.to_s
             when 'show'
               return 'worker_id is required for the "show" action.' unless worker_id
@@ -46,9 +49,7 @@ module Legion
             "Error fetching worker data: #{e.message}"
           end
 
-          private
-
-          def handle_list(status_filter)
+          def self.handle_list(status_filter)
             path = '/api/workers'
             path += "?lifecycle_state=#{status_filter}" if status_filter && !status_filter.strip.empty?
             data = api_get(path)
@@ -66,7 +67,7 @@ module Legion
             lines.join("\n")
           end
 
-          def handle_show(worker_id)
+          def self.handle_show(worker_id)
             data = api_get("/api/workers/#{worker_id}")
             w = data[:data] || data
             return "Worker #{worker_id} not found." if w[:error]
@@ -76,7 +77,7 @@ module Legion
             lines.join("\n")
           end
 
-          def handle_health
+          def self.handle_health
             data = api_get('/api/workers?health_status=unhealthy')
             unhealthy = extract_collection(data)
 
@@ -101,19 +102,19 @@ module Legion
             lines.join("\n")
           end
 
-          def display_fields(worker)
+          def self.display_fields(worker)
             %i[name lifecycle_state risk_tier team extension_name owner_msid health_status
                created_at].filter_map do |key|
               [key, worker[key]] if worker[key]
             end
           end
 
-          def extract_collection(data)
+          def self.extract_collection(data)
             entries = data[:data] || data
             entries.is_a?(Array) ? entries : []
           end
 
-          def api_get(path)
+          def self.api_get(path)
             uri = URI("http://#{DEFAULT_HOST}:#{api_port}#{path}")
             http = Net::HTTP.new(uri.host, uri.port)
             http.open_timeout = 2
@@ -122,7 +123,7 @@ module Legion
             ::JSON.parse(response.body, symbolize_names: true)
           end
 
-          def api_port
+          def self.api_port
             return DEFAULT_PORT unless defined?(Legion::Settings)
 
             Legion::Settings[:api]&.dig(:port) || DEFAULT_PORT

--- a/lib/legion/cli/chat/tools/write_file.rb
+++ b/lib/legion/cli/chat/tools/write_file.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby_llm'
 require 'legion/cli/chat_command'
 require 'fileutils'
 
@@ -8,12 +7,19 @@ module Legion
   module CLI
     class Chat
       module Tools
-        class WriteFile < RubyLLM::Tool
+        class WriteFile < Legion::Tools::Base
+          tool_name 'legion.write_file'
           description 'Create a new file or overwrite an existing file with the given content.'
-          param :path, type: 'string', desc: 'Path to the file to write'
-          param :content, type: 'string', desc: 'Content to write to the file'
+          input_schema({
+                         type:       'object',
+                         properties: {
+                           path:    { type: 'string', description: 'Path to the file to write' },
+                           content: { type: 'string', description: 'Content to write to the file' }
+                         },
+                         required:   %w[path content]
+                       })
 
-          def execute(path:, content:)
+          def self.call(path:, content:)
             expanded = File.expand_path(path)
             require 'legion/cli/chat/checkpoint'
             Checkpoint.save(expanded)

--- a/lib/legion/cli/generate_command.rb
+++ b/lib/legion/cli/generate_command.rb
@@ -332,31 +332,38 @@ module Legion
         end
 
         def tool_template(lex, lex_class, _name, class_name)
+          tool_snake = class_name.gsub(/([a-z\d])([A-Z])/, '\1_\2').gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').downcase
           <<~RUBY
             # frozen_string_literal: true
 
-            require 'ruby_llm'
             require 'legion/cli/chat/extension_tool'
 
             module Legion
               module Extensions
                 module #{lex_class}
                   module Tools
-                    class #{class_name} < RubyLLM::Tool
+                    class #{class_name} < Legion::Tools::Base
                       include Legion::CLI::Chat::ExtensionTool
 
+                      tool_name 'legion.#{lex}.#{tool_snake}'
                       description 'TODO: Describe what this tool does'
-                      param :example, type: 'string', desc: 'TODO: Describe this parameter'
+                      input_schema({
+                        type: 'object',
+                        properties: {
+                          example: { type: 'string', description: 'TODO: Describe this parameter' }
+                        },
+                        required: ['example']
+                      })
 
                       permission_tier :write
 
-                      def execute(example:)
+                      def self.call(example:)
                         settings = Legion::Settings[:extensions][:#{lex}] || {}
                         client = Legion::Extensions::#{lex_class}::Client.new(**settings)
                         # TODO: implement
-                        'Not yet implemented'
+                        text_response('Not yet implemented')
                       rescue StandardError => e
-                        "Error: \#{e.message}"
+                        error_response(e.message)
                       end
                     end
                   end

--- a/lib/legion/identity/process.rb
+++ b/lib/legion/identity/process.rb
@@ -8,17 +8,19 @@ module Legion
   module Identity
     module Process
       EMPTY_STATE = {
-        id:             nil,
-        canonical_name: nil,
-        kind:           nil,
-        source:         nil,
-        persistent:     false,
-        groups:         [].freeze,
-        metadata:       {}.freeze,
-        trust:          nil,
-        aliases:        {}.freeze,
-        providers:      {}.freeze,
-        profile:        {}.freeze
+        id:              nil,
+        canonical_name:  nil,
+        kind:            nil,
+        source:          nil,
+        persistent:      false,
+        groups:          [].freeze,
+        metadata:        {}.freeze,
+        trust:           nil,
+        aliases:         {}.freeze,
+        providers:       {}.freeze,
+        profile:         {}.freeze,
+        db_principal_id: nil,
+        db_identity_id:  nil
       }.freeze
 
       class << self
@@ -78,22 +80,32 @@ module Legion
           @state.get[:profile] || {}.freeze
         end
 
+        def db_principal_id
+          @state.get[:db_principal_id]
+        end
+
+        def db_identity_id
+          @state.get[:db_identity_id]
+        end
+
         def identity_hash
           {
-            id:             id,
-            canonical_name: canonical_name,
-            kind:           kind,
-            source:         source,
-            mode:           mode,
-            queue_prefix:   queue_prefix,
-            resolved:       resolved?,
-            persistent:     persistent?,
-            groups:         @state.get[:groups] || [],
-            metadata:       @state.get[:metadata] || {},
-            trust:          trust,
-            aliases:        aliases,
-            providers:      providers,
-            profile:        profile
+            id:              id,
+            canonical_name:  canonical_name,
+            kind:            kind,
+            source:          source,
+            mode:            mode,
+            queue_prefix:    queue_prefix,
+            resolved:        resolved?,
+            persistent:      persistent?,
+            groups:          @state.get[:groups] || [],
+            metadata:        @state.get[:metadata] || {},
+            trust:           trust,
+            aliases:         aliases,
+            providers:       providers,
+            profile:         profile,
+            db_principal_id: @state.get[:db_principal_id],
+            db_identity_id:  @state.get[:db_identity_id]
           }
         end
 
@@ -101,17 +113,19 @@ module Legion
           @provider = provider
           provider_source = provider.respond_to?(:provider_name) ? provider.provider_name : nil
           @state.set({
-                       id:             identity_hash[:id],
-                       canonical_name: identity_hash[:canonical_name],
-                       kind:           identity_hash[:kind],
-                       source:         identity_hash.key?(:source) ? identity_hash[:source] : provider_source,
-                       persistent:     identity_hash.fetch(:persistent, true),
-                       groups:         Array(identity_hash[:groups]).compact.freeze,
-                       metadata:       identity_hash[:metadata].is_a?(Hash) ? identity_hash[:metadata].dup.freeze : {}.freeze,
-                       trust:          identity_hash[:trust],
-                       aliases:        identity_hash[:aliases].is_a?(Hash) ? identity_hash[:aliases].dup.freeze : {}.freeze,
-                       providers:      identity_hash[:providers].is_a?(Hash) ? identity_hash[:providers].dup.freeze : {}.freeze,
-                       profile:        identity_hash[:profile].is_a?(Hash) ? identity_hash[:profile].dup.freeze : {}.freeze
+                       id:              identity_hash[:id],
+                       canonical_name:  identity_hash[:canonical_name],
+                       kind:            identity_hash[:kind],
+                       source:          identity_hash.key?(:source) ? identity_hash[:source] : provider_source,
+                       persistent:      identity_hash.fetch(:persistent, true),
+                       groups:          Array(identity_hash[:groups]).compact.freeze,
+                       metadata:        identity_hash[:metadata].is_a?(Hash) ? identity_hash[:metadata].dup.freeze : {}.freeze,
+                       trust:           identity_hash[:trust],
+                       aliases:         identity_hash[:aliases].is_a?(Hash) ? identity_hash[:aliases].dup.freeze : {}.freeze,
+                       providers:       identity_hash[:providers].is_a?(Hash) ? identity_hash[:providers].dup.freeze : {}.freeze,
+                       profile:         identity_hash[:profile].is_a?(Hash) ? identity_hash[:profile].dup.freeze : {}.freeze,
+                       db_principal_id: identity_hash[:db_principal_id],
+                       db_identity_id:  identity_hash[:db_identity_id]
                      })
           @resolved.make_true
         end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.31'
+  VERSION = '1.9.32'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.32'
+  VERSION = '1.9.33'
 end

--- a/spec/cli/chat/extension_tool_loader_spec.rb
+++ b/spec/cli/chat/extension_tool_loader_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe Legion::CLI::Chat::ExtensionToolLoader do
   end
 
   describe '.collect_tool_classes' do
-    it 'collects RubyLLM::Tool subclasses from a module' do
+    it 'collects Legion::Tools::Base subclasses from a module' do
       mod = Module.new
-      tool_class = Class.new(RubyLLM::Tool) do
+      tool_class = Class.new(Legion::Tools::Base) do
         include Legion::CLI::Chat::ExtensionTool
 
         description 'Test tool'
@@ -68,7 +68,7 @@ RSpec.describe Legion::CLI::Chat::ExtensionToolLoader do
 
   describe '.effective_tier' do
     let(:tool_class) do
-      Class.new(RubyLLM::Tool) do
+      Class.new(Legion::Tools::Base) do
         include Legion::CLI::Chat::ExtensionTool
 
         description 'Test'

--- a/spec/cli/chat/extension_tool_spec.rb
+++ b/spec/cli/chat/extension_tool_spec.rb
@@ -6,7 +6,7 @@ require 'legion/cli/chat/extension_tool'
 
 RSpec.describe Legion::CLI::Chat::ExtensionTool do
   let(:read_tool) do
-    Class.new(RubyLLM::Tool) do
+    Class.new(Legion::Tools::Base) do
       include Legion::CLI::Chat::ExtensionTool
 
       description 'A read tool'
@@ -15,7 +15,7 @@ RSpec.describe Legion::CLI::Chat::ExtensionTool do
   end
 
   let(:default_tool) do
-    Class.new(RubyLLM::Tool) do
+    Class.new(Legion::Tools::Base) do
       include Legion::CLI::Chat::ExtensionTool
 
       description 'A default tool'
@@ -23,7 +23,7 @@ RSpec.describe Legion::CLI::Chat::ExtensionTool do
   end
 
   let(:shell_tool) do
-    Class.new(RubyLLM::Tool) do
+    Class.new(Legion::Tools::Base) do
       include Legion::CLI::Chat::ExtensionTool
 
       description 'A shell tool'
@@ -45,7 +45,7 @@ RSpec.describe Legion::CLI::Chat::ExtensionTool do
 
   it 'rejects invalid tiers' do
     expect do
-      Class.new(RubyLLM::Tool) do
+      Class.new(Legion::Tools::Base) do
         include Legion::CLI::Chat::ExtensionTool
 
         permission_tier :admin

--- a/spec/cli/chat/permissions_spec.rb
+++ b/spec/cli/chat/permissions_spec.rb
@@ -7,7 +7,7 @@ require 'legion/cli/chat/extension_tool'
 
 RSpec.describe Legion::CLI::Chat::Permissions do
   let(:read_tool) do
-    Class.new(RubyLLM::Tool) do
+    Class.new(Legion::Tools::Base) do
       include Legion::CLI::Chat::ExtensionTool
 
       description 'Read tool'
@@ -16,7 +16,7 @@ RSpec.describe Legion::CLI::Chat::Permissions do
   end
 
   let(:write_tool) do
-    Class.new(RubyLLM::Tool) do
+    Class.new(Legion::Tools::Base) do
       include Legion::CLI::Chat::ExtensionTool
 
       description 'Write tool'

--- a/spec/cli/chat/plan_mode_extension_tools_spec.rb
+++ b/spec/cli/chat/plan_mode_extension_tools_spec.rb
@@ -7,7 +7,7 @@ require 'legion/cli/chat/extension_tool'
 
 RSpec.describe 'Plan mode with extension tools' do
   let(:read_ext_tool) do
-    Class.new(RubyLLM::Tool) do
+    Class.new(Legion::Tools::Base) do
       include Legion::CLI::Chat::ExtensionTool
 
       description 'Read ext tool'
@@ -16,7 +16,7 @@ RSpec.describe 'Plan mode with extension tools' do
   end
 
   let(:write_ext_tool) do
-    Class.new(RubyLLM::Tool) do
+    Class.new(Legion::Tools::Base) do
       include Legion::CLI::Chat::ExtensionTool
 
       description 'Write ext tool'

--- a/spec/cli/chat/tool_registry_spec.rb
+++ b/spec/cli/chat/tool_registry_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Legion::CLI::Chat::ToolRegistry do
     end
 
     it 'includes extension tools when available' do
-      fake_tool = Class.new(RubyLLM::Tool) do
+      fake_tool = Class.new(Legion::Tools::Base) do
         description 'Fake extension tool'
         def execute = 'ok'
       end

--- a/spec/cli/generate_tool_spec.rb
+++ b/spec/cli/generate_tool_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe 'legion generate tool' do
     generator.tool('get_key')
     path = File.join(tmpdir, 'lib/legion/extensions/redis/tools/get_key.rb')
     content = File.read(path)
-    expect(content).to include('class GetKey < RubyLLM::Tool')
+    expect(content).to include('class GetKey < Legion::Tools::Base')
     expect(content).to include('permission_tier :write')
-    expect(content).to include('def execute')
+    expect(content).to include('def self.call')
     expect(content).to include('Legion::Extensions::Redis::Client')
   end
 

--- a/spec/legion/api/llm_inference_spec.rb
+++ b/spec/legion/api/llm_inference_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe 'LLM inference API route' do
         end
       end)
 
-      stub_const('RubyLLM::Tool', Class.new)
+      stub_const('Legion::Tools::Base', Class.new)
       pr = make_pipeline_response
       stub_const('Legion::LLM::Inference::Executor', Class.new do
         define_method(:initialize) { |_req| nil }

--- a/spec/legion/cli/chat/extension_tool_loader_spec.rb
+++ b/spec/legion/cli/chat/extension_tool_loader_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'ruby_llm'
 require 'legion/cli/chat/extension_tool_loader'
 
 RSpec.describe Legion::CLI::Chat::ExtensionToolLoader do
@@ -47,18 +46,18 @@ RSpec.describe Legion::CLI::Chat::ExtensionToolLoader do
 
   describe '.effective_tier' do
     let(:read_tool) do
-      klass = Class.new(RubyLLM::Tool)
+      klass = Class.new(Legion::Tools::Base)
       klass.define_singleton_method(:declared_permission_tier) { :read }
       klass
     end
 
     let(:write_tool) do
-      klass = Class.new(RubyLLM::Tool)
+      klass = Class.new(Legion::Tools::Base)
       klass.define_singleton_method(:declared_permission_tier) { :write }
       klass
     end
 
-    let(:bare_tool) { Class.new(RubyLLM::Tool) }
+    let(:bare_tool) { Class.new(Legion::Tools::Base) }
 
     before do
       allow(described_class).to receive(:settings_tier_for).and_return(nil)
@@ -84,9 +83,9 @@ RSpec.describe Legion::CLI::Chat::ExtensionToolLoader do
   end
 
   describe '.collect_tool_classes' do
-    it 'finds RubyLLM::Tool subclasses' do
+    it 'finds Legion::Tools::Base subclasses' do
       tools_mod = Module.new
-      tool_class = Class.new(RubyLLM::Tool)
+      tool_class = Class.new(Legion::Tools::Base)
       non_tool = Class.new
       tools_mod.const_set(:MyTool, tool_class)
       tools_mod.const_set(:Helper, non_tool)

--- a/spec/legion/cli/chat/permissions_spec.rb
+++ b/spec/legion/cli/chat/permissions_spec.rb
@@ -51,19 +51,19 @@ RSpec.describe Legion::CLI::Chat::Permissions do
   end
 
   describe 'Gate module on WriteFile' do
-    let(:tool) { Legion::CLI::Chat::Tools::WriteFile.new }
+    let(:tool) { Legion::CLI::Chat::Tools::WriteFile }
     let(:path) { File.join(tmpdir, 'gated.txt') }
 
     it 'auto-allows in headless mode' do
       described_class.mode = :headless
-      result = tool.call({ path: path, content: 'hello' })
+      result = tool.call(path: path, content: 'hello')
       expect(File.read(path)).to eq('hello')
       expect(result).to include('Wrote')
     end
 
     it 'auto-allows in auto_approve mode' do
       described_class.mode = :auto_approve
-      result = tool.call({ path: path, content: 'hello' })
+      result = tool.call(path: path, content: 'hello')
       expect(File.read(path)).to eq('hello')
       expect(result).to include('Wrote')
     end
@@ -73,7 +73,7 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       allow($stdin).to receive(:gets).and_return("y\n")
       allow($stderr).to receive(:print)
 
-      result = tool.call({ path: path, content: 'hello' })
+      result = tool.call(path: path, content: 'hello')
       expect(File.read(path)).to eq('hello')
       expect(result).to include('Wrote')
     end
@@ -83,8 +83,8 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       allow($stdin).to receive(:gets).and_return("n\n")
       allow($stderr).to receive(:print)
 
-      result = tool.call({ path: path, content: 'hello' })
-      expect(result).to eq('Tool execution denied by user.')
+      result = tool.call(path: path, content: 'hello')
+      expect(result).to eq({ content: [{ type: 'text', text: '{"error":"Tool execution denied by user."}' }], error: true })
       expect(File.exist?(path)).to be false
     end
 
@@ -93,12 +93,12 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       allow($stdin).to receive(:gets).and_return("y\n")
 
       expect($stderr).to receive(:print).with(a_string_including(path))
-      tool.call({ path: path, content: 'hello' })
+      tool.call(path: path, content: 'hello')
     end
   end
 
   describe 'Gate module on EditFile' do
-    let(:tool) { Legion::CLI::Chat::Tools::EditFile.new }
+    let(:tool) { Legion::CLI::Chat::Tools::EditFile }
     let(:path) { File.join(tmpdir, 'edit_gated.txt') }
 
     before { File.write(path, 'hello world') }
@@ -108,8 +108,8 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       allow($stdin).to receive(:gets).and_return("n\n")
       allow($stderr).to receive(:print)
 
-      result = tool.call({ path: path, old_text: 'world', new_text: 'legion' })
-      expect(result).to eq('Tool execution denied by user.')
+      result = tool.call(path: path, old_text: 'world', new_text: 'legion')
+      expect(result).to eq({ content: [{ type: 'text', text: '{"error":"Tool execution denied by user."}' }], error: true })
       expect(File.read(path)).to eq('hello world')
     end
 
@@ -118,22 +118,22 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       allow($stdin).to receive(:gets).and_return("yes\n")
       allow($stderr).to receive(:print)
 
-      result = tool.call({ path: path, old_text: 'world', new_text: 'legion' })
+      result = tool.call(path: path, old_text: 'world', new_text: 'legion')
       expect(result).to include('Replaced')
       expect(File.read(path)).to eq('hello legion')
     end
   end
 
   describe 'Gate module on RunCommand' do
-    let(:tool) { Legion::CLI::Chat::Tools::RunCommand.new }
+    let(:tool) { Legion::CLI::Chat::Tools::RunCommand }
 
     it 'blocks when user denies' do
       described_class.mode = :interactive
       allow($stdin).to receive(:gets).and_return("n\n")
       allow($stderr).to receive(:print)
 
-      result = tool.call({ command: 'echo hello' })
-      expect(result).to eq('Tool execution denied by user.')
+      result = tool.call(command: 'echo hello')
+      expect(result).to eq({ content: [{ type: 'text', text: '{"error":"Tool execution denied by user."}' }], error: true })
     end
 
     it 'allows when user approves' do
@@ -141,7 +141,7 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       allow($stdin).to receive(:gets).and_return("y\n")
       allow($stderr).to receive(:print)
 
-      result = tool.call({ command: 'echo hello' })
+      result = tool.call(command: 'echo hello')
       expect(result).to include('hello')
     end
 
@@ -150,12 +150,12 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       allow($stdin).to receive(:gets).and_return("y\n")
 
       expect($stderr).to receive(:print).with(a_string_including('echo hello'))
-      tool.call({ command: 'echo hello' })
+      tool.call(command: 'echo hello')
     end
   end
 
   describe 'ReadFile is NOT gated' do
-    let(:tool) { Legion::CLI::Chat::Tools::ReadFile.new }
+    let(:tool) { Legion::CLI::Chat::Tools::ReadFile }
 
     it 'executes without prompting in interactive mode' do
       described_class.mode = :interactive
@@ -163,20 +163,20 @@ RSpec.describe Legion::CLI::Chat::Permissions do
       File.write(path, 'content here')
 
       expect($stdin).not_to receive(:gets)
-      result = tool.call({ path: path })
+      result = tool.call(path: path)
       expect(result).to include('content here')
     end
   end
 
   describe 'SearchFiles is NOT gated' do
-    let(:tool) { Legion::CLI::Chat::Tools::SearchFiles.new }
+    let(:tool) { Legion::CLI::Chat::Tools::SearchFiles }
 
     it 'executes without prompting in interactive mode' do
       described_class.mode = :interactive
       File.write(File.join(tmpdir, 'findme.rb'), '')
 
       expect($stdin).not_to receive(:gets)
-      result = tool.call({ pattern: '*.rb', directory: tmpdir })
+      result = tool.call(pattern: '*.rb', directory: tmpdir)
       expect(result).to include('findme.rb')
     end
   end

--- a/spec/legion/cli/chat/tool_registry_spec.rb
+++ b/spec/legion/cli/chat/tool_registry_spec.rb
@@ -5,23 +5,23 @@ require 'legion/cli/chat/tool_registry'
 
 RSpec.describe Legion::CLI::Chat::ToolRegistry do
   describe '.builtin_tools' do
-    it 'returns an array of RubyLLM::Tool subclasses' do
+    it 'returns an array of Legion::Tools::Base subclasses' do
       tools = described_class.builtin_tools
       expect(tools).to be_an(Array)
       expect(tools).not_to be_empty
       tools.each do |tool|
-        expect(tool).to be < RubyLLM::Tool
+        expect(tool).to be < Legion::Tools::Base
       end
     end
 
     it 'includes file and shell tools' do
-      names = described_class.builtin_tools.map { |t| t.new.name }
-      expect(names.any? { |n| n.end_with?('read_file') }).to be true
-      expect(names.any? { |n| n.end_with?('write_file') }).to be true
-      expect(names.any? { |n| n.end_with?('edit_file') }).to be true
-      expect(names.any? { |n| n.end_with?('search_files') }).to be true
-      expect(names.any? { |n| n.end_with?('search_content') }).to be true
-      expect(names.any? { |n| n.end_with?('run_command') }).to be true
+      names = described_class.builtin_tools.map(&:tool_name)
+      expect(names).to include('legion.read_file')
+      expect(names).to include('legion.write_file')
+      expect(names).to include('legion.edit_file')
+      expect(names).to include('legion.search_files')
+      expect(names).to include('legion.search_content')
+      expect(names).to include('legion.run_command')
     end
 
     it 'returns a mutable copy of the constants array' do

--- a/spec/legion/cli/chat/tools/arbitrage_status_spec.rb
+++ b/spec/legion/cli/chat/tools/arbitrage_status_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'ruby_llm'
 require 'legion/cli/chat/tools/arbitrage_status'
 
 RSpec.describe Legion::CLI::Chat::Tools::ArbitrageStatus do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:arb_mod) do
     Module.new do
@@ -36,7 +35,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ArbitrageStatus do
 
   describe '#execute' do
     it 'returns overview with cost table' do
-      result = tool.execute
+      result = tool.call
       expect(result).to include('LLM Cost Arbitrage')
       expect(result).to include('gpt-4o')
       expect(result).to include('gpt-4o-mini')
@@ -44,26 +43,26 @@ RSpec.describe Legion::CLI::Chat::Tools::ArbitrageStatus do
     end
 
     it 'shows cheapest per tier when enabled' do
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Cheapest per tier')
       expect(result).to include('basic')
       expect(result).to include('reasoning')
     end
 
     it 'returns specific tier info' do
-      result = tool.execute(capability: 'reasoning')
+      result = tool.call(capability: 'reasoning')
       expect(result).to include('tier: reasoning')
       expect(result).to include('gpt-4o')
     end
 
     it 'returns error for invalid tier' do
-      result = tool.execute(capability: 'invalid')
+      result = tool.call(capability: 'invalid')
       expect(result).to include('Invalid tier')
     end
 
     it 'returns unavailable when module not defined' do
       hide_const('Legion::LLM::Arbitrage')
-      result = tool.execute
+      result = tool.call
       expect(result).to eq('LLM arbitrage module not available.')
     end
   end

--- a/spec/legion/cli/chat/tools/budget_status_spec.rb
+++ b/spec/legion/cli/chat/tools/budget_status_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/budget_status'
 
 RSpec.describe Legion::CLI::Chat::Tools::BudgetStatus do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   before do
     stub_const('Legion::LLM', Module.new)
@@ -37,7 +37,7 @@ RSpec.describe Legion::CLI::Chat::Tools::BudgetStatus do
 
   describe '#execute' do
     it 'returns budget status by default' do
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Session Budget Status')
       expect(result).to include('Enforcing:  YES')
       expect(result).to include('Budget:')
@@ -45,7 +45,7 @@ RSpec.describe Legion::CLI::Chat::Tools::BudgetStatus do
     end
 
     it 'returns cost summary when requested' do
-      result = tool.execute(action: 'summary')
+      result = tool.call(action: 'summary')
       expect(result).to include('Session Cost Summary')
       expect(result).to include('claude-sonnet-4-6')
       expect(result).to include('gpt-4o-mini')
@@ -53,7 +53,7 @@ RSpec.describe Legion::CLI::Chat::Tools::BudgetStatus do
 
     it 'returns error when LLM not available' do
       hide_const('Legion::LLM')
-      result = tool.execute
+      result = tool.call
       expect(result).to eq('Legion::LLM not available.')
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe Legion::CLI::Chat::Tools::BudgetStatus do
     end
 
     it 'shows enforcing as no' do
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Enforcing:  no')
     end
   end
@@ -83,7 +83,7 @@ RSpec.describe Legion::CLI::Chat::Tools::BudgetStatus do
     end
 
     it 'returns no requests message' do
-      result = tool.execute(action: 'summary')
+      result = tool.call(action: 'summary')
       expect(result).to eq('No LLM requests recorded this session.')
     end
   end

--- a/spec/legion/cli/chat/tools/consolidate_memory_spec.rb
+++ b/spec/legion/cli/chat/tools/consolidate_memory_spec.rb
@@ -6,7 +6,7 @@ require 'legion/cli/chat/memory_store'
 require 'legion/cli/chat/tools/consolidate_memory'
 
 RSpec.describe Legion::CLI::Chat::Tools::ConsolidateMemory do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:tmpdir) { Dir.mktmpdir('consolidate-test') }
 
@@ -19,14 +19,14 @@ RSpec.describe Legion::CLI::Chat::Tools::ConsolidateMemory do
 
   describe '#execute' do
     it 'returns message when no entries exist' do
-      result = tool.execute(scope: 'project')
+      result = tool.call(scope: 'project')
       expect(result).to include('No memory entries found')
     end
 
     it 'returns message when fewer than 3 entries' do
       2.times { |i| Legion::CLI::Chat::MemoryStore.add("entry #{i}", scope: :project, base_dir: tmpdir) }
       allow(Legion::CLI::Chat::MemoryStore).to receive(:list).and_return(%w[one two])
-      result = tool.execute(scope: 'project')
+      result = tool.call(scope: 'project')
       expect(result).to include('no consolidation needed')
     end
 
@@ -46,7 +46,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ConsolidateMemory do
       stub_const('Legion::LLM', llm_mod)
       allow(Legion::LLM).to receive(:chat_direct).and_return(fake_session)
 
-      result = tool.execute(scope: 'project')
+      result = tool.call(scope: 'project')
       expect(result).to include('4 -> 2')
       expect(result).to include('2 removed/merged')
     end
@@ -63,7 +63,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ConsolidateMemory do
       stub_const('Legion::LLM', llm_mod)
       allow(Legion::LLM).to receive(:chat_direct).and_return(fake_session)
 
-      result = tool.execute(scope: 'project', dry_run: 'true')
+      result = tool.call(scope: 'project', dry_run: 'true')
       expect(result).to include('Preview')
       expect(result).to include('3 -> 2')
     end
@@ -73,7 +73,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ConsolidateMemory do
       allow(Legion::CLI::Chat::MemoryStore).to receive(:list).and_return(entries)
 
       hide_const('Legion::LLM')
-      result = tool.execute(scope: 'project')
+      result = tool.call(scope: 'project')
       expect(result).to include('could not generate summary')
     end
 
@@ -89,7 +89,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ConsolidateMemory do
       stub_const('Legion::LLM', llm_mod)
       allow(Legion::LLM).to receive(:chat_direct).and_return(fake_session)
 
-      result = tool.execute(scope: 'global')
+      result = tool.call(scope: 'global')
       expect(result).to include('global memory')
       expect(result).to include('3 -> 1')
     end
@@ -106,7 +106,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ConsolidateMemory do
       stub_const('Legion::LLM', llm_mod)
       allow(Legion::LLM).to receive(:chat_direct).and_return(fake_session)
 
-      tool.execute(scope: 'project')
+      tool.call(scope: 'project')
 
       path = Legion::CLI::Chat::MemoryStore.project_path
       expect(File).to exist(path)
@@ -118,7 +118,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ConsolidateMemory do
 
     it 'handles errors gracefully' do
       allow(Legion::CLI::Chat::MemoryStore).to receive(:list).and_raise(StandardError, 'disk full')
-      result = tool.execute(scope: 'project')
+      result = tool.call(scope: 'project')
       expect(result).to include('Error consolidating memory')
       expect(result).to include('disk full')
     end

--- a/spec/legion/cli/chat/tools/cost_summary_spec.rb
+++ b/spec/legion/cli/chat/tools/cost_summary_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/cost_summary'
 
 RSpec.describe Legion::CLI::Chat::Tools::CostSummary do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:stub_http) { instance_double(Net::HTTP) }
 
@@ -26,7 +26,7 @@ RSpec.describe Legion::CLI::Chat::Tools::CostSummary do
       end
 
       it 'returns formatted cost summary' do
-        result = tool.execute
+        result = tool.call
         expect(result).to include('Cost Summary')
         expect(result).to include('$0.1234')
         expect(result).to include('$0.5678')
@@ -48,7 +48,7 @@ RSpec.describe Legion::CLI::Chat::Tools::CostSummary do
       end
 
       it 'returns top cost consumers' do
-        result = tool.execute(action: 'top', limit: 5)
+        result = tool.call(action: 'top', limit: 5)
         expect(result).to include('Top')
         expect(result).to include('w-1')
       end
@@ -65,7 +65,7 @@ RSpec.describe Legion::CLI::Chat::Tools::CostSummary do
       end
 
       it 'returns worker cost details' do
-        result = tool.execute(action: 'worker', worker_id: 'w-1')
+        result = tool.call(action: 'worker', worker_id: 'w-1')
         expect(result).to include('Worker: w-1')
         expect(result).to include('total_cost_usd')
       end
@@ -73,7 +73,7 @@ RSpec.describe Legion::CLI::Chat::Tools::CostSummary do
 
     context 'with worker action and missing worker_id' do
       it 'returns error message' do
-        result = tool.execute(action: 'worker')
+        result = tool.call(action: 'worker')
         expect(result).to include('worker_id is required')
       end
     end
@@ -85,7 +85,7 @@ RSpec.describe Legion::CLI::Chat::Tools::CostSummary do
       end
 
       it 'returns no workers message' do
-        result = tool.execute(action: 'top')
+        result = tool.call(action: 'top')
         expect(result).to eq('No workers found.')
       end
     end
@@ -96,7 +96,7 @@ RSpec.describe Legion::CLI::Chat::Tools::CostSummary do
       end
 
       it 'returns daemon not running message' do
-        result = tool.execute
+        result = tool.call
         expect(result).to include('daemon not running')
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe Legion::CLI::Chat::Tools::CostSummary do
       end
 
       it 'returns the error message' do
-        result = tool.execute
+        result = tool.call
         expect(result).to include('API error: internal')
       end
     end

--- a/spec/legion/cli/chat/tools/detect_anomalies_spec.rb
+++ b/spec/legion/cli/chat/tools/detect_anomalies_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/detect_anomalies'
 
 RSpec.describe Legion::CLI::Chat::Tools::DetectAnomalies do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:api_port) { 4567 }
 
@@ -19,7 +19,7 @@ RSpec.describe Legion::CLI::Chat::Tools::DetectAnomalies do
         recent_period: 'last 1 hour', baseline_period: 'previous 23 hours'
       )
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('No anomalies detected')
       expect(result).to include('50 records')
     end
@@ -34,7 +34,7 @@ RSpec.describe Legion::CLI::Chat::Tools::DetectAnomalies do
         recent_period: 'last 1 hour', baseline_period: 'previous 23 hours'
       )
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('2 anomalies detected')
       expect(result).to include('[CRITICAL] Average cost')
       expect(result).to include('[WARNING] Average latency')
@@ -44,21 +44,21 @@ RSpec.describe Legion::CLI::Chat::Tools::DetectAnomalies do
     it 'passes custom threshold' do
       stub_api_response_for_threshold(3.5, anomalies: [], recent_count: 10, baseline_count: 100)
 
-      result = tool.execute(threshold: 3.5)
+      result = tool.call(threshold: 3.5)
       expect(result).to include('No anomalies detected')
     end
 
     it 'handles API error response' do
       stub_api_error('trace_search_unavailable', 'TraceSearch requires LLM subsystem')
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('TraceSearch requires LLM subsystem')
     end
 
     it 'handles connection refused' do
       allow(tool).to receive(:api_get).and_raise(Errno::ECONNREFUSED)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Legion daemon not running')
     end
 
@@ -68,7 +68,7 @@ RSpec.describe Legion::CLI::Chat::Tools::DetectAnomalies do
         recent_count: 15, baseline_count: 200
       )
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('1 anomaly detected')
     end
   end

--- a/spec/legion/cli/chat/tools/entity_extract_spec.rb
+++ b/spec/legion/cli/chat/tools/entity_extract_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'ruby_llm'
 require 'legion/cli/chat/tools/entity_extract'
 
 RSpec.describe Legion::CLI::Chat::Tools::EntityExtract do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:extractor_mod) do
     Module.new do
@@ -28,21 +27,21 @@ RSpec.describe Legion::CLI::Chat::Tools::EntityExtract do
 
   describe '#execute' do
     it 'returns extracted entities' do
-      result = tool.execute(text: 'Alice works on LegionIO')
+      result = tool.call(text: 'Alice works on LegionIO')
       expect(result).to include('Extracted 2 entities')
       expect(result).to include('Alice')
       expect(result).to include('LegionIO')
     end
 
     it 'filters by entity type' do
-      result = tool.execute(text: 'Alice works on LegionIO', entity_types: 'person')
+      result = tool.call(text: 'Alice works on LegionIO', entity_types: 'person')
       expect(result).to include('Alice')
       expect(result).not_to include('LegionIO')
     end
 
     it 'returns unavailable when extractor not loaded' do
       hide_const('Legion::Extensions::Apollo::Runners::EntityExtractor')
-      result = tool.execute(text: 'test')
+      result = tool.call(text: 'test')
       expect(result).to eq('Apollo entity extractor not available.')
     end
 
@@ -53,12 +52,12 @@ RSpec.describe Legion::CLI::Chat::Tools::EntityExtract do
         end
       end
       stub_const('Legion::Extensions::Apollo::Runners::EntityExtractor', empty_mod)
-      result = tool.execute(text: 'nothing here', min_confidence: 0.99)
+      result = tool.call(text: 'nothing here', min_confidence: 0.99)
       expect(result).to eq('No entities found in the provided text.')
     end
 
     it 'shows confidence percentages' do
-      result = tool.execute(text: 'Alice')
+      result = tool.call(text: 'Alice')
       expect(result).to include('95%')
     end
   end

--- a/spec/legion/cli/chat/tools/escalation_status_spec.rb
+++ b/spec/legion/cli/chat/tools/escalation_status_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'ruby_llm'
 require 'legion/cli/chat/tools/escalation_status'
 
 RSpec.describe Legion::CLI::Chat::Tools::EscalationStatus do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:tracker_mod) do
     Module.new do
@@ -31,27 +30,27 @@ RSpec.describe Legion::CLI::Chat::Tools::EscalationStatus do
 
   describe '#execute' do
     it 'returns summary by default' do
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Model Escalation Summary')
       expect(result).to include('Total Escalations: 3')
       expect(result).to include('quality')
     end
 
     it 'shows escalated-to models' do
-      result = tool.execute
+      result = tool.call
       expect(result).to include('gpt-4o')
       expect(result).to include('Escalated To')
     end
 
     it 'shows rate when requested' do
-      result = tool.execute(action: 'rate')
+      result = tool.call(action: 'rate')
       expect(result).to include('Escalation Rate')
       expect(result).to include('3 escalations')
     end
 
     it 'returns unavailable when tracker not defined' do
       hide_const('Legion::LLM::EscalationTracker')
-      result = tool.execute
+      result = tool.call
       expect(result).to eq('Escalation tracker not available.')
     end
   end

--- a/spec/legion/cli/chat/tools/file_tools_spec.rb
+++ b/spec/legion/cli/chat/tools/file_tools_spec.rb
@@ -11,28 +11,33 @@ require 'legion/cli/chat/tools/search_content'
 RSpec.describe 'Chat File Tools' do
   let(:tmpdir) { Dir.mktmpdir }
 
-  after { FileUtils.rm_rf(tmpdir) }
+  before { Legion::CLI::Chat::Permissions.mode = :headless if defined?(Legion::CLI::Chat::Permissions) }
+
+  after do
+    FileUtils.rm_rf(tmpdir)
+    Legion::CLI::Chat::Permissions.mode = :interactive if defined?(Legion::CLI::Chat::Permissions)
+  end
 
   describe Legion::CLI::Chat::Tools::ReadFile do
-    let(:tool) { described_class.new }
+    let(:tool) { described_class }
 
     it 'reads file contents' do
       path = File.join(tmpdir, 'test.txt')
       File.write(path, "line1\nline2\nline3")
-      result = tool.execute(path: path)
+      result = tool.call(path: path)
       expect(result).to include('line1')
       expect(result).to include('line3')
     end
 
     it 'returns error for missing file' do
-      result = tool.execute(path: '/nonexistent/file.txt')
+      result = tool.call(path: '/nonexistent/file.txt')
       expect(result).to include('error'.downcase).or include('Error')
     end
 
     it 'supports offset and limit' do
       path = File.join(tmpdir, 'test.txt')
       File.write(path, "line1\nline2\nline3\nline4\nline5")
-      result = tool.execute(path: path, offset: 2, limit: 2)
+      result = tool.call(path: path, offset: 2, limit: 2)
       expect(result).to include('line2')
       expect(result).to include('line3')
       expect(result).not_to include('line4')
@@ -40,29 +45,29 @@ RSpec.describe 'Chat File Tools' do
   end
 
   describe Legion::CLI::Chat::Tools::WriteFile do
-    let(:tool) { described_class.new }
+    let(:tool) { described_class }
 
     it 'creates a new file' do
       path = File.join(tmpdir, 'new.txt')
-      result = tool.execute(path: path, content: 'hello world')
+      result = tool.call(path: path, content: 'hello world')
       expect(File.read(path)).to eq('hello world')
       expect(result.downcase).to include('wrote')
     end
 
     it 'creates parent directories' do
       path = File.join(tmpdir, 'sub', 'dir', 'new.txt')
-      tool.execute(path: path, content: 'nested')
+      tool.call(path: path, content: 'nested')
       expect(File.read(path)).to eq('nested')
     end
   end
 
   describe Legion::CLI::Chat::Tools::EditFile do
-    let(:tool) { described_class.new }
+    let(:tool) { described_class }
 
     it 'replaces text in a file' do
       path = File.join(tmpdir, 'edit.txt')
       File.write(path, 'hello world')
-      result = tool.execute(path: path, old_text: 'world', new_text: 'legion')
+      result = tool.call(path: path, old_text: 'world', new_text: 'legion')
       expect(File.read(path)).to eq('hello legion')
       expect(result.downcase).to include('replaced')
     end
@@ -70,21 +75,21 @@ RSpec.describe 'Chat File Tools' do
     it 'errors when old_text not found' do
       path = File.join(tmpdir, 'edit.txt')
       File.write(path, 'hello world')
-      result = tool.execute(path: path, old_text: 'missing', new_text: 'x')
+      result = tool.call(path: path, old_text: 'missing', new_text: 'x')
       expect(result.downcase).to include('error')
     end
 
     it 'errors when old_text matches multiple times' do
       path = File.join(tmpdir, 'edit.txt')
       File.write(path, 'aaa bbb aaa')
-      result = tool.execute(path: path, old_text: 'aaa', new_text: 'x')
+      result = tool.call(path: path, old_text: 'aaa', new_text: 'x')
       expect(result.downcase).to include('error')
     end
 
     it 'errors when no old_text and no start_line provided' do
       path = File.join(tmpdir, 'edit.txt')
       File.write(path, "line1\nline2\n")
-      result = tool.execute(path: path, new_text: 'x')
+      result = tool.call(path: path, new_text: 'x')
       expect(result.downcase).to include('error')
     end
 
@@ -92,7 +97,7 @@ RSpec.describe 'Chat File Tools' do
       it 'replaces a single line when only start_line is given' do
         path = File.join(tmpdir, 'lines.txt')
         File.write(path, "line1\nline2\nline3\n")
-        result = tool.execute(path: path, new_text: 'replaced', start_line: 2)
+        result = tool.call(path: path, new_text: 'replaced', start_line: 2)
         expect(File.read(path)).to eq("line1\nreplaced\nline3\n")
         expect(result.downcase).to include('replaced')
       end
@@ -100,7 +105,7 @@ RSpec.describe 'Chat File Tools' do
       it 'replaces a range of lines when start_line and end_line are given' do
         path = File.join(tmpdir, 'lines.txt')
         File.write(path, "line1\nline2\nline3\nline4\n")
-        result = tool.execute(path: path, new_text: 'new', start_line: 2, end_line: 3)
+        result = tool.call(path: path, new_text: 'new', start_line: 2, end_line: 3)
         expect(File.read(path)).to eq("line1\nnew\nline4\n")
         expect(result.downcase).to include('replaced')
       end
@@ -108,28 +113,28 @@ RSpec.describe 'Chat File Tools' do
       it 'replaces the first line' do
         path = File.join(tmpdir, 'lines.txt')
         File.write(path, "line1\nline2\nline3\n")
-        tool.execute(path: path, new_text: 'first', start_line: 1)
+        tool.call(path: path, new_text: 'first', start_line: 1)
         expect(File.read(path)).to eq("first\nline2\nline3\n")
       end
 
       it 'replaces the last line' do
         path = File.join(tmpdir, 'lines.txt')
         File.write(path, "line1\nline2\nline3\n")
-        tool.execute(path: path, new_text: 'last', start_line: 3)
+        tool.call(path: path, new_text: 'last', start_line: 3)
         expect(File.read(path)).to eq("line1\nline2\nlast\n")
       end
 
       it 'preserves trailing newline when replacement text already has one' do
         path = File.join(tmpdir, 'lines.txt')
         File.write(path, "line1\nline2\nline3\n")
-        tool.execute(path: path, new_text: "newline\n", start_line: 2)
+        tool.call(path: path, new_text: "newline\n", start_line: 2)
         expect(File.read(path)).to eq("line1\nnewline\nline3\n")
       end
 
       it 'ignores old_text when start_line is provided' do
         path = File.join(tmpdir, 'lines.txt')
         File.write(path, "line1\nline2\nline3\n")
-        result = tool.execute(path: path, new_text: 'x', old_text: 'nomatch', start_line: 1)
+        result = tool.call(path: path, new_text: 'x', old_text: 'nomatch', start_line: 1)
         expect(result.downcase).not_to include('error')
         expect(File.read(path)).to include('x')
       end
@@ -137,34 +142,34 @@ RSpec.describe 'Chat File Tools' do
       it 'errors when start_line is out of bounds' do
         path = File.join(tmpdir, 'lines.txt')
         File.write(path, "line1\nline2\n")
-        result = tool.execute(path: path, new_text: 'x', start_line: 10)
+        result = tool.call(path: path, new_text: 'x', start_line: 10)
         expect(result.downcase).to include('error')
       end
 
       it 'errors when end_line is out of bounds' do
         path = File.join(tmpdir, 'lines.txt')
         File.write(path, "line1\nline2\n")
-        result = tool.execute(path: path, new_text: 'x', start_line: 1, end_line: 99)
+        result = tool.call(path: path, new_text: 'x', start_line: 1, end_line: 99)
         expect(result.downcase).to include('error')
       end
 
       it 'errors when end_line is before start_line' do
         path = File.join(tmpdir, 'lines.txt')
         File.write(path, "line1\nline2\nline3\n")
-        result = tool.execute(path: path, new_text: 'x', start_line: 3, end_line: 1)
+        result = tool.call(path: path, new_text: 'x', start_line: 3, end_line: 1)
         expect(result.downcase).to include('error')
       end
     end
   end
 
   describe Legion::CLI::Chat::Tools::SearchFiles do
-    let(:tool) { described_class.new }
+    let(:tool) { described_class }
 
     it 'finds files matching a glob pattern' do
       File.write(File.join(tmpdir, 'foo.rb'), '')
       File.write(File.join(tmpdir, 'bar.rb'), '')
       File.write(File.join(tmpdir, 'baz.txt'), '')
-      result = tool.execute(pattern: '*.rb', directory: tmpdir)
+      result = tool.call(pattern: '*.rb', directory: tmpdir)
       expect(result).to include('foo.rb')
       expect(result).to include('bar.rb')
       expect(result).not_to include('baz.txt')
@@ -172,12 +177,12 @@ RSpec.describe 'Chat File Tools' do
   end
 
   describe Legion::CLI::Chat::Tools::SearchContent do
-    let(:tool) { described_class.new }
+    let(:tool) { described_class }
 
     it 'finds files containing a pattern' do
       File.write(File.join(tmpdir, 'match.rb'), 'def hello; end')
       File.write(File.join(tmpdir, 'nomatch.rb'), 'x = 1')
-      result = tool.execute(pattern: 'def hello', directory: tmpdir)
+      result = tool.call(pattern: 'def hello', directory: tmpdir)
       expect(result).to include('match.rb')
     end
   end

--- a/spec/legion/cli/chat/tools/generate_insights_spec.rb
+++ b/spec/legion/cli/chat/tools/generate_insights_spec.rb
@@ -4,14 +4,14 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/generate_insights'
 
 RSpec.describe Legion::CLI::Chat::Tools::GenerateInsights do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   before { allow(tool).to receive(:api_port).and_return(4567) }
 
   describe '#execute' do
     it 'generates a comprehensive report' do
       stub_all_endpoints
-      result = tool.execute
+      result = tool.call
       expect(result).to include('System Insights Report')
       expect(result).to include('Health: ok')
       expect(result).to include('Anomalies: None detected')
@@ -22,13 +22,13 @@ RSpec.describe Legion::CLI::Chat::Tools::GenerateInsights do
       stub_all_endpoints(
         anomalies: { data: { anomalies: [{ metric: 'Average cost', ratio: 5.0, severity: 'critical' }] } }
       )
-      result = tool.execute
+      result = tool.call
       expect(result).to include('[CRITICAL] Average cost')
     end
 
     it 'shows trend direction' do
       stub_all_endpoints
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Trend (24h)')
     end
 
@@ -36,27 +36,27 @@ RSpec.describe Legion::CLI::Chat::Tools::GenerateInsights do
       stub_all_endpoints(
         anomalies: { data: { anomalies: [{ metric: 'Average cost', ratio: 3.0, severity: 'warning' }] } }
       )
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Recommendations')
       expect(result).to include('model downgrade')
     end
 
     it 'handles daemon not running' do
       allow(tool).to receive(:safe_fetch).and_return(nil)
-      result = tool.execute
+      result = tool.call
       expect(result).to include('daemon not running')
     end
 
     it 'handles connection refused' do
       allow(tool).to receive(:gather_sections).and_raise(Errno::ECONNREFUSED)
-      result = tool.execute
+      result = tool.call
       expect(result).to include('daemon not running')
     end
 
     it 'handles partial data gracefully' do
       allow(tool).to receive(:safe_fetch).and_return(nil)
       allow(tool).to receive(:safe_fetch).with('/api/health').and_return({ data: { status: 'ok' } })
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Health: ok')
     end
   end

--- a/spec/legion/cli/chat/tools/graph_explore_spec.rb
+++ b/spec/legion/cli/chat/tools/graph_explore_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'ruby_llm'
 require 'legion/cli/chat/tools/graph_explore'
 
 RSpec.describe Legion::CLI::Chat::Tools::GraphExplore do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:mock_http) { instance_double(Net::HTTP) }
 
@@ -61,7 +60,7 @@ RSpec.describe Legion::CLI::Chat::Tools::GraphExplore do
       response = instance_double(Net::HTTPOK, body: graph_body)
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Knowledge Graph Topology')
       expect(result).to include('general')
       expect(result).to include('claims_optimization')
@@ -73,7 +72,7 @@ RSpec.describe Legion::CLI::Chat::Tools::GraphExplore do
       response = instance_double(Net::HTTPOK, body: expertise_body)
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute(action: 'expertise')
+      result = tool.call(action: 'expertise')
       expect(result).to include('Expertise Map')
       expect(result).to include('claude-agent')
       expect(result).to include('85.0%')
@@ -83,7 +82,7 @@ RSpec.describe Legion::CLI::Chat::Tools::GraphExplore do
       response = instance_double(Net::HTTPOK, body: disputed_body)
       allow(mock_http).to receive(:request).and_return(response)
 
-      result = tool.execute(action: 'disputed')
+      result = tool.call(action: 'disputed')
       expect(result).to include('Disputed Knowledge Entries')
       expect(result).to include('#42')
       expect(result).to include('Disputed claim about caching')
@@ -93,14 +92,14 @@ RSpec.describe Legion::CLI::Chat::Tools::GraphExplore do
       response = instance_double(Net::HTTPOK, body: JSON.generate({ data: { entries: [], count: 0 } }))
       allow(mock_http).to receive(:request).and_return(response)
 
-      result = tool.execute(action: 'disputed')
+      result = tool.call(action: 'disputed')
       expect(result).to eq('No disputed entries in the knowledge graph.')
     end
 
     it 'handles connection refused' do
       allow(mock_http).to receive(:get).and_raise(Errno::ECONNREFUSED)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to eq('Apollo unavailable (daemon not running).')
     end
   end

--- a/spec/legion/cli/chat/tools/ingest_knowledge_spec.rb
+++ b/spec/legion/cli/chat/tools/ingest_knowledge_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/ingest_knowledge'
 
 RSpec.describe Legion::CLI::Chat::Tools::IngestKnowledge do
-  let(:tool) { described_class.new }
+  let(:tool) { described_class }
 
   let(:success_response) do
     response = instance_double(Net::HTTPSuccess, body: JSON.dump({ data: { id: 42, status: 'created' } }))
@@ -22,34 +22,34 @@ RSpec.describe Legion::CLI::Chat::Tools::IngestKnowledge do
 
   describe '#execute' do
     it 'returns success message with id' do
-      result = tool.execute(content: 'Ruby uses GIL for thread safety')
+      result = tool.call(content: 'Ruby uses GIL for thread safety')
       expect(result).to include('Saved to Apollo')
       expect(result).to include('id: 42')
     end
 
     it 'defaults content_type to observation' do
-      result = tool.execute(content: 'test')
+      result = tool.call(content: 'test')
       expect(result).to include('type: observation')
     end
 
     it 'accepts valid content types' do
-      result = tool.execute(content: 'test', content_type: 'fact')
+      result = tool.call(content: 'test', content_type: 'fact')
       expect(result).to include('type: fact')
     end
 
     it 'rejects invalid content types and falls back to observation' do
-      result = tool.execute(content: 'test', content_type: 'garbage')
+      result = tool.call(content: 'test', content_type: 'garbage')
       expect(result).to include('type: observation')
     end
 
     it 'parses comma-separated tags' do
-      result = tool.execute(content: 'test', tags: 'ruby, performance, gc')
+      result = tool.call(content: 'test', tags: 'ruby, performance, gc')
       expect(result).to include('ruby')
       expect(result).to include('performance')
     end
 
     it 'handles empty tags gracefully' do
-      result = tool.execute(content: 'test', tags: '')
+      result = tool.call(content: 'test', tags: '')
       expect(result).to include('Saved to Apollo')
     end
 
@@ -63,19 +63,19 @@ RSpec.describe Legion::CLI::Chat::Tools::IngestKnowledge do
       allow(http).to receive(:read_timeout=)
       allow(http).to receive(:request).and_return(error_response)
 
-      result = tool.execute(content: 'test')
+      result = tool.call(content: 'test')
       expect(result).to include('Failed to ingest')
     end
 
     it 'returns unavailable message when daemon is down' do
       allow(Net::HTTP).to receive(:new).and_raise(Errno::ECONNREFUSED)
-      result = tool.execute(content: 'test')
+      result = tool.call(content: 'test')
       expect(result).to include('Apollo unavailable')
     end
 
     it 'returns error message on unexpected failure' do
       allow(Net::HTTP).to receive(:new).and_raise(StandardError, 'network error')
-      result = tool.execute(content: 'test')
+      result = tool.call(content: 'test')
       expect(result).to include('Error saving to knowledge graph')
       expect(result).to include('network error')
     end

--- a/spec/legion/cli/chat/tools/knowledge_maintenance_spec.rb
+++ b/spec/legion/cli/chat/tools/knowledge_maintenance_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/knowledge_maintenance'
 
 RSpec.describe Legion::CLI::Chat::Tools::KnowledgeMaintenance do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:mock_http) { instance_double(Net::HTTP) }
 
@@ -22,7 +22,7 @@ RSpec.describe Legion::CLI::Chat::Tools::KnowledgeMaintenance do
       )
       allow(mock_http).to receive(:request).and_return(response)
 
-      result = tool.execute(action: 'decay_cycle')
+      result = tool.call(action: 'decay_cycle')
       expect(result).to include('Decay cycle complete')
       expect(result).to include('Entries decayed: 12')
       expect(result).to include('Entries removed (below threshold): 3')
@@ -36,14 +36,14 @@ RSpec.describe Legion::CLI::Chat::Tools::KnowledgeMaintenance do
       )
       allow(mock_http).to receive(:request).and_return(response)
 
-      result = tool.execute(action: 'corroboration')
+      result = tool.call(action: 'corroboration')
       expect(result).to include('Corroboration check complete')
       expect(result).to include('Entries checked: 100')
       expect(result).to include('Entries boosted (mutually supporting): 15')
     end
 
     it 'rejects invalid actions' do
-      result = tool.execute(action: 'delete_all')
+      result = tool.call(action: 'delete_all')
       expect(result).to include('Invalid action: delete_all')
       expect(result).to include('decay_cycle')
       expect(result).to include('corroboration')
@@ -56,14 +56,14 @@ RSpec.describe Legion::CLI::Chat::Tools::KnowledgeMaintenance do
       )
       allow(mock_http).to receive(:request).and_return(response)
 
-      result = tool.execute(action: 'decay_cycle')
+      result = tool.call(action: 'decay_cycle')
       expect(result).to include('Apollo error: table not available')
     end
 
     it 'handles connection refused' do
       allow(Net::HTTP).to receive(:new).and_raise(Errno::ECONNREFUSED)
 
-      result = tool.execute(action: 'decay_cycle')
+      result = tool.call(action: 'decay_cycle')
       expect(result).to include('Apollo unavailable')
     end
 
@@ -74,7 +74,7 @@ RSpec.describe Legion::CLI::Chat::Tools::KnowledgeMaintenance do
       )
       allow(mock_http).to receive(:request).and_return(response)
 
-      result = tool.execute(action: 'decay_cycle')
+      result = tool.call(action: 'decay_cycle')
       expect(result).to include('Entries decayed: 5')
       expect(result).not_to include('Duration')
     end
@@ -86,7 +86,7 @@ RSpec.describe Legion::CLI::Chat::Tools::KnowledgeMaintenance do
       )
       allow(mock_http).to receive(:request).and_return(response)
 
-      result = tool.execute(action: '  corroboration  ')
+      result = tool.call(action: '  corroboration  ')
       expect(result).to include('Corroboration check complete')
     end
 
@@ -97,7 +97,7 @@ RSpec.describe Legion::CLI::Chat::Tools::KnowledgeMaintenance do
       )
       allow(mock_http).to receive(:request).and_return(response)
 
-      result = tool.execute(action: 'decay_cycle')
+      result = tool.call(action: 'decay_cycle')
       expect(result).to include('Entries decayed: 7')
       expect(result).to include('Entries removed (below threshold): 2')
     end

--- a/spec/legion/cli/chat/tools/knowledge_stats_spec.rb
+++ b/spec/legion/cli/chat/tools/knowledge_stats_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/knowledge_stats'
 
 RSpec.describe Legion::CLI::Chat::Tools::KnowledgeStats do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:mock_http) { instance_double(Net::HTTP) }
 
@@ -30,7 +30,7 @@ RSpec.describe Legion::CLI::Chat::Tools::KnowledgeStats do
       )
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Total entries: 42')
       expect(result).to include('Recent (24h): 8')
       expect(result).to include('Avg confidence: 0.782')
@@ -47,7 +47,7 @@ RSpec.describe Legion::CLI::Chat::Tools::KnowledgeStats do
       )
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Total entries: 0')
       expect(result).not_to include('By Status')
     end
@@ -59,14 +59,14 @@ RSpec.describe Legion::CLI::Chat::Tools::KnowledgeStats do
       )
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Apollo error: apollo_entries table not available')
     end
 
     it 'handles connection refused' do
       allow(Net::HTTP).to receive(:new).and_raise(Errno::ECONNREFUSED)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Apollo unavailable')
     end
 
@@ -77,7 +77,7 @@ RSpec.describe Legion::CLI::Chat::Tools::KnowledgeStats do
       )
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Total entries: 0')
       expect(result).to include('Avg confidence: 0.0')
     end

--- a/spec/legion/cli/chat/tools/list_extensions_spec.rb
+++ b/spec/legion/cli/chat/tools/list_extensions_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/list_extensions'
 
 RSpec.describe Legion::CLI::Chat::Tools::ListExtensions do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:mock_http) { instance_double(Net::HTTP) }
 
@@ -29,7 +29,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ListExtensions do
         )
         allow(mock_http).to receive(:get).and_return(response)
 
-        result = tool.execute
+        result = tool.call
         expect(result).to include('Loaded Extensions (3)')
         expect(result).to include('lex-node (running)')
         expect(result).to include('lex-detect (stopped)')
@@ -40,7 +40,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ListExtensions do
         allow(response).to receive(:body).and_return(JSON.generate({ data: [] }))
         allow(mock_http).to receive(:get).and_return(response)
 
-        result = tool.execute
+        result = tool.call
         expect(result).to include('No extensions found')
       end
 
@@ -52,7 +52,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ListExtensions do
           response
         end
 
-        tool.execute(state: 'running')
+        tool.call(state: 'running')
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ListExtensions do
           call_count == 1 ? ext_response : runners_response
         end
 
-        result = tool.execute(extension_name: 'lex-node')
+        result = tool.call(extension_name: 'lex-node')
         expect(result).to include('Extension: lex-node')
         expect(result).to include('State: running')
         expect(result).to include('Runners (1)')
@@ -102,14 +102,14 @@ RSpec.describe Legion::CLI::Chat::Tools::ListExtensions do
           call_count == 1 ? ext_response : runners_response
         end
 
-        result = tool.execute(extension_name: 'lex-empty')
+        result = tool.call(extension_name: 'lex-empty')
         expect(result).to include('No runners registered')
       end
     end
 
     it 'handles connection refused' do
       allow(Net::HTTP).to receive(:new).and_raise(Errno::ECONNREFUSED)
-      result = tool.execute
+      result = tool.call
       expect(result).to include('daemon not running')
     end
 
@@ -118,7 +118,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ListExtensions do
       allow(response).to receive(:body).and_return(JSON.generate({ error: 'data unavailable' }))
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('API error: data unavailable')
     end
   end

--- a/spec/legion/cli/chat/tools/manage_schedules_spec.rb
+++ b/spec/legion/cli/chat/tools/manage_schedules_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/manage_schedules'
 
 RSpec.describe Legion::CLI::Chat::Tools::ManageSchedules do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:stub_http) { instance_double(Net::HTTP) }
 
@@ -17,7 +17,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageSchedules do
   describe '#execute' do
     context 'with invalid action' do
       it 'returns error message' do
-        result = tool.execute(action: 'delete')
+        result = tool.call(action: 'delete')
         expect(result).to include('Invalid action')
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageSchedules do
       end
 
       it 'returns formatted schedule list' do
-        result = tool.execute(action: 'list')
+        result = tool.call(action: 'list')
         expect(result).to include('Schedules (1)')
         expect(result).to include('#1')
         expect(result).to include('active')
@@ -49,7 +49,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageSchedules do
       end
 
       it 'returns no schedules message' do
-        result = tool.execute(action: 'list')
+        result = tool.call(action: 'list')
         expect(result).to eq('No schedules found.')
       end
     end
@@ -65,13 +65,13 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageSchedules do
       end
 
       it 'returns schedule details' do
-        result = tool.execute(action: 'show', schedule_id: '1')
+        result = tool.call(action: 'show', schedule_id: '1')
         expect(result).to include('Schedule #1')
         expect(result).to include('cron: 0 * * * *')
       end
 
       it 'requires schedule_id' do
-        result = tool.execute(action: 'show')
+        result = tool.call(action: 'show')
         expect(result).to include('schedule_id is required')
       end
     end
@@ -87,13 +87,13 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageSchedules do
       end
 
       it 'returns schedule logs' do
-        result = tool.execute(action: 'logs', schedule_id: '1')
+        result = tool.call(action: 'logs', schedule_id: '1')
         expect(result).to include('Logs for Schedule #1')
         expect(result).to include('success')
       end
 
       it 'requires schedule_id' do
-        result = tool.execute(action: 'logs')
+        result = tool.call(action: 'logs')
         expect(result).to include('schedule_id is required')
       end
     end
@@ -107,18 +107,18 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageSchedules do
       end
 
       it 'creates a schedule' do
-        result = tool.execute(action: 'create', function_id: '5', cron: '0 * * * *')
+        result = tool.call(action: 'create', function_id: '5', cron: '0 * * * *')
         expect(result).to include('Schedule created')
         expect(result).to include('id: 2')
       end
 
       it 'requires function_id' do
-        result = tool.execute(action: 'create', cron: '0 * * * *')
+        result = tool.call(action: 'create', cron: '0 * * * *')
         expect(result).to include('function_id is required')
       end
 
       it 'requires cron' do
-        result = tool.execute(action: 'create', function_id: '5')
+        result = tool.call(action: 'create', function_id: '5')
         expect(result).to include('cron expression is required')
       end
     end
@@ -129,7 +129,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageSchedules do
       end
 
       it 'returns daemon not running message' do
-        result = tool.execute(action: 'list')
+        result = tool.call(action: 'list')
         expect(result).to include('daemon not running')
       end
     end

--- a/spec/legion/cli/chat/tools/manage_tasks_spec.rb
+++ b/spec/legion/cli/chat/tools/manage_tasks_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/manage_tasks'
 
 RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:mock_http) { instance_double(Net::HTTP) }
 
@@ -17,7 +17,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
   describe '#execute' do
     context 'invalid action' do
       it 'returns error for unknown action' do
-        result = tool.execute(action: 'destroy')
+        result = tool.call(action: 'destroy')
         expect(result).to include('Invalid action: destroy')
         expect(result).to include('list, show, logs, trigger')
       end
@@ -38,7 +38,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
         )
         allow(mock_http).to receive(:get).and_return(response)
 
-        result = tool.execute(action: 'list')
+        result = tool.call(action: 'list')
         expect(result).to include('Recent Tasks (2)')
         expect(result).to include('#1 [completed]')
         expect(result).to include('#2 [failed]')
@@ -53,7 +53,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
           response
         end
 
-        tool.execute(action: 'list', status: 'failed')
+        tool.call(action: 'list', status: 'failed')
       end
 
       it 'returns message when no tasks found' do
@@ -61,7 +61,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
         allow(response).to receive(:body).and_return(JSON.generate({ data: [] }))
         allow(mock_http).to receive(:get).and_return(response)
 
-        result = tool.execute(action: 'list')
+        result = tool.call(action: 'list')
         expect(result).to include('No tasks found')
       end
     end
@@ -85,7 +85,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
         )
         allow(mock_http).to receive(:get).and_return(response)
 
-        result = tool.execute(action: 'show', task_id: 42)
+        result = tool.call(action: 'show', task_id: 42)
         expect(result).to include('Task #42')
         expect(result).to include('Status: completed')
         expect(result).to include('Metering:')
@@ -94,7 +94,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
       end
 
       it 'requires task_id' do
-        result = tool.execute(action: 'show')
+        result = tool.call(action: 'show')
         expect(result).to include('task_id is required')
       end
     end
@@ -112,14 +112,14 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
         )
         allow(mock_http).to receive(:get).and_return(response)
 
-        result = tool.execute(action: 'logs', task_id: 42)
+        result = tool.call(action: 'logs', task_id: 42)
         expect(result).to include('Logs for Task #42 (2 entries)')
         expect(result).to include('Task started')
         expect(result).to include('Task completed')
       end
 
       it 'requires task_id' do
-        result = tool.execute(action: 'logs')
+        result = tool.call(action: 'logs')
         expect(result).to include('task_id is required')
       end
 
@@ -128,7 +128,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
         allow(response).to receive(:body).and_return(JSON.generate({ data: [] }))
         allow(mock_http).to receive(:get).and_return(response)
 
-        result = tool.execute(action: 'logs', task_id: 99)
+        result = tool.call(action: 'logs', task_id: 99)
         expect(result).to include('No logs found for task 99')
       end
     end
@@ -145,18 +145,18 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
         allow(Net::HTTP::Post).to receive(:new).and_return(request)
         allow(mock_http).to receive(:request).and_return(response)
 
-        result = tool.execute(action: 'trigger', runner_class: 'Node::Runners::Info', function: 'execute')
+        result = tool.call(action: 'trigger', runner_class: 'Node::Runners::Info', function: 'execute')
         expect(result).to include('Task triggered successfully')
         expect(result).to include('Task ID: 100')
       end
 
       it 'requires runner_class' do
-        result = tool.execute(action: 'trigger', function: 'execute')
+        result = tool.call(action: 'trigger', function: 'execute')
         expect(result).to include('runner_class is required')
       end
 
       it 'requires function' do
-        result = tool.execute(action: 'trigger', runner_class: 'Node::Runners::Info')
+        result = tool.call(action: 'trigger', runner_class: 'Node::Runners::Info')
         expect(result).to include('function is required')
       end
 
@@ -176,14 +176,14 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
           expect(parsed[:target]).to eq('localhost')
         end
 
-        tool.execute(action: 'trigger', runner_class: 'Node::Runners::Info',
-                     function: 'execute', payload: '{"target":"localhost"}')
+        tool.call(action: 'trigger', runner_class: 'Node::Runners::Info',
+                  function: 'execute', payload: '{"target":"localhost"}')
       end
     end
 
     it 'handles connection refused' do
       allow(Net::HTTP).to receive(:new).and_raise(Errno::ECONNREFUSED)
-      result = tool.execute(action: 'list')
+      result = tool.call(action: 'list')
       expect(result).to include('daemon not running')
     end
 
@@ -192,7 +192,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ManageTasks do
       allow(response).to receive(:body).and_return(JSON.generate({ error: 'service unavailable' }))
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute(action: 'list')
+      result = tool.call(action: 'list')
       expect(result).to include('API error: service unavailable')
     end
   end

--- a/spec/legion/cli/chat/tools/memory_and_agent_tools_spec.rb
+++ b/spec/legion/cli/chat/tools/memory_and_agent_tools_spec.rb
@@ -11,7 +11,7 @@ require 'legion/cli/chat/tools/web_search'
 
 RSpec.describe 'Chat Memory and Agent Tools' do
   describe Legion::CLI::Chat::Tools::SaveMemory do
-    let(:tool) { described_class.new }
+    let(:tool) { described_class }
 
     before do
       allow(Legion::CLI::Chat::MemoryStore).to receive(:add).and_return('/tmp/.legion/memory.md')
@@ -19,44 +19,44 @@ RSpec.describe 'Chat Memory and Agent Tools' do
     end
 
     it 'saves to project memory by default' do
-      result = tool.execute(text: 'always use rspec')
+      result = tool.call(text: 'always use rspec')
       expect(result).to include('project memory')
       expect(Legion::CLI::Chat::MemoryStore).to have_received(:add).with('always use rspec', scope: :project)
     end
 
     it 'saves to global memory when scope is global' do
-      result = tool.execute(text: 'prefer vim', scope: 'global')
+      result = tool.call(text: 'prefer vim', scope: 'global')
       expect(result).to include('global memory')
       expect(Legion::CLI::Chat::MemoryStore).to have_received(:add).with('prefer vim', scope: :global)
     end
 
     it 'includes the file path in response' do
-      result = tool.execute(text: 'test')
+      result = tool.call(text: 'test')
       expect(result).to include('/tmp/.legion/memory.md')
     end
 
     it 'includes apollo confirmation when available' do
       allow(tool).to receive(:ingest_to_apollo).and_return('Also ingested into Apollo knowledge graph.')
-      result = tool.execute(text: 'important fact')
+      result = tool.call(text: 'important fact')
       expect(result).to include('project memory')
       expect(result).to include('Apollo knowledge graph')
     end
 
     it 'omits apollo when unavailable' do
-      result = tool.execute(text: 'test')
+      result = tool.call(text: 'test')
       expect(result).not_to include('Apollo')
     end
 
     it 'returns error message on failure' do
       allow(Legion::CLI::Chat::MemoryStore).to receive(:add).and_raise(Errno::EACCES, 'Permission denied')
-      result = tool.execute(text: 'test')
+      result = tool.call(text: 'test')
       expect(result).to include('Error saving memory')
       expect(result).to include('Permission denied')
     end
   end
 
   describe Legion::CLI::Chat::Tools::SearchMemory do
-    let(:tool) { described_class.new }
+    let(:tool) { described_class }
 
     before do
       allow(Legion::CLI::Chat::MemoryStore).to receive(:search).and_return([])
@@ -64,7 +64,7 @@ RSpec.describe 'Chat Memory and Agent Tools' do
     end
 
     it 'returns no-match message when empty' do
-      result = tool.execute(query: 'nonexistent')
+      result = tool.call(query: 'nonexistent')
       expect(result).to include('No matching memories')
     end
 
@@ -73,7 +73,7 @@ RSpec.describe 'Chat Memory and Agent Tools' do
                                                                              { text: 'always use rspec', source: '/project/.legion/memory.md', line: 3 },
                                                                              { text: 'prefer snake_case', source: '/project/.legion/memory.md', line: 5 }
                                                                            ])
-      result = tool.execute(query: 'use')
+      result = tool.call(query: 'use')
       expect(result).to include('Memory matches (2)')
       expect(result).to include('always use rspec')
       expect(result).to include('prefer snake_case')
@@ -83,7 +83,7 @@ RSpec.describe 'Chat Memory and Agent Tools' do
       allow(tool).to receive(:search_apollo).and_return([
                                                           { type: 'pattern', content: 'Use YJIT for performance', confidence: 0.95 }
                                                         ])
-      result = tool.execute(query: 'performance')
+      result = tool.call(query: 'performance')
       expect(result).to include('Apollo knowledge (1)')
       expect(result).to include('[pattern] Use YJIT for performance')
       expect(result).to include('confidence: 0.95')
@@ -96,7 +96,7 @@ RSpec.describe 'Chat Memory and Agent Tools' do
       allow(tool).to receive(:search_apollo).and_return([
                                                           { type: 'fact', content: 'RSpec is the standard test framework', confidence: 0.9 }
                                                         ])
-      result = tool.execute(query: 'rspec')
+      result = tool.call(query: 'rspec')
       expect(result).to include('Memory matches (1)')
       expect(result).to include('Apollo knowledge (1)')
     end
@@ -105,34 +105,34 @@ RSpec.describe 'Chat Memory and Agent Tools' do
       allow(Legion::CLI::Chat::MemoryStore).to receive(:search).and_return([
                                                                              { text: 'fact one', source: 'x', line: 1 }
                                                                            ])
-      result = tool.execute(query: 'fact')
+      result = tool.call(query: 'fact')
       expect(result).to include('fact one')
       expect(result).not_to include('Apollo')
     end
 
     it 'returns error message on failure' do
       allow(Legion::CLI::Chat::MemoryStore).to receive(:search).and_raise(StandardError, 'disk error')
-      result = tool.execute(query: 'test')
+      result = tool.call(query: 'test')
       expect(result).to include('Error searching memory')
       expect(result).to include('disk error')
     end
   end
 
   describe Legion::CLI::Chat::Tools::SpawnAgent do
-    let(:tool) { described_class.new }
+    let(:tool) { described_class }
 
     before do
       allow(Legion::CLI::Chat::Subagent).to receive(:spawn).and_return({ id: 'agent-001' })
     end
 
     it 'starts a subagent and returns confirmation' do
-      result = tool.execute(task: 'review the auth module')
+      result = tool.call(task: 'review the auth module')
       expect(result).to include('agent-001')
       expect(result).to include('review the auth module')
     end
 
     it 'passes task and model to Subagent.spawn' do
-      tool.execute(task: 'fix the bug', model: 'claude-sonnet')
+      tool.call(task: 'fix the bug', model: 'claude-sonnet')
       expect(Legion::CLI::Chat::Subagent).to have_received(:spawn).with(
         hash_including(task: 'fix the bug', model: 'claude-sonnet')
       )
@@ -140,21 +140,21 @@ RSpec.describe 'Chat Memory and Agent Tools' do
 
     it 'reports subagent errors' do
       allow(Legion::CLI::Chat::Subagent).to receive(:spawn).and_return({ error: 'concurrency limit reached' })
-      result = tool.execute(task: 'test')
+      result = tool.call(task: 'test')
       expect(result).to include('Subagent error')
       expect(result).to include('concurrency limit reached')
     end
 
     it 'returns error message on exception' do
       allow(Legion::CLI::Chat::Subagent).to receive(:spawn).and_raise(StandardError, 'spawn failed')
-      result = tool.execute(task: 'test')
+      result = tool.call(task: 'test')
       expect(result).to include('Error spawning subagent')
       expect(result).to include('spawn failed')
     end
   end
 
   describe Legion::CLI::Chat::Tools::WebSearch do
-    let(:tool) { described_class.new }
+    let(:tool) { described_class }
 
     let(:search_results) do
       {
@@ -172,14 +172,14 @@ RSpec.describe 'Chat Memory and Agent Tools' do
     end
 
     it 'returns formatted search results' do
-      result = tool.execute(query: 'ruby testing')
+      result = tool.call(query: 'ruby testing')
       expect(result).to include('RSpec Guide')
       expect(result).to include('https://rspec.info')
       expect(result).to include('Behaviour driven development')
     end
 
     it 'includes fetched content from top result' do
-      result = tool.execute(query: 'ruby testing')
+      result = tool.call(query: 'ruby testing')
       expect(result).to include('Top Result Content')
       expect(result).to include('Full page content from RSpec Guide')
     end
@@ -188,12 +188,12 @@ RSpec.describe 'Chat Memory and Agent Tools' do
       allow(Legion::CLI::Chat::WebSearch).to receive(:search).and_return(
         search_results.merge(fetched_content: nil)
       )
-      result = tool.execute(query: 'ruby testing')
+      result = tool.call(query: 'ruby testing')
       expect(result).not_to include('Top Result Content')
     end
 
     it 'passes max_results to search' do
-      tool.execute(query: 'test', max_results: 3)
+      tool.call(query: 'test', max_results: 3)
       expect(Legion::CLI::Chat::WebSearch).to have_received(:search).with('test', max_results: 3)
     end
 
@@ -201,14 +201,14 @@ RSpec.describe 'Chat Memory and Agent Tools' do
       allow(Legion::CLI::Chat::WebSearch).to receive(:search).and_raise(
         Legion::CLI::Chat::WebSearch::SearchError, 'No results found.'
       )
-      result = tool.execute(query: 'xyznonexistent')
+      result = tool.call(query: 'xyznonexistent')
       expect(result).to include('Search error')
       expect(result).to include('No results found')
     end
 
     it 'returns generic error message on unexpected failure' do
       allow(Legion::CLI::Chat::WebSearch).to receive(:search).and_raise(StandardError, 'network timeout')
-      result = tool.execute(query: 'test')
+      result = tool.call(query: 'test')
       expect(result).to include('Error:')
       expect(result).to include('network timeout')
     end

--- a/spec/legion/cli/chat/tools/memory_status_spec.rb
+++ b/spec/legion/cli/chat/tools/memory_status_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'ruby_llm'
 require 'legion/cli/chat/tools/memory_status'
 
 RSpec.describe Legion::CLI::Chat::Tools::MemoryStatus do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   before do
     allow(tool).to receive(:api_port).and_return(4567)
@@ -18,7 +17,7 @@ RSpec.describe Legion::CLI::Chat::Tools::MemoryStatus do
         allow(tool).to receive(:session_list).and_return([{ name: 'session1' }])
         allow(tool).to receive(:apollo_stats).and_return(nil)
 
-        result = tool.execute
+        result = tool.call
         expect(result).to include('Memory & Knowledge Overview')
         expect(result).to include('2 project, 1 global')
         expect(result).to include('Saved Sessions: 1')
@@ -31,7 +30,7 @@ RSpec.describe Legion::CLI::Chat::Tools::MemoryStatus do
           { total: 500, confirmed: 400, disputed: 5, candidates: 95 }
         )
 
-        result = tool.execute
+        result = tool.call
         expect(result).to include('500 entries')
         expect(result).to include('400 confirmed')
         expect(result).to include('5 disputed')
@@ -44,7 +43,7 @@ RSpec.describe Legion::CLI::Chat::Tools::MemoryStatus do
           "Persistent Memory Detail:\n\n  Project Memory:\n    1. use bun for install\n    2. prefer postgres\n\n  Global Memory:\n    1. timezone: CT"
         )
 
-        result = tool.execute(action: 'memories')
+        result = tool.call(action: 'memories')
         expect(result).to include('use bun for install')
         expect(result).to include('prefer postgres')
         expect(result).to include('timezone: CT')
@@ -59,7 +58,7 @@ RSpec.describe Legion::CLI::Chat::Tools::MemoryStatus do
             domains: { 'infrastructure' => 120, 'security' => 80 } }
         )
 
-        result = tool.execute(action: 'apollo')
+        result = tool.call(action: 'apollo')
         expect(result).to include('Total Entries:  300')
         expect(result).to include('Avg Confidence: 0.87')
         expect(result).to include('infrastructure')
@@ -68,7 +67,7 @@ RSpec.describe Legion::CLI::Chat::Tools::MemoryStatus do
       it 'handles apollo unavailable' do
         allow(tool).to receive(:apollo_stats).and_return(nil)
 
-        result = tool.execute(action: 'apollo')
+        result = tool.call(action: 'apollo')
         expect(result).to include('not available')
       end
     end
@@ -84,7 +83,7 @@ RSpec.describe Legion::CLI::Chat::Tools::MemoryStatus do
         ].join("\n")
         allow(tool).to receive(:format_sessions).and_return(session_output)
 
-        result = tool.execute(action: 'sessions')
+        result = tool.call(action: 'sessions')
         expect(result).to include('debug-cache')
         expect(result).to include('feature-auth')
         expect(result).to include('Debugging cache')
@@ -93,7 +92,7 @@ RSpec.describe Legion::CLI::Chat::Tools::MemoryStatus do
       it 'handles no sessions' do
         allow(tool).to receive(:format_sessions).and_return('No saved sessions found.')
 
-        result = tool.execute(action: 'sessions')
+        result = tool.call(action: 'sessions')
         expect(result).to include('No saved sessions')
       end
     end

--- a/spec/legion/cli/chat/tools/model_comparison_spec.rb
+++ b/spec/legion/cli/chat/tools/model_comparison_spec.rb
@@ -1,39 +1,38 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'ruby_llm'
 require 'legion/cli/chat/tools/model_comparison'
 
 RSpec.describe Legion::CLI::Chat::Tools::ModelComparison do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   describe '#execute' do
     it 'returns comparison table for all models' do
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Model Comparison')
       expect(result).to include('gpt-4o-mini')
       expect(result).to include('claude-sonnet-4-6')
     end
 
     it 'filters by model name substring' do
-      result = tool.execute(models: 'claude')
+      result = tool.call(models: 'claude')
       expect(result).to include('claude-sonnet-4-6')
       expect(result).not_to include('gpt-4o-mini')
     end
 
     it 'returns no matching message for unknown model' do
-      result = tool.execute(models: 'nonexistent-model-xyz')
+      result = tool.call(models: 'nonexistent-model-xyz')
       expect(result).to eq('No matching models found.')
     end
 
     it 'includes cost estimate' do
-      result = tool.execute(tokens: 5000)
+      result = tool.call(tokens: 5000)
       expect(result).to include('5000 input')
       expect(result).to include('Est. Cost')
     end
 
     it 'shows price ratio when multiple models compared' do
-      result = tool.execute
+      result = tool.call
       expect(result).to include('more expensive than')
     end
 
@@ -42,7 +41,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ModelComparison do
       tracker.const_set(:DEFAULT_PRICING, { 'test-model' => { input: 1.0, output: 2.0 } }.freeze)
       stub_const('Legion::LLM::CostTracker', tracker)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('test-model')
     end
   end

--- a/spec/legion/cli/chat/tools/provider_health_spec.rb
+++ b/spec/legion/cli/chat/tools/provider_health_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/provider_health'
 
 RSpec.describe Legion::CLI::Chat::Tools::ProviderHealth do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   describe '#execute' do
     context 'when native provider inventory is loaded' do
@@ -38,7 +38,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ProviderHealth do
       end
 
       it 'returns health report from inventory' do
-        result = tool.execute
+        result = tool.call
         expect(result).to include('Provider Health Report')
         expect(result).to include('anthropic')
         expect(result).to include('openai')
@@ -47,19 +47,19 @@ RSpec.describe Legion::CLI::Chat::Tools::ProviderHealth do
       end
 
       it 'returns detail for a specific native provider' do
-        result = tool.execute(provider: 'anthropic')
+        result = tool.call(provider: 'anthropic')
         expect(result).to include('Provider: anthropic')
         expect(result).to include('Healthy:    YES')
       end
 
       it 'returns not found for unknown native providers' do
-        result = tool.execute(provider: 'bedrock')
+        result = tool.call(provider: 'bedrock')
         expect(result).to eq('Provider not found: bedrock')
       end
     end
 
     it 'returns error when provider inventory is not available' do
-      result = tool.execute
+      result = tool.call
       expect(result).to eq('LLM provider inventory not available.')
     end
 
@@ -71,7 +71,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ProviderHealth do
       end
       stub_const('Legion::Extensions::Llm::Gateway::Runners::ProviderStats', stats_mod)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to eq('LLM provider inventory not available.')
     end
   end

--- a/spec/legion/cli/chat/tools/query_knowledge_spec.rb
+++ b/spec/legion/cli/chat/tools/query_knowledge_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/query_knowledge'
 
 RSpec.describe Legion::CLI::Chat::Tools::QueryKnowledge do
-  let(:tool) { described_class.new }
+  let(:tool) { described_class }
   let(:mock_http) { instance_double(Net::HTTP) }
 
   let(:query_response_body) do
@@ -42,27 +42,27 @@ RSpec.describe Legion::CLI::Chat::Tools::QueryKnowledge do
       end
 
       it 'returns formatted entries' do
-        result = tool.execute(query: 'how does legion communicate')
+        result = tool.call(query: 'how does legion communicate')
         expect(result).to include('Found 2 knowledge entries')
       end
 
       it 'includes content type' do
-        result = tool.execute(query: 'messaging')
+        result = tool.call(query: 'messaging')
         expect(result).to include('[fact]')
       end
 
       it 'includes confidence score' do
-        result = tool.execute(query: 'messaging')
+        result = tool.call(query: 'messaging')
         expect(result).to include('confidence: 0.95')
       end
 
       it 'includes content text' do
-        result = tool.execute(query: 'amqp')
+        result = tool.call(query: 'amqp')
         expect(result).to include('Legion uses AMQP')
       end
 
       it 'includes tags' do
-        result = tool.execute(query: 'amqp')
+        result = tool.call(query: 'amqp')
         expect(result).to include('architecture')
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe Legion::CLI::Chat::Tools::QueryKnowledge do
       end
 
       it 'returns no results message' do
-        result = tool.execute(query: 'nonexistent topic')
+        result = tool.call(query: 'nonexistent topic')
         expect(result).to include('No knowledge entries found')
       end
     end
@@ -86,7 +86,7 @@ RSpec.describe Legion::CLI::Chat::Tools::QueryKnowledge do
       end
 
       it 'returns error message' do
-        result = tool.execute(query: 'anything')
+        result = tool.call(query: 'anything')
         expect(result).to include('apollo not available')
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe Legion::CLI::Chat::Tools::QueryKnowledge do
       end
 
       it 'returns error message' do
-        result = tool.execute(query: 'test')
+        result = tool.call(query: 'test')
         expect(result).to include('Error querying knowledge graph')
       end
     end
@@ -114,7 +114,7 @@ RSpec.describe Legion::CLI::Chat::Tools::QueryKnowledge do
       end
 
       it 'passes domain to API' do
-        tool.execute(query: 'test', domain: 'architecture')
+        tool.call(query: 'test', domain: 'architecture')
       end
     end
 
@@ -130,7 +130,7 @@ RSpec.describe Legion::CLI::Chat::Tools::QueryKnowledge do
       end
 
       it 'passes limit to API' do
-        tool.execute(query: 'test', limit: 5)
+        tool.call(query: 'test', limit: 5)
       end
     end
 
@@ -142,7 +142,7 @@ RSpec.describe Legion::CLI::Chat::Tools::QueryKnowledge do
         response
       end
 
-      tool.execute(query: 'test', limit: 999)
+      tool.call(query: 'test', limit: 999)
     end
   end
 end

--- a/spec/legion/cli/chat/tools/reflect_spec.rb
+++ b/spec/legion/cli/chat/tools/reflect_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/reflect'
 
 RSpec.describe Legion::CLI::Chat::Tools::Reflect do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:stub_http) { instance_double(Net::HTTP) }
   let(:success_response) { instance_double(Net::HTTPSuccess, is_a?: true) }
@@ -28,7 +28,7 @@ RSpec.describe Legion::CLI::Chat::Tools::Reflect do
       end
 
       it 'ingests the raw text as a single entry' do
-        result = tool.execute(text: 'Ruby blocks capture their enclosing scope')
+        result = tool.call(text: 'Ruby blocks capture their enclosing scope')
         expect(result).to include('Reflected on 1 knowledge entries')
         expect(result).to include('Ruby blocks capture their enclosing scope')
       end
@@ -62,14 +62,14 @@ RSpec.describe Legion::CLI::Chat::Tools::Reflect do
       end
 
       it 'extracts and ingests multiple entries' do
-        result = tool.execute(text: 'We used **opts pattern and snake_case conventions')
+        result = tool.call(text: 'We used **opts pattern and snake_case conventions')
         expect(result).to include('Reflected on 2 knowledge entries')
         expect(result).to include('Pattern: use **opts for extensible params')
         expect(result).to include('Convention: snake_case for methods')
       end
 
       it 'reports save counts' do
-        result = tool.execute(text: 'We used **opts pattern')
+        result = tool.call(text: 'We used **opts pattern')
         expect(result).to include('Saved: 2 to Apollo, 2 to memory')
       end
     end
@@ -85,7 +85,7 @@ RSpec.describe Legion::CLI::Chat::Tools::Reflect do
       end
 
       it 'saves to memory only' do
-        result = tool.execute(text: 'Important finding')
+        result = tool.call(text: 'Important finding')
         expect(result).to include('0 to Apollo')
         expect(result).to include('1 to memory')
       end
@@ -109,7 +109,7 @@ RSpec.describe Legion::CLI::Chat::Tools::Reflect do
       end
 
       it 'returns no actionable knowledge message' do
-        result = tool.execute(text: 'Just chatting about nothing')
+        result = tool.call(text: 'Just chatting about nothing')
         expect(result).to include('No actionable knowledge')
       end
     end
@@ -126,7 +126,7 @@ RSpec.describe Legion::CLI::Chat::Tools::Reflect do
       end
 
       it 'passes domain to apollo ingest' do
-        tool.execute(text: 'Database indexes speed up queries', domain: 'database')
+        tool.call(text: 'Database indexes speed up queries', domain: 'database')
         expect(stub_http).to have_received(:request).with(
           an_object_having_attributes(body: a_string_including('"knowledge_domain":"database"'))
         )

--- a/spec/legion/cli/chat/tools/relate_knowledge_spec.rb
+++ b/spec/legion/cli/chat/tools/relate_knowledge_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/relate_knowledge'
 
 RSpec.describe Legion::CLI::Chat::Tools::RelateKnowledge do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:mock_http) { instance_double(Net::HTTP) }
 
@@ -29,7 +29,7 @@ RSpec.describe Legion::CLI::Chat::Tools::RelateKnowledge do
       )
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute(entry_id: 42)
+      result = tool.call(entry_id: 42)
       expect(result).to include('Related entries for #42')
       expect(result).to include('[supports]')
       expect(result).to include('AMQP uses RabbitMQ')
@@ -41,7 +41,7 @@ RSpec.describe Legion::CLI::Chat::Tools::RelateKnowledge do
       allow(response).to receive(:body).and_return(JSON.generate({ data: { entries: [] } }))
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute(entry_id: 99)
+      result = tool.call(entry_id: 99)
       expect(result).to include('No related entries found')
     end
 
@@ -50,14 +50,14 @@ RSpec.describe Legion::CLI::Chat::Tools::RelateKnowledge do
       allow(response).to receive(:body).and_return(JSON.generate({ data: { error: 'not found' } }))
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute(entry_id: 1)
+      result = tool.call(entry_id: 1)
       expect(result).to include('Apollo error: not found')
     end
 
     it 'handles connection refused' do
       allow(Net::HTTP).to receive(:new).and_raise(Errno::ECONNREFUSED)
 
-      result = tool.execute(entry_id: 1)
+      result = tool.call(entry_id: 1)
       expect(result).to include('Apollo unavailable')
     end
 
@@ -69,7 +69,7 @@ RSpec.describe Legion::CLI::Chat::Tools::RelateKnowledge do
         response
       end
 
-      tool.execute(entry_id: 1, depth: 10)
+      tool.call(entry_id: 1, depth: 10)
     end
 
     it 'passes relation_types as query param' do
@@ -80,7 +80,7 @@ RSpec.describe Legion::CLI::Chat::Tools::RelateKnowledge do
         response
       end
 
-      tool.execute(entry_id: 1, relation_types: 'supports,contradicts')
+      tool.call(entry_id: 1, relation_types: 'supports,contradicts')
     end
 
     it 'includes depth in output header' do
@@ -90,7 +90,7 @@ RSpec.describe Legion::CLI::Chat::Tools::RelateKnowledge do
       )
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute(entry_id: 5, depth: 3)
+      result = tool.call(entry_id: 5, depth: 3)
       expect(result).to include('depth: 3')
     end
   end

--- a/spec/legion/cli/chat/tools/run_command_spec.rb
+++ b/spec/legion/cli/chat/tools/run_command_spec.rb
@@ -4,32 +4,35 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/run_command'
 
 RSpec.describe Legion::CLI::Chat::Tools::RunCommand do
-  let(:tool) { described_class.new }
+  before { Legion::CLI::Chat::Permissions.mode = :headless if defined?(Legion::CLI::Chat::Permissions) }
+  after { Legion::CLI::Chat::Permissions.mode = :interactive if defined?(Legion::CLI::Chat::Permissions) }
+
+  let(:tool) { described_class }
 
   it 'executes a shell command and returns output' do
-    result = tool.execute(command: 'echo hello')
+    result = tool.call(command: 'echo hello')
     expect(result).to include('hello')
   end
 
   it 'returns exit code' do
-    result = tool.execute(command: 'echo hello')
+    result = tool.call(command: 'echo hello')
     expect(result).to include('exit code: 0')
   end
 
   it 'returns stderr on failure' do
-    result = tool.execute(command: 'ls /nonexistent_path_12345')
+    result = tool.call(command: 'ls /nonexistent_path_12345')
     expect(result).to include('exit code')
   end
 
   it 'respects timeout' do
-    result = tool.execute(command: 'sleep 10', timeout: 1)
+    result = tool.call(command: 'sleep 10', timeout: 1)
     expect(result).to include('timed out')
   end
 
   describe 'sandbox routing' do
     it 'defaults to direct execution when sandboxed_commands not enabled' do
       allow(Legion::Settings).to receive(:dig).with(:chat, :sandboxed_commands, :enabled).and_return(nil)
-      result = tool.execute(command: 'echo sandbox-test')
+      result = tool.call(command: 'echo sandbox-test')
       expect(result).to include('sandbox-test')
       expect(result).to include('exit code: 0')
     end
@@ -43,7 +46,7 @@ RSpec.describe Legion::CLI::Chat::Tools::RunCommand do
         end
       end)
 
-      result = tool.execute(command: 'echo hello')
+      result = tool.call(command: 'echo hello')
       expect(result).to include('sandboxed: echo hello')
     end
 
@@ -56,7 +59,7 @@ RSpec.describe Legion::CLI::Chat::Tools::RunCommand do
         end
       end)
 
-      result = tool.execute(command: 'rm -rf /')
+      result = tool.call(command: 'rm -rf /')
       expect(result).to include('blocked by sandbox')
       expect(result).to include('rm not in allowlist')
     end
@@ -65,7 +68,7 @@ RSpec.describe Legion::CLI::Chat::Tools::RunCommand do
       allow(Legion::Settings).to receive(:dig).with(:chat, :sandboxed_commands, :enabled).and_return(true)
       hide_const('Legion::Extensions::Exec::Runners::Shell') if defined?(Legion::Extensions::Exec::Runners::Shell)
 
-      result = tool.execute(command: 'echo fallback')
+      result = tool.call(command: 'echo fallback')
       expect(result).to include('fallback')
       expect(result).to include('exit code: 0')
     end

--- a/spec/legion/cli/chat/tools/scheduling_status_spec.rb
+++ b/spec/legion/cli/chat/tools/scheduling_status_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'ruby_llm'
 require 'legion/cli/chat/tools/scheduling_status'
 
 RSpec.describe Legion::CLI::Chat::Tools::SchedulingStatus do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:scheduling_mod) do
     Module.new do
@@ -44,14 +43,14 @@ RSpec.describe Legion::CLI::Chat::Tools::SchedulingStatus do
 
   describe '#execute' do
     it 'returns overview by default' do
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Scheduling & Batch Overview')
       expect(result).to include('peak now')
       expect(result).to include('Queue Depth: 5')
     end
 
     it 'shows scheduling detail' do
-      result = tool.execute(action: 'scheduling')
+      result = tool.call(action: 'scheduling')
       expect(result).to include('Scheduling Detail')
       expect(result).to include('14..22')
       expect(result).to include('Max Defer Hours:  8')
@@ -59,7 +58,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SchedulingStatus do
     end
 
     it 'shows batch detail' do
-      result = tool.execute(action: 'batch')
+      result = tool.call(action: 'batch')
       expect(result).to include('Batch Queue Detail')
       expect(result).to include('Queue Size:     5')
       expect(result).to include('normal')
@@ -68,13 +67,13 @@ RSpec.describe Legion::CLI::Chat::Tools::SchedulingStatus do
 
     it 'handles missing scheduling module' do
       hide_const('Legion::LLM::Scheduling')
-      result = tool.execute(action: 'scheduling')
+      result = tool.call(action: 'scheduling')
       expect(result).to eq('Scheduling module not available.')
     end
 
     it 'handles missing batch module' do
       hide_const('Legion::LLM::Batch')
-      result = tool.execute(action: 'batch')
+      result = tool.call(action: 'batch')
       expect(result).to eq('Batch module not available.')
     end
   end

--- a/spec/legion/cli/chat/tools/search_traces_spec.rb
+++ b/spec/legion/cli/chat/tools/search_traces_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/search_traces'
 
 RSpec.describe Legion::CLI::Chat::Tools::SearchTraces do
-  let(:tool) { described_class.new }
+  let(:tool) { described_class }
 
   let(:now) { Time.now.utc }
 
@@ -79,72 +79,72 @@ RSpec.describe Legion::CLI::Chat::Tools::SearchTraces do
 
   describe '#execute' do
     it 'returns results matching a keyword query' do
-      result = tool.execute(query: 'deployment timeline')
+      result = tool.call(query: 'deployment timeline')
       expect(result).to include('deployment')
       expect(result).to include('Bob Smith')
     end
 
     it 'filters by person name' do
-      result = tool.execute(query: 'deployment', person: 'Bob Smith')
+      result = tool.call(query: 'deployment', person: 'Bob Smith')
       expect(result).to include('Bob Smith')
     end
 
     it 'filters by domain tag' do
-      result = tool.execute(query: 'sprint', domain: 'meeting')
+      result = tool.call(query: 'sprint', domain: 'meeting')
       expect(result).to include('Sprint Planning')
     end
 
     it 'filters by trace type' do
-      result = tool.execute(query: 'SRE', trace_type: 'semantic')
+      result = tool.call(query: 'SRE', trace_type: 'semantic')
       expect(result).to include('Alice Johnson')
     end
 
     it 'returns no-match message when query has zero keyword hits' do
-      result = tool.execute(query: 'xyznonexistent')
+      result = tool.call(query: 'xyznonexistent')
       expect(result).to include('No traces matched')
     end
 
     it 'returns unavailable message when trace store is not loaded' do
       allow(Legion::Extensions::Agentic::Memory::Trace).to receive(:respond_to?).with(:shared_store).and_return(false)
-      result = tool.execute(query: 'test')
+      result = tool.call(query: 'test')
       expect(result).to include('not available')
     end
 
     it 'attempts to require the gem when constant is not defined' do
       hide_const('Legion::Extensions::Agentic::Memory::Trace')
       allow(tool).to receive(:load_trace_gem)
-      tool.execute(query: 'test')
+      tool.call(query: 'test')
       expect(tool).to have_received(:load_trace_gem)
     end
 
     it 'respects limit parameter' do
-      result = tool.execute(query: 'Bob Alice Grid Sprint', limit: 1)
+      result = tool.call(query: 'Bob Alice Grid Sprint', limit: 1)
       expect(result).to include('Found 1 matching')
     end
 
     it 'clamps limit to valid range' do
-      result = tool.execute(query: 'teams', limit: 100)
+      result = tool.call(query: 'teams', limit: 100)
       expect(result).not_to include('Found 100')
     end
 
     it 'displays trace metadata' do
-      result = tool.execute(query: 'deployment')
+      result = tool.call(query: 'deployment')
       expect(result).to include('tags:')
       expect(result).to include('strength:')
     end
 
     it 'formats age for recent traces' do
-      result = tool.execute(query: 'Grid Infrastructure')
+      result = tool.call(query: 'Grid Infrastructure')
       expect(result).to include('m ago')
     end
 
     it 'formats age for hour-old traces' do
-      result = tool.execute(query: 'deployment')
+      result = tool.call(query: 'deployment')
       expect(result).to include('h ago')
     end
 
     it 'formats age for day-old traces' do
-      result = tool.execute(query: 'Sprint Planning')
+      result = tool.call(query: 'Sprint Planning')
       expect(result).to include('d ago')
     end
   end
@@ -158,7 +158,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SearchTraces do
         associated_traces: []
       }
       all_traces.push(plain_trace)
-      result = tool.execute(query: 'servers')
+      result = tool.call(query: 'servers')
       expect(result).to include('servers')
     end
 
@@ -170,7 +170,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SearchTraces do
         associated_traces: []
       }
       all_traces.push(hash_trace)
-      result = tool.execute(query: 'Carol Engineer')
+      result = tool.call(query: 'Carol Engineer')
       expect(result).to include('Carol')
     end
   end

--- a/spec/legion/cli/chat/tools/shadow_eval_status_spec.rb
+++ b/spec/legion/cli/chat/tools/shadow_eval_status_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'ruby_llm'
 require 'legion/cli/chat/tools/shadow_eval_status'
 
 RSpec.describe Legion::CLI::Chat::Tools::ShadowEvalStatus do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:shadow_mod) do
     Module.new do
@@ -35,14 +34,14 @@ RSpec.describe Legion::CLI::Chat::Tools::ShadowEvalStatus do
 
   describe '#execute' do
     it 'returns summary by default' do
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Shadow Evaluation Summary')
       expect(result).to include('Evaluations:      3')
       expect(result).to include('65.0%')
     end
 
     it 'returns history when requested' do
-      result = tool.execute(action: 'history')
+      result = tool.call(action: 'history')
       expect(result).to include('Shadow Evaluation History')
       expect(result).to include('gpt-4o')
       expect(result).to include('gpt-4o-mini')
@@ -50,7 +49,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ShadowEvalStatus do
 
     it 'returns unavailable when module not defined' do
       hide_const('Legion::LLM::ShadowEval')
-      result = tool.execute
+      result = tool.call
       expect(result).to eq('Shadow evaluation not available.')
     end
 
@@ -64,7 +63,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ShadowEvalStatus do
         end
       end
       stub_const('Legion::LLM::ShadowEval', empty_mod)
-      result = tool.execute
+      result = tool.call
       expect(result).to include('llm.shadow.enabled')
     end
   end

--- a/spec/legion/cli/chat/tools/summarize_traces_spec.rb
+++ b/spec/legion/cli/chat/tools/summarize_traces_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/summarize_traces'
 
 RSpec.describe Legion::CLI::Chat::Tools::SummarizeTraces do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   describe '#execute' do
     before do
@@ -26,7 +26,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SummarizeTraces do
                                                                      top_workers:      [{ id: 'worker-1', count: 60 }]
                                                                    })
 
-      result = tool.execute(query: 'all tasks today')
+      result = tool.call(query: 'all tasks today')
       expect(result).to include('150 records')
       expect(result).to include('45000 in / 12000 out')
       expect(result).to include('$3.4567')
@@ -39,7 +39,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SummarizeTraces do
     it 'returns error when filter generation fails' do
       allow(Legion::TraceSearch).to receive(:summarize).and_return({ error: 'no filter generated' })
 
-      result = tool.execute(query: 'gibberish')
+      result = tool.call(query: 'gibberish')
       expect(result).to include('Error: no filter generated')
     end
 
@@ -57,7 +57,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SummarizeTraces do
                                                                      top_workers:      []
                                                                    })
 
-      result = tool.execute(query: 'empty query')
+      result = tool.call(query: 'empty query')
       expect(result).to include('0 records')
       expect(result).not_to include('Time range')
       expect(result).not_to include('Status')
@@ -68,14 +68,14 @@ RSpec.describe Legion::CLI::Chat::Tools::SummarizeTraces do
       hide_const('Legion::TraceSearch')
       allow(tool).to receive(:require).with('legion/trace_search').and_raise(LoadError)
 
-      result = tool.execute(query: 'test')
+      result = tool.call(query: 'test')
       expect(result).to include('Trace search unavailable')
     end
 
     it 'handles unexpected errors' do
       allow(Legion::TraceSearch).to receive(:summarize).and_raise(StandardError, 'db timeout')
 
-      result = tool.execute(query: 'test')
+      result = tool.call(query: 'test')
       expect(result).to include('Error summarizing traces: db timeout')
     end
   end

--- a/spec/legion/cli/chat/tools/system_status_spec.rb
+++ b/spec/legion/cli/chat/tools/system_status_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/system_status'
 
 RSpec.describe Legion::CLI::Chat::Tools::SystemStatus do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:mock_http) { instance_double(Net::HTTP) }
 
@@ -50,7 +50,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SystemStatus do
         call_count == 1 ? health_response : ready_response
       end
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Legion System Status')
       expect(result).to include('Status: ok')
       expect(result).to include('Version: 1.4.150')
@@ -66,14 +66,14 @@ RSpec.describe Legion::CLI::Chat::Tools::SystemStatus do
     it 'handles daemon not running' do
       allow(Net::HTTP).to receive(:new).and_raise(Errno::ECONNREFUSED)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('daemon not running')
     end
 
     it 'handles both endpoints failing gracefully' do
       allow(mock_http).to receive(:get).and_raise(StandardError.new('timeout'))
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Health endpoint: unreachable')
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SystemStatus do
         call_count == 1 ? health_response : ready_response
       end
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('1d 1h 1m')
     end
 
@@ -109,7 +109,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SystemStatus do
         call_count == 1 ? health_response : ready_response
       end
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('45s')
     end
 
@@ -127,7 +127,7 @@ RSpec.describe Legion::CLI::Chat::Tools::SystemStatus do
         call_count == 1 ? health_response : ready_response
       end
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Status: ok')
       expect(result).not_to include('Components:')
     end

--- a/spec/legion/cli/chat/tools/trigger_dream_spec.rb
+++ b/spec/legion/cli/chat/tools/trigger_dream_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/trigger_dream'
 
 RSpec.describe Legion::CLI::Chat::Tools::TriggerDream do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   before { allow(tool).to receive(:api_port).and_return(4567) }
 
@@ -13,7 +13,7 @@ RSpec.describe Legion::CLI::Chat::Tools::TriggerDream do
       it 'triggers dream cycle on daemon' do
         allow(tool).to receive(:api_post).and_return({ data: { task_id: 42 } })
 
-        result = tool.execute
+        result = tool.call
         expect(result).to include('Dream cycle triggered')
         expect(result).to include('Task ID: 42')
       end
@@ -21,7 +21,7 @@ RSpec.describe Legion::CLI::Chat::Tools::TriggerDream do
       it 'handles API error' do
         allow(tool).to receive(:api_post).and_return({ error: { message: 'runner not found' } })
 
-        result = tool.execute
+        result = tool.call
         expect(result).to include('Dream trigger failed')
         expect(result).to include('runner not found')
       end
@@ -29,7 +29,7 @@ RSpec.describe Legion::CLI::Chat::Tools::TriggerDream do
       it 'handles connection refused' do
         allow(tool).to receive(:api_post).and_raise(Errno::ECONNREFUSED)
 
-        result = tool.execute
+        result = tool.call
         expect(result).to include('Legion daemon not running')
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe Legion::CLI::Chat::Tools::TriggerDream do
         allow(tool).to receive(:find_latest_journal).and_return('/tmp/dream-test.md')
         allow(File).to receive(:read).with('/tmp/dream-test.md', encoding: 'utf-8').and_return(journal_content)
 
-        result = tool.execute(action: 'journal')
+        result = tool.call(action: 'journal')
         expect(result).to include('Dream Cycle')
         expect(result).to include('Memory Audit')
       end
@@ -48,7 +48,7 @@ RSpec.describe Legion::CLI::Chat::Tools::TriggerDream do
       it 'reports when no journal entries found' do
         allow(tool).to receive(:find_latest_journal).and_return(nil)
 
-        result = tool.execute(action: 'journal')
+        result = tool.call(action: 'journal')
         expect(result).to include('No dream journal entries found')
       end
 
@@ -57,7 +57,7 @@ RSpec.describe Legion::CLI::Chat::Tools::TriggerDream do
         allow(tool).to receive(:find_latest_journal).and_return('/tmp/dream-long.md')
         allow(File).to receive(:read).with('/tmp/dream-long.md', encoding: 'utf-8').and_return(long_content)
 
-        result = tool.execute(action: 'journal')
+        result = tool.call(action: 'journal')
         expect(result.length).to be <= 2000
         expect(result).to end_with('...')
       end

--- a/spec/legion/cli/chat/tools/view_events_spec.rb
+++ b/spec/legion/cli/chat/tools/view_events_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/view_events'
 
 RSpec.describe Legion::CLI::Chat::Tools::ViewEvents do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:mock_http) { instance_double(Net::HTTP) }
 
@@ -29,7 +29,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ViewEvents do
       )
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Recent Events (2)')
       expect(result).to include('runner.completed')
       expect(result).to include('extension: lex-node')
@@ -42,7 +42,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ViewEvents do
       allow(response).to receive(:body).and_return(JSON.generate({ data: [] }))
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('No recent events')
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ViewEvents do
         response
       end
 
-      tool.execute(count: 5)
+      tool.call(count: 5)
     end
 
     it 'clamps count to valid range' do
@@ -65,12 +65,12 @@ RSpec.describe Legion::CLI::Chat::Tools::ViewEvents do
         response
       end
 
-      tool.execute(count: 999)
+      tool.call(count: 999)
     end
 
     it 'handles connection refused' do
       allow(Net::HTTP).to receive(:new).and_raise(Errno::ECONNREFUSED)
-      result = tool.execute
+      result = tool.call
       expect(result).to include('daemon not running')
     end
 
@@ -79,7 +79,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ViewEvents do
       allow(response).to receive(:body).and_return(JSON.generate({ error: 'events unavailable' }))
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('API error: events unavailable')
     end
 
@@ -92,7 +92,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ViewEvents do
       )
       allow(mock_http).to receive(:get).and_return(response)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('service.ready')
       expect(result).not_to include('—')
     end

--- a/spec/legion/cli/chat/tools/view_trends_spec.rb
+++ b/spec/legion/cli/chat/tools/view_trends_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/view_trends'
 
 RSpec.describe Legion::CLI::Chat::Tools::ViewTrends do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   before { allow(tool).to receive(:api_port).and_return(4567) }
 
@@ -18,7 +18,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ViewTrends do
         hours: 4, bucket_minutes: 120
       )
 
-      result = tool.execute(hours: 4, buckets: 2)
+      result = tool.call(hours: 4, buckets: 2)
       expect(result).to include('Trend (last 4h')
       expect(result).to include('Count')
       expect(result).to include('Avg Cost')
@@ -34,7 +34,7 @@ RSpec.describe Legion::CLI::Chat::Tools::ViewTrends do
         hours: 24, bucket_minutes: 720
       )
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('rising')
     end
 
@@ -45,28 +45,28 @@ RSpec.describe Legion::CLI::Chat::Tools::ViewTrends do
         hours: 24, bucket_minutes: 720
       )
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('stable')
     end
 
     it 'handles empty trend data' do
       stub_trend(buckets: [], hours: 24, bucket_minutes: 120)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('No trend data available')
     end
 
     it 'handles connection refused' do
       allow(tool).to receive(:api_get).and_raise(Errno::ECONNREFUSED)
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('Legion daemon not running')
     end
 
     it 'handles API error response' do
       allow(tool).to receive(:api_get).and_return({ error: { message: 'LLM unavailable' } })
 
-      result = tool.execute
+      result = tool.call
       expect(result).to include('LLM unavailable')
     end
   end

--- a/spec/legion/cli/chat/tools/worker_status_spec.rb
+++ b/spec/legion/cli/chat/tools/worker_status_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'legion/cli/chat/tools/worker_status'
 
 RSpec.describe Legion::CLI::Chat::Tools::WorkerStatus do
-  subject(:tool) { described_class.new }
+  subject(:tool) { described_class }
 
   let(:stub_http) { instance_double(Net::HTTP) }
 
@@ -26,7 +26,7 @@ RSpec.describe Legion::CLI::Chat::Tools::WorkerStatus do
       end
 
       it 'returns formatted worker list' do
-        result = tool.execute
+        result = tool.call
         expect(result).to include('Digital Workers (1)')
         expect(result).to include('w-1')
         expect(result).to include('Sync Bot')
@@ -41,7 +41,7 @@ RSpec.describe Legion::CLI::Chat::Tools::WorkerStatus do
       end
 
       it 'returns no workers message' do
-        result = tool.execute
+        result = tool.call
         expect(result).to eq('No digital workers found.')
       end
     end
@@ -55,7 +55,7 @@ RSpec.describe Legion::CLI::Chat::Tools::WorkerStatus do
       end
 
       it 'passes the filter to the API' do
-        tool.execute(status_filter: 'paused')
+        tool.call(status_filter: 'paused')
         expect(stub_http).to have_received(:get).with('/api/workers?lifecycle_state=paused')
       end
     end
@@ -71,14 +71,14 @@ RSpec.describe Legion::CLI::Chat::Tools::WorkerStatus do
       end
 
       it 'returns worker details' do
-        result = tool.execute(action: 'show', worker_id: 'w-1')
+        result = tool.call(action: 'show', worker_id: 'w-1')
         expect(result).to include('Worker: w-1')
         expect(result).to include('name: Sync Bot')
         expect(result).to include('team: ops')
       end
 
       it 'requires worker_id' do
-        result = tool.execute(action: 'show')
+        result = tool.call(action: 'show')
         expect(result).to include('worker_id is required')
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe Legion::CLI::Chat::Tools::WorkerStatus do
       end
 
       it 'returns health summary' do
-        result = tool.execute(action: 'health')
+        result = tool.call(action: 'health')
         expect(result).to include('Worker Health Summary')
         expect(result).to include('Total:     3')
         expect(result).to include('Active:    2')
@@ -117,7 +117,7 @@ RSpec.describe Legion::CLI::Chat::Tools::WorkerStatus do
       end
 
       it 'returns daemon not running message' do
-        result = tool.execute
+        result = tool.call
         expect(result).to include('daemon not running')
       end
     end

--- a/spec/legion/identity/process_spec.rb
+++ b/spec/legion/identity/process_spec.rb
@@ -242,8 +242,17 @@ RSpec.describe Legion::Identity::Process do
       expect(hash[:metadata]).to eq({})
     end
 
-    it 'returns a Hash with exactly 14 keys' do
-      expect(hash.keys).to match_array(%i[id canonical_name kind source mode queue_prefix resolved persistent groups metadata trust aliases providers profile])
+    it 'returns a Hash with exactly 16 keys' do
+      expect(hash.keys).to match_array(%i[id canonical_name kind source mode queue_prefix resolved persistent groups metadata trust aliases providers profile
+                                          db_principal_id db_identity_id])
+    end
+
+    it 'has nil db_principal_id when not bound with db fields' do
+      expect(hash[:db_principal_id]).to be_nil
+    end
+
+    it 'has nil db_identity_id when not bound with db fields' do
+      expect(hash[:db_identity_id]).to be_nil
     end
 
     context 'when the provider exposes provider_name' do
@@ -259,6 +268,26 @@ RSpec.describe Legion::Identity::Process do
 
       it 'includes source from provider.provider_name' do
         expect(hash[:source]).to eq(:custom_provider)
+      end
+    end
+
+    context 'when bound with db integer PKs' do
+      before do
+        described_class.reset!
+        described_class.bind!(double('provider', provider_name: 'test'), {
+                                id:              fixed_uuid,
+                                canonical_name:  'hash-test',
+                                kind:            :machine,
+                                persistent:      true,
+                                db_principal_id: 42,
+                                db_identity_id:  99
+                              })
+      end
+
+      it 'includes db_principal_id and db_identity_id' do
+        h = described_class.identity_hash
+        expect(h[:db_principal_id]).to eq(42)
+        expect(h[:db_identity_id]).to eq(99)
       end
     end
 
@@ -350,6 +379,30 @@ RSpec.describe Legion::Identity::Process do
       it 'does not raise' do
         expect { described_class.refresh_credentials }.not_to raise_error
       end
+    end
+  end
+
+  describe '#db_principal_id' do
+    it 'returns nil before bind' do
+      expect(described_class.db_principal_id).to be_nil
+    end
+
+    it 'returns integer after bind with db_principal_id' do
+      described_class.bind!(double('provider', provider_name: 'test'),
+                            { canonical_name: 'alice', kind: :human, db_principal_id: 42, db_identity_id: 99 })
+      expect(described_class.db_principal_id).to eq(42)
+    end
+  end
+
+  describe '#db_identity_id' do
+    it 'returns nil before bind' do
+      expect(described_class.db_identity_id).to be_nil
+    end
+
+    it 'returns integer after bind with db_identity_id' do
+      described_class.bind!(double('provider', provider_name: 'test'),
+                            { canonical_name: 'alice', kind: :human, db_principal_id: 42, db_identity_id: 99 })
+      expect(described_class.db_identity_id).to eq(99)
     end
   end
 


### PR DESCRIPTION
## Summary
- Migrated all 40 CLI chat tool classes from `RubyLLM::Tool` to native `Legion::Tools::Base` interface
- Removed `gem 'ruby_llm'` from Gemfile — eliminates the dependency entirely
- Updated infrastructure: `tool_registry.rb`, `extension_tool_loader.rb`, `generate_command.rb`, `permissions.rb`

## Key Changes Per Tool
- `param :x, type:, desc:, required:` → `input_schema({ JSON Schema hash })`
- `def execute(**args)` → `def self.call(**args)`
- Explicit `tool_name 'legion.<snake_case>'` added
- Private instance helpers converted to class methods
- `Permissions::Gate` now prepends on singleton_class for class-method interception

## Test plan
- [x] 5173 specs pass, 0 failures
- [x] 0 RuboCop offenses
- [x] `bundle install` removes ruby_llm from lockfile
- [x] `generate_command.rb` template emits correct new interface
- [x] Permissions Gate correctly intercepts class-method `.call`
- [x] Extension tool loader discovers `Legion::Tools::Base` subclasses