### PR TITLE
Fix tool discovery, extension naming, and add /api/extensions/tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.9.34] - 2026-05-18
+
+### Added
+- API: `GET /api/extensions/tools` endpoint with extension, runner, deferred, and triggered filters
+- Tools::Discovery: writes to `Legion::Settings::Extensions.register_tool` (bridges discovery to LLM pipeline)
+
+### Fixed
+- Extensions: `extension_parts_from_const` no longer converts underscores to dashes (fixes lex-microsoft_teams filtering)
+- Core: `generate_runner_messages` strips `?` and `!` from method names before creating constants
+
 ## [1.9.33] - 2026-05-15
 
 ### Added

--- a/lib/legion/api/extensions.rb
+++ b/lib/legion/api/extensions.rb
@@ -6,6 +6,7 @@ module Legion
       module Extensions
         def self.registered(app)
           register_loaded_summary_route(app)
+          register_tools_route(app)
           register_available_route(app)
           register_extension_routes(app)
           register_runner_routes(app)
@@ -26,6 +27,41 @@ module Legion
             end
 
             json_response(items)
+          end
+        end
+
+        def self.register_tools_route(app)
+          app.get '/api/extensions/tools' do
+            entries = Array(Legion::Settings::Extensions.tools)
+
+            entries = entries.select { |e| e[:extension].to_s == params[:extension] } if params[:extension]
+            entries = entries.select { |e| e[:runner].to_s == params[:runner] } if params[:runner]
+            entries = entries.select { |e| e[:deferred] == (params[:deferred] == 'true') } if params.key?(:deferred)
+            entries = entries.select { |e| Array(e[:trigger_words]).any? } if params[:triggered] == 'true'
+
+            if params[:extension_filter]
+              mod_name = params[:extension_filter]
+              ext_mod = find_extension_module(mod_name.delete_prefix('lex-'))
+              if ext_mod
+                entries = entries.select { |e| e[:deferred] == false } if ext_mod.respond_to?(:mcp_tools_deferred?) && !ext_mod.mcp_tools_deferred?
+                entries = [] if ext_mod.respond_to?(:mcp_tools?) && !ext_mod.mcp_tools?
+              end
+            end
+
+            tools = entries.map do |e|
+              {
+                name:          e[:name],
+                description:   e[:description],
+                extension:     e[:extension],
+                runner:        e[:runner],
+                deferred:      e[:deferred],
+                trigger_words: e[:trigger_words],
+                source:        e[:source],
+                sticky:        e[:sticky]
+              }.compact
+            end
+
+            json_response({ total: tools.size, tools: tools })
           end
         end
 
@@ -205,8 +241,9 @@ module Legion
               started_at: entry[:started_at]&.iso8601 }
           end
 
-          private :register_loaded_summary_route, :register_available_route, :register_extension_routes,
-                  :register_runner_routes, :register_function_routes, :register_invoke_route
+          private :register_loaded_summary_route, :register_tools_route, :register_available_route,
+                  :register_extension_routes, :register_runner_routes, :register_function_routes,
+                  :register_invoke_route
         end
       end
     end

--- a/lib/legion/api/extensions.rb
+++ b/lib/legion/api/extensions.rb
@@ -32,35 +32,8 @@ module Legion
 
         def self.register_tools_route(app)
           app.get '/api/extensions/tools' do
-            entries = Array(Legion::Settings::Extensions.tools)
-
-            entries = entries.select { |e| e[:extension].to_s == params[:extension] } if params[:extension]
-            entries = entries.select { |e| e[:runner].to_s == params[:runner] } if params[:runner]
-            entries = entries.select { |e| e[:deferred] == (params[:deferred] == 'true') } if params.key?(:deferred)
-            entries = entries.select { |e| Array(e[:trigger_words]).any? } if params[:triggered] == 'true'
-
-            if params[:extension_filter]
-              mod_name = params[:extension_filter]
-              ext_mod = find_extension_module(mod_name.delete_prefix('lex-'))
-              if ext_mod
-                entries = entries.select { |e| e[:deferred] == false } if ext_mod.respond_to?(:mcp_tools_deferred?) && !ext_mod.mcp_tools_deferred?
-                entries = [] if ext_mod.respond_to?(:mcp_tools?) && !ext_mod.mcp_tools?
-              end
-            end
-
-            tools = entries.map do |e|
-              {
-                name:          e[:name],
-                description:   e[:description],
-                extension:     e[:extension],
-                runner:        e[:runner],
-                deferred:      e[:deferred],
-                trigger_words: e[:trigger_words],
-                source:        e[:source],
-                sticky:        e[:sticky]
-              }.compact
-            end
-
+            entries = filter_tool_entries(Array(Legion::Settings::Extensions.tools), params)
+            tools = entries.map { |e| serialize_tool_entry(e) }
             json_response({ total: tools.size, tools: tools })
           end
         end
@@ -239,6 +212,27 @@ module Legion
             { name: name, state: entry[:state].to_s,
               registered_at: entry[:registered_at]&.iso8601,
               started_at: entry[:started_at]&.iso8601 }
+          end
+
+          def filter_tool_entries(entries, params)
+            entries = entries.select { |e| e[:extension].to_s == params[:extension] } if params[:extension]
+            entries = entries.select { |e| e[:runner].to_s == params[:runner] } if params[:runner]
+            entries = entries.select { |e| e[:deferred] == (params[:deferred] == 'true') } if params.key?(:deferred)
+            entries = entries.select { |e| Array(e[:trigger_words]).any? } if params[:triggered] == 'true'
+            entries
+          end
+
+          def serialize_tool_entry(entry)
+            {
+              name:          entry[:name],
+              description:   entry[:description],
+              extension:     entry[:extension],
+              runner:        entry[:runner],
+              deferred:      entry[:deferred],
+              trigger_words: entry[:trigger_words],
+              source:        entry[:source],
+              sticky:        entry[:sticky]
+            }.compact
           end
 
           private :register_loaded_summary_route, :register_tools_route, :register_available_route,

--- a/lib/legion/extensions.rb
+++ b/lib/legion/extensions.rb
@@ -1061,7 +1061,7 @@ module Legion
         parts[(idx + 1)..].to_a.each_with_object([]) do |part, extension_parts|
           break extension_parts if %w[Actor Actors Runners Helpers Transport Data Hooks Skills].include?(part)
 
-          extension_parts << camel_to_snake(part).tr('_', '-')
+          extension_parts << camel_to_snake(part)
         end
       end
 

--- a/lib/legion/extensions/absorbers/base.rb
+++ b/lib/legion/extensions/absorbers/base.rb
@@ -198,7 +198,7 @@ module Legion
         end
 
         def build_chunk_payload(chunk, tags, opts)
-          {
+          payload = {
             content:      chunk[:content],
             content_type: opts[:content_type] || 'absorbed_chunk',
             content_hash: chunk[:content_hash],
@@ -211,6 +211,8 @@ module Legion
               token_count:  chunk[:token_count]
             }.merge(opts.fetch(:metadata, {}))
           }
+          payload[:access_scope] = opts[:access_scope] if opts.key?(:access_scope)
+          payload
         end
       end
     end

--- a/lib/legion/extensions/core.rb
+++ b/lib/legion/extensions/core.rb
@@ -174,7 +174,8 @@ module Legion
         return unless runner_module.respond_to?(:definitions)
 
         runner_module.definitions.each_key do |method_name|
-          const_name = "#{camelize(runner_name)}#{camelize(method_name)}"
+          sanitized = method_name.to_s.delete('?!')
+          const_name = "#{camelize(runner_name)}#{camelize(sanitized)}"
           next if ctx[:messages_mod].const_defined?(const_name, false)
 
           rk_value = "#{ctx[:prefix]}.runners.#{runner_name}.#{method_name}"

--- a/lib/legion/tools/discovery.rb
+++ b/lib/legion/tools/discovery.rb
@@ -125,6 +125,7 @@ module Legion
           )
           return unless Legion::Tools::Registry.register(tool_class)
 
+          register_in_settings_extensions(tool_class, ext, runner_mod, is_deferred)
           record_tool_owner(ext, tool_class)
         end
 
@@ -214,6 +215,28 @@ module Legion
               error_response(e.message)
             end
           end
+        end
+
+        def register_in_settings_extensions(tool_class, ext, runner_mod, is_deferred)
+          return unless defined?(Legion::Settings::Extensions) &&
+                        Legion::Settings::Extensions.respond_to?(:register_tool)
+
+          ext_name = derive_extension_name(ext)
+          Legion::Settings::Extensions.register_tool(tool_class.tool_name, {
+                                                       description:   tool_class.respond_to?(:description) ? tool_class.description : nil,
+                                                       input_schema:  tool_class.respond_to?(:input_schema) ? tool_class.input_schema : {},
+                                                       tool_class:    tool_class,
+                                                       dispatch_type: :class_call,
+                                                       extension:     "lex-#{ext_name}",
+                                                       runner:        derive_runner_snake(runner_mod),
+                                                       source:        :tools_discovery,
+                                                       deferred:      is_deferred,
+                                                       trigger_words: tool_class.respond_to?(:trigger_words) ? tool_class.trigger_words : [],
+                                                       sticky:        tool_class.respond_to?(:sticky?) ? tool_class.sticky? : true,
+                                                       mcp_tier:      tool_class.respond_to?(:mcp_tier) ? tool_class.mcp_tier : nil
+                                                     })
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :register_in_settings_extensions)
         end
 
         def record_tool_owner(ext, tool_class)

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.33'
+  VERSION = '1.9.34'
 end


### PR DESCRIPTION
## Summary
- `Tools::Discovery.register_function` now writes to `Legion::Settings::Extensions.register_tool` — this is the bridge that was severed when legion-mcp removed the `load_tools_from_legacy_registry` fallback. Without this, the LLM inference pipeline sees 0 extension tools.
- `extension_parts_from_const` no longer does `.tr('_', '-')` on snake_cased module names. This fixes `lex-microsoft_teams` (and `lex-home_assistant`, etc.) being converted to `lex-microsoft-teams` which failed the handle name comparison and filtered them out of `loaded_extension_modules`.
- `generate_runner_messages` now strips `?` and `!` from method names before creating constants (fixes `wrong constant name LocalCacheLocalCacheAvailable?`).
- New `GET /api/extensions/tools` endpoint returns all registered tools with optional `extension`, `runner`, `deferred`, and `triggered` query param filters.

## Test plan
- [ ] `bundle exec rspec spec/legion/tools/` passes (53 examples, 0 failures confirmed)
- [ ] After restart, `/api/extensions/tools?extension=lex-microsoft_teams` returns Teams tools
- [ ] `/api/extensions/tools` returns all 167+ discovered tools
- [ ] Extensions with underscores in gem name (lex-microsoft_teams, lex-home_assistant) appear in loaded_extension_modules