### PR TITLE
fix(cli): add legionio service command for macOS 26+ launchd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.9.36] - 2026-05-22
+
+### Fixed
+- Identity: preload identity provider gems and resolve process identity before LLM setup so `llm.registry` availability events include Legion identity headers.
+- Identity: use the persisted `identity.json` value as a cached resolver fallback ahead of unverified system identity when fresh auth providers are unavailable.
+
 ## [1.9.35] - 2026-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - Identity: preload identity provider gems and resolve process identity before LLM setup so `llm.registry` availability events include Legion identity headers.
 - Identity: use the persisted `identity.json` value as a cached resolver fallback ahead of unverified system identity when fresh auth providers are unavailable.
+- Bundler: load sibling Legion and LLM provider path dependencies outside the test group when those local checkouts exist, so local service boots can use the active workspace gems.
 
 ## [1.9.35] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.9.35] - 2026-05-22
+
+### Added
+- CLI: `legionio service start|stop|restart|status` subcommand for direct launchd control
+
+### Fixed
+- CLI: `legionio bootstrap --start` now calls `launchctl kickstart` after brew services start to force immediate spawn on macOS 26+ (Tahoe defers `RunAtLoad` for mid-session bootstraps)
+
 ## [1.9.34] - 2026-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - CLI: `legionio service start|stop|restart|status` subcommand for direct launchd control
+- Logging transport forwarding now publishes structured log headers/properties, including identity and Legion version headers supplied by `legion-logging`.
 
 ### Fixed
 - CLI: `legionio bootstrap --start` now calls `launchctl kickstart` after brew services start to force immediate spawn on macOS 26+ (Tahoe defers `RunAtLoad` for mid-session bootstraps)

--- a/Gemfile
+++ b/Gemfile
@@ -8,36 +8,39 @@ gem 'pg'
 gem 'kramdown', '>= 2.0'
 gem 'mysql2'
 
+gem 'legion-data', path: '../legion-data' if File.exist?(File.expand_path('../legion-data', __dir__))
+gem 'legion-logging', path: '../legion-logging' if File.exist?(File.expand_path('../legion-logging', __dir__))
+gem 'legion-settings', path: '../legion-settings' if File.exist?(File.expand_path('../legion-settings', __dir__))
+
+gem 'legion-apollo', path: '../legion-apollo' if File.exist?(File.expand_path('../legion-apollo', __dir__))
+gem 'legion-gaia', path: '../legion-gaia' if File.exist?(File.expand_path('../legion-gaia', __dir__))
+gem 'legion-llm', path: '../legion-llm' if File.exist?(File.expand_path('../legion-llm', __dir__))
+gem 'legion-mcp', path: '../legion-mcp' if File.exist?(File.expand_path('../legion-mcp', __dir__))
+gem 'legion-tty', path: '../legion-tty' if File.exist?(File.expand_path('../legion-tty', __dir__))
+
+gem 'lex-apollo', path: '../extensions/lex-apollo' if File.exist?(File.expand_path('../extensions/lex-apollo', __dir__))
+gem 'lex-llm', path: '../extensions-ai/lex-llm' if File.exist?(File.expand_path('../extensions-ai/lex-llm', __dir__))
+# gem 'lex-llm-ledger', path: '../extensions-ai/lex-llm-ledger' if File.exist?(File.expand_path('../extensions-ai/lex-llm-ledger', __dir__))
+
+if File.exist?(File.expand_path('../extensions-identity/lex-identity-entra', __dir__))
+  gem 'lex-identity-entra', path: '../extensions-identity/lex-identity-entra'
+end
+if File.exist?(File.expand_path('../extensions-identity/lex-identity-kerberos', __dir__))
+  gem 'lex-identity-kerberos', path: '../extensions-identity/lex-identity-kerberos'
+end
+
+gem 'lex-kerberos', path: '../extensions-identity/lex-kerberos' if File.exist?(File.expand_path('../extensions-identity/lex-kerberos', __dir__))
+
+if File.exist?(File.expand_path('../extensions-identity/lex-identity-system', __dir__))
+  gem 'lex-identity-system', path: '../extensions-identity/lex-identity-system'
+end
+
+%w[anthropic azure-foundry bedrock gemini mlx ollama openai vertex vllm].each do |provider|
+  provider_path = "../extensions-ai/lex-llm-#{provider}"
+  gem "lex-llm-#{provider}", path: provider_path if File.exist?(File.expand_path(provider_path, __dir__))
+end
+
 group :test do
-  gem 'legion-data', path: '../legion-data' if File.exist?(File.expand_path('../legion-data', __dir__))
-  gem 'legion-logging', path: '../legion-logging' if File.exist?(File.expand_path('../legion-logging', __dir__))
-  gem 'legion-settings', path: '../legion-settings' if File.exist?(File.expand_path('../legion-settings', __dir__))
-
-  gem 'legion-apollo', path: '../legion-apollo' if File.exist?(File.expand_path('../legion-apollo', __dir__))
-  gem 'legion-gaia', path: '../legion-gaia' if File.exist?(File.expand_path('../legion-gaia', __dir__))
-  gem 'legion-llm', path: '../legion-llm' if File.exist?(File.expand_path('../legion-llm', __dir__))
-  gem 'legion-mcp', path: '../legion-mcp' if File.exist?(File.expand_path('../legion-mcp', __dir__))
-  gem 'legion-tty', path: '../legion-tty' if File.exist?(File.expand_path('../legion-tty', __dir__))
-
-  gem 'lex-apollo', path: '../extensions/lex-apollo' if File.exist?(File.expand_path('../extensions/lex-apollo', __dir__))
-  gem 'lex-llm', path: '../extensions-ai/lex-llm' if File.exist?(File.expand_path('../extensions-ai/lex-llm', __dir__))
-  gem 'lex-llm-ledger', path: '../extensions-ai/lex-llm-ledger' if File.exist?(File.expand_path('../extensions-ai/lex-llm-ledger', __dir__))
-
-  if File.exist?(File.expand_path('../extensions-identity/lex-identity-entra', __dir__))
-    gem 'lex-identity-entra', path: '../extensions-identity/lex-identity-entra'
-  end
-  if File.exist?(File.expand_path('../extensions-identity/lex-identity-kerberos', __dir__))
-    gem 'lex-identity-kerberos', path: '../extensions-identity/lex-identity-kerberos'
-  end
-  if File.exist?(File.expand_path('../extensions-identity/lex-identity-system', __dir__))
-    gem 'lex-identity-system', path: '../extensions-identity/lex-identity-system'
-  end
-
-  %w[anthropic azure-foundry bedrock gemini mlx ollama openai vertex vllm].each do |provider|
-    provider_path = "../extensions-ai/lex-llm-#{provider}"
-    gem "lex-llm-#{provider}", path: provider_path if File.exist?(File.expand_path(provider_path, __dir__))
-  end
-
   gem 'faraday'
   gem 'faraday-net_http'
   gem 'graphql'

--- a/lib/legion/cli.rb
+++ b/lib/legion/cli.rb
@@ -69,6 +69,7 @@ module Legion
     autoload :Debug,        'legion/cli/debug_command'
     autoload :CodegenCommand, 'legion/cli/codegen_command'
     autoload :Bootstrap,      'legion/cli/bootstrap_command'
+    autoload :ServiceCommand, 'legion/cli/service_command'
     autoload :Broker,         'legion/cli/broker_command'
     autoload :AdminCommand,   'legion/cli/admin_command'
     autoload :Workflow,       'legion/cli/workflow_command'
@@ -257,6 +258,9 @@ module Legion
 
       desc 'setup SUBCOMMAND', 'Install feature packs and configure IDE integrations'
       subcommand 'setup', Legion::CLI::Setup
+
+      desc 'service SUBCOMMAND', 'Manage the Legion launchd background service'
+      subcommand 'service', Legion::CLI::ServiceCommand
 
       desc 'bootstrap SOURCE', 'One-command setup: fetch config, scaffold, and install packs'
       subcommand 'bootstrap', Legion::CLI::Bootstrap

--- a/lib/legion/cli/bootstrap_command.rb
+++ b/lib/legion/cli/bootstrap_command.rb
@@ -3,6 +3,7 @@
 require 'English'
 require 'json'
 require 'fileutils'
+require 'open3'
 require 'rbconfig'
 require 'thor'
 require 'legion/cli/output'
@@ -393,13 +394,23 @@ module Legion
           output, success = shell_capture("brew services start #{service}")
           if success
             out.success("#{service} started") unless options[:json]
-            true
           else
             out.warn("#{service} failed to start: #{output.strip.lines.last&.strip}") unless options[:json]
-            false
           end
+          kickstart_launchd_service("homebrew.mxcl.#{service}", out)
         rescue StandardError => e
           out.warn("brew services start #{service} raised: #{e.message}") unless options[:json]
+          false
+        end
+
+        def kickstart_launchd_service(label, out)
+          return true unless RbConfig::CONFIG['host_os'] =~ /darwin/
+
+          uid = ::Process.uid
+          _, status = Open3.capture2e('launchctl', 'kickstart', "gui/#{uid}/#{label}")
+          return true if status.success?
+
+          out.warn("launchctl kickstart #{label} failed (service may already be running)") unless options[:json]
           false
         end
 

--- a/lib/legion/cli/bootstrap_command.rb
+++ b/lib/legion/cli/bootstrap_command.rb
@@ -392,11 +392,12 @@ module Legion
 
         def run_brew_service(service, out)
           output, success = shell_capture("brew services start #{service}")
-          if success
-            out.success("#{service} started") unless options[:json]
-          else
+          unless success
             out.warn("#{service} failed to start: #{output.strip.lines.last&.strip}") unless options[:json]
+            return false
           end
+
+          out.success("#{service} started") unless options[:json]
           kickstart_launchd_service("homebrew.mxcl.#{service}", out)
         rescue StandardError => e
           out.warn("brew services start #{service} raised: #{e.message}") unless options[:json]

--- a/lib/legion/cli/service_command.rb
+++ b/lib/legion/cli/service_command.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'rbconfig'
+require 'thor'
+require 'legion/cli/output'
+
+module Legion
+  module CLI
+    class ServiceCommand < Thor
+      namespace 'service'
+
+      def self.exit_on_failure?
+        true
+      end
+
+      class_option :json,     type: :boolean, default: false, desc: 'Output as JSON'
+      class_option :no_color, type: :boolean, default: false, desc: 'Disable color output'
+
+      SERVICE_LABEL = 'homebrew.mxcl.legionio'
+
+      desc 'start', 'Start the Legion launchd service'
+      long_desc <<~DESC
+        Starts the Legion background service via launchd. On macOS 26+ (Tahoe),
+        uses launchctl kickstart to ensure immediate process spawn after bootstrap.
+      DESC
+      def start
+        out = Output::Formatter.new(json: options[:json], color: !options[:no_color])
+        ensure_macos!(out)
+
+        plist = plist_path
+        unless File.exist?(plist)
+          out.error("Service plist not found at #{plist}")
+          out.info('Run: brew install legionio')
+          raise SystemExit, 1
+        end
+
+        uid = ::Process.uid
+        target = "gui/#{uid}"
+
+        if service_loaded?(target)
+          out.info('Service already loaded, kicking...')
+        else
+          _, status = Open3.capture2e('launchctl', 'bootstrap', target, plist)
+          out.warn('bootstrap failed (may already be loaded), attempting kickstart anyway') unless status.success?
+        end
+
+        _, status = Open3.capture2e('launchctl', 'kickstart', '-k', "#{target}/#{SERVICE_LABEL}")
+        if status.success?
+          out.success('Legion service started')
+        else
+          out.error('Failed to kickstart Legion service')
+          raise SystemExit, 1
+        end
+
+        poll_ready(out)
+      end
+
+      desc 'stop', 'Stop the Legion launchd service'
+      def stop
+        out = Output::Formatter.new(json: options[:json], color: !options[:no_color])
+        ensure_macos!(out)
+
+        uid = ::Process.uid
+        target = "gui/#{uid}"
+
+        _, status = Open3.capture2e('launchctl', 'bootout', "#{target}/#{SERVICE_LABEL}")
+        if status.success?
+          out.success('Legion service stopped')
+        else
+          out.warn('Service was not loaded (already stopped?)')
+        end
+      end
+
+      desc 'restart', 'Restart the Legion launchd service'
+      def restart
+        out = Output::Formatter.new(json: options[:json], color: !options[:no_color])
+        ensure_macos!(out)
+
+        uid = ::Process.uid
+        target = "gui/#{uid}"
+
+        Open3.capture2e('launchctl', 'bootout', "#{target}/#{SERVICE_LABEL}")
+        sleep 1
+
+        plist = plist_path
+        Open3.capture2e('launchctl', 'bootstrap', target, plist) if File.exist?(plist)
+
+        _, status = Open3.capture2e('launchctl', 'kickstart', '-k', "#{target}/#{SERVICE_LABEL}")
+        if status.success?
+          out.success('Legion service restarted')
+        else
+          out.error('Failed to restart Legion service')
+          raise SystemExit, 1
+        end
+
+        poll_ready(out)
+      end
+
+      desc 'status', 'Show Legion launchd service status'
+      def status
+        out = Output::Formatter.new(json: options[:json], color: !options[:no_color])
+        ensure_macos!(out)
+
+        uid = ::Process.uid
+        target = "gui/#{uid}"
+        output, status = Open3.capture2e('launchctl', 'print', "#{target}/#{SERVICE_LABEL}")
+
+        unless status.success?
+          out.info('Service is not loaded')
+          return
+        end
+
+        state = output[/state = (.+)/, 1] || 'unknown'
+        pid = output[/pid = (\d+)/, 1]
+        runs = output[/runs = (\d+)/, 1]
+
+        if options[:json]
+          puts Legion::JSON.dump({ state: state, pid: pid&.to_i, runs: runs&.to_i })
+        else
+          out.info("State: #{state}")
+          out.info("PID: #{pid}") if pid
+          out.info("Runs: #{runs}") if runs
+        end
+      end
+
+      private
+
+      def ensure_macos!(out)
+        return if RbConfig::CONFIG['host_os'] =~ /darwin/
+
+        out.error('The service command is only available on macOS (uses launchd)')
+        raise SystemExit, 1
+      end
+
+      def plist_path
+        File.expand_path("~/Library/LaunchAgents/#{SERVICE_LABEL}.plist")
+      end
+
+      def service_loaded?(target)
+        _, status = Open3.capture2e('launchctl', 'print', "#{target}/#{SERVICE_LABEL}")
+        status.success?
+      end
+
+      def poll_ready(out, port: 4567, timeout: 15)
+        require 'net/http'
+        deadline = ::Time.now + timeout
+        until ::Time.now > deadline
+          begin
+            resp = Net::HTTP.get_response(URI("http://localhost:#{port}/api/ready"))
+            if resp.is_a?(Net::HTTPSuccess)
+              out.success("Daemon ready on port #{port}")
+              return
+            end
+          rescue StandardError
+            # not ready yet
+          end
+          sleep 1
+        end
+        out.info('Service started but not yet ready (boot in progress)')
+      end
+    end
+  end
+end

--- a/lib/legion/extensions.rb
+++ b/lib/legion/extensions.rb
@@ -132,6 +132,24 @@ module Legion
         Legion::Logging.info "[Extensions] flushed #{count} pending registrations" if defined?(Legion::Logging)
       end
 
+      def require_identity_extensions
+        find_extensions.select { |entry| entry[:category] == :identity }.each do |entry|
+          gem_name = entry[:gem_name]
+          ext_settings = extension_settings_for_entry(entry)
+
+          if ext_settings.is_a?(Hash) && ext_settings.key?(:enabled) && !ext_settings[:enabled]
+            Legion::Logging.info "Skipping #{gem_name} identity preload because it's disabled"
+            next
+          end
+
+          Catalog.register(gem_name)
+          register_extension_handle(gem_name, state:                    :registered,
+                                              latest_installed_version: latest_installed_version(gem_name))
+          ensure_namespace(entry[:const_path]) if entry[:segments].length > 1
+          gem_load(entry)
+        end
+      end
+
       def pause_actors
         @running_instances&.each do |inst|
           timer = inst.instance_variable_get(:@timer)

--- a/lib/legion/identity/broker.rb
+++ b/lib/legion/identity/broker.rb
@@ -21,6 +21,10 @@ module Legion
           token
         end
 
+        def credential_for(provider_name, qualifier: nil, for_context: nil, purpose: nil, context: nil)
+          token_for(provider_name, qualifier: qualifier, for_context: for_context, purpose: purpose, context: context)
+        end
+
         def lease_for(provider_name, qualifier: nil)
           name = provider_name.to_sym
           resolved = qualifier || default_qualifier_for(name)

--- a/lib/legion/identity/resolver.rb
+++ b/lib/legion/identity/resolver.rb
@@ -34,6 +34,12 @@ module Legion
           winning_provider, winning_result, provider_results = resolve_auth(auth_providers, timeout: timeout)
 
           if winning_provider.nil?
+            log.debug('resolve!: no auth winner, trying cached identity')
+            winning_provider, winning_result, cached_results = resolve_cached_identity
+            provider_results.merge!(cached_results) if cached_results
+          end
+
+          if winning_provider.nil?
             log.debug('resolve!: no auth winner, trying fallback providers')
             winning_provider, winning_result, fallback_results = resolve_auth(fallback_providers, timeout: timeout)
             provider_results.merge!(fallback_results) if fallback_results
@@ -226,6 +232,67 @@ module Legion
             log.debug("resolve_auth: winner=#{winner_name}")
             winner_info = provider_results[winner_name]
             [winner_info[:provider], winner_info[:result], provider_results]
+          end
+        end
+
+        def resolve_cached_identity
+          cached = read_cached_identity
+          return [nil, nil, {}] unless cached
+
+          provider = cached_identity_provider
+          result = {
+            canonical_name: cached[:canonical_name],
+            kind:           cached[:kind] || :human,
+            source:         :identity_json,
+            persistent:     true
+          }
+
+          [
+            provider,
+            result,
+            {
+              provider.provider_name => {
+                status:      :resolved,
+                trust:       provider.trust_level,
+                resolved_at: Time.now,
+                provider:    provider,
+                result:      result
+              }
+            }
+          ]
+        end
+
+        def read_cached_identity
+          path = File.expand_path('~/.legionio/settings/identity.json')
+          return nil unless File.file?(path)
+
+          data = if defined?(Legion::JSON)
+                   Legion::JSON.load(File.read(path))
+                 else
+                   require 'json'
+                   ::JSON.parse(File.read(path), symbolize_names: true)
+                 end
+          canonical = data[:canonical_name] || data['canonical_name']
+          return nil if canonical.to_s.strip.empty?
+
+          {
+            canonical_name: canonical.to_s,
+            kind:           (data[:kind] || data['kind'] || :human).to_sym
+          }
+        rescue StandardError => e
+          log.warn("identity.json read failed: #{e.message}")
+          nil
+        end
+
+        def cached_identity_provider
+          @cached_identity_provider ||= Module.new do
+            module_function
+
+            def provider_name = :identity_cache
+            def provider_type = :auth
+            def priority = -100
+            def trust_weight = 150
+            def trust_level = :cached
           end
         end
 

--- a/lib/legion/service.rb
+++ b/lib/legion/service.rb
@@ -589,7 +589,7 @@ module Legion
       end
     end
 
-    def setup_logging_transport # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+    def setup_logging_transport # rubocop:disable Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
       return unless defined?(Legion::Transport::Connection)
       return unless Legion::Transport::Connection.session_open?
 
@@ -612,11 +612,16 @@ module Legion
       exchange = log_channel.topic('legion.logging', durable: true)
 
       if forward_logs
-        Legion::Logging.log_writer = lambda { |event, routing_key:|
+        Legion::Logging.log_writer = lambda { |event, routing_key:, headers: {}, properties: {}|
           begin
             next unless log_channel&.open?
 
-            exchange.publish(Legion::JSON.dump(event), routing_key: routing_key)
+            exchange.publish(
+              Legion::JSON.dump(event),
+              routing_key: routing_key,
+              headers:     headers,
+              **properties
+            )
           rescue StandardError
             nil
           end

--- a/lib/legion/service.rb
+++ b/lib/legion/service.rb
@@ -112,6 +112,8 @@ module Legion
       end
       setup_cluster if data
 
+      setup_identity_before_llm(extensions: extensions, transport: transport)
+
       if llm
         begin
           setup_llm
@@ -161,15 +163,14 @@ module Legion
       setup_safety_metrics
       setup_supervision if supervision
 
-      require_relative 'identity' if File.exist?(File.expand_path('identity.rb', __dir__))
-
       if extensions
         load_extensions
         Legion::Readiness.mark_ready(:extensions)
         setup_generated_functions
       end
 
-      # Identity resolution — after extensions so lex-identity-* providers are loaded
+      # Re-run identity after full extension load so any providers with autobuild-time
+      # registration can upgrade the pre-LLM identity.
       db_available = defined?(Legion::Data) && Legion::Data.respond_to?(:connected?) && Legion::Data.connected?
       setup_identity if transport || db_available
       register_credential_providers if extensions && (transport || db_available)
@@ -923,6 +924,8 @@ module Legion
         Legion::Readiness.mark_skipped(:rbac)
       end
 
+      setup_identity_before_llm(extensions: true, transport: true)
+
       if defined?(Legion::LLM)
         setup_llm
       else
@@ -950,7 +953,6 @@ module Legion
       # Phase 5: re-run identity resolution after extensions are loaded so that
       # any identity providers registered by lex-identity-* extensions are
       # available to the resolver (mirrors the boot-time ordering).
-      Legion::Identity::Resolver.reset! if defined?(Legion::Identity::Resolver)
       setup_identity
 
       db_available = defined?(Legion::Data) && Legion::Data.respond_to?(:connected?) && Legion::Data.connected?
@@ -979,6 +981,18 @@ module Legion
     def load_extensions
       require 'legion/runner'
       Legion::Extensions.hook_extensions
+    end
+
+    def setup_identity_before_llm(extensions:, transport:)
+      require_relative 'identity' if File.exist?(File.expand_path('identity.rb', __dir__))
+      Legion::Extensions.require_identity_extensions if extensions &&
+                                                        defined?(Legion::Extensions) &&
+                                                        Legion::Extensions.respond_to?(:require_identity_extensions)
+
+      db_available = defined?(Legion::Data) && Legion::Data.respond_to?(:connected?) && Legion::Data.connected?
+      setup_identity if transport || db_available
+    rescue StandardError => e
+      handle_exception(e, level: :warn, operation: 'service.setup_identity_before_llm')
     end
 
     def register_core_tools

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.35'
+  VERSION = '1.9.36'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.34'
+  VERSION = '1.9.35'
 end

--- a/spec/legion/extensions_phased_loading_spec.rb
+++ b/spec/legion/extensions_phased_loading_spec.rb
@@ -212,6 +212,57 @@ RSpec.describe Legion::Extensions do
     end
   end
 
+  describe '.require_identity_extensions' do
+    let(:lex_identity) do
+      {
+        gem_name:      'lex-identity-system',
+        category:      :identity,
+        tier:          0,
+        segments:      %w[identity system],
+        const_path:    'Legion::Extensions::Identity::System',
+        require_path:  'legion/extensions/identity/system',
+        settings_path: %i[identity system]
+      }
+    end
+    let(:lex_http) do
+      {
+        gem_name:      'lex-http',
+        category:      :core,
+        tier:          1,
+        segments:      ['http'],
+        const_path:    'Legion::Extensions::Http',
+        require_path:  'legion/extensions/http',
+        settings_path: [:http]
+      }
+    end
+
+    before do
+      allow(described_class).to receive(:find_extensions).and_return([lex_identity, lex_http])
+      allow(described_class).to receive(:extension_settings_for_entry).and_return({})
+      allow(described_class).to receive(:latest_installed_version)
+      allow(described_class).to receive(:register_extension_handle)
+      allow(described_class).to receive(:ensure_namespace)
+      allow(described_class).to receive(:gem_load)
+      allow(Legion::Extensions::Catalog).to receive(:register)
+    end
+
+    it 'requires identity extension files without loading non-identity extensions' do
+      described_class.require_identity_extensions
+
+      expect(described_class).to have_received(:gem_load).with(lex_identity)
+      expect(described_class).not_to have_received(:gem_load).with(lex_http)
+    end
+
+    it 'does not require disabled identity extensions' do
+      allow(described_class).to receive(:extension_settings_for_entry).with(lex_identity).and_return(enabled: false)
+      allow(described_class).to receive(:extension_settings_for_entry).with(lex_http).and_return({})
+
+      described_class.require_identity_extensions
+
+      expect(described_class).not_to have_received(:gem_load)
+    end
+  end
+
   describe '.default_category_registry' do
     subject(:registry) { described_class.send(:default_category_registry) }
 

--- a/spec/legion/identity/broker_spec.rb
+++ b/spec/legion/identity/broker_spec.rb
@@ -83,6 +83,18 @@ RSpec.describe Legion::Identity::Broker do
     end
   end
 
+  describe '.credential_for' do
+    it 'returns the raw token for a registered provider' do
+      described_class.register_provider(:anthropic, provider: double('p'), lease: make_static_lease(token: 'sk-ant'))
+
+      expect(described_class.credential_for(:anthropic)).to eq('sk-ant')
+    end
+
+    it 'returns nil when the provider has no valid credential' do
+      expect(described_class.credential_for(:anthropic)).to be_nil
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # credentials_for
   # ---------------------------------------------------------------------------

--- a/spec/legion/identity/resolver_spec.rb
+++ b/spec/legion/identity/resolver_spec.rb
@@ -166,6 +166,8 @@ RSpec.describe Legion::Identity::Resolver do
   describe '.resolve!' do
     before do
       Legion::Identity::Process.reset!
+      allow(File).to receive(:file?).and_call_original
+      allow(File).to receive(:file?).with(File.expand_path('~/.legionio/settings/identity.json')).and_return(false)
     end
 
     after do
@@ -282,6 +284,27 @@ RSpec.describe Legion::Identity::Resolver do
         described_class.register(system_provider)
         described_class.resolve!
         expect(described_class.composite[:trust]).to eq(:unverified)
+      end
+    end
+
+    context 'with cached identity' do
+      before do
+        allow(described_class).to receive(:persist_identity_json)
+        allow(File).to receive(:read).and_call_original
+      end
+
+      it 'uses identity.json before unverified fallback providers' do
+        allow(File).to receive(:file?).with(File.expand_path('~/.legionio/settings/identity.json')).and_return(true)
+        allow(File).to receive(:read).with(File.expand_path('~/.legionio/settings/identity.json'))
+                                     .and_return('{"canonical_name":"cached-user","kind":"human"}')
+
+        described_class.register(system_provider)
+        described_class.resolve!
+
+        expect(described_class.composite[:canonical_name]).to eq('cached-user')
+        expect(described_class.composite[:trust]).to eq(:cached)
+        expect(described_class.composite[:providers][:identity_cache][:status]).to eq(:resolved)
+        expect(Legion::Identity::Process.canonical_name).to eq('cached-user')
       end
     end
 

--- a/spec/legion/service_credential_scoping_spec.rb
+++ b/spec/legion/service_credential_scoping_spec.rb
@@ -249,6 +249,43 @@ RSpec.describe Legion::Service do
   # §8.1 Boot — setup_identity credential swap
   # ---------------------------------------------------------------------------
 
+  describe '#setup_identity_before_llm' do
+    before do
+      allow(service).to receive(:require_relative)
+      allow(service).to receive(:setup_identity)
+      allow(service).to receive(:handle_exception)
+
+      data = Module.new do
+        def self.respond_to?(method, *) = method == :connected? ? true : super
+        def self.connected? = false
+      end
+      extensions = Module.new do
+        def self.respond_to?(method, *) = method == :require_identity_extensions ? true : super
+        def self.require_identity_extensions = nil
+      end
+
+      stub_const('Legion::Data', data)
+      stub_const('Legion::Extensions', extensions)
+      allow(Legion::Extensions).to receive(:require_identity_extensions)
+    end
+
+    it 'requires identity extensions and resolves identity before LLM setup can run' do
+      expect(service).to receive(:require_relative).with('identity').ordered
+      expect(Legion::Extensions).to receive(:require_identity_extensions).ordered
+      expect(service).to receive(:setup_identity).ordered
+
+      service.send(:setup_identity_before_llm, extensions: true, transport: true)
+    end
+
+    it 'does not require identity extensions when extension loading is disabled' do
+      expect(Legion::Extensions).not_to receive(:require_identity_extensions)
+
+      service.send(:setup_identity_before_llm, extensions: false, transport: true)
+
+      expect(service).to have_received(:setup_identity)
+    end
+  end
+
   describe '#setup_identity — credential swap' do
     before do
       # Stub identity/process requires
@@ -263,6 +300,12 @@ RSpec.describe Legion::Service do
         def self.bind_fallback! = nil
       end
       stub_const('Legion::Identity::Process', identity_process)
+
+      identity_resolver = Module.new do
+        def self.resolve! = nil
+        def self.resolved? = true
+      end
+      stub_const('Legion::Identity::Resolver', identity_resolver)
 
       settings = Module.new do
         def self.respond_to?(method, *) = method == :resolve_secrets! ? true : super

--- a/spec/legion/service_logging_transport_spec.rb
+++ b/spec/legion/service_logging_transport_spec.rb
@@ -83,8 +83,19 @@ RSpec.describe 'Service#setup_logging_transport' do
     it 'publishes via exchange when log_writer is called' do
       allow(mock_exchange).to receive(:publish)
       service.send(:setup_logging_transport)
-      Legion::Logging.log_writer.call({ message: 'test' }, routing_key: 'legion.logging.log.warn.core.unknown')
-      expect(mock_exchange).to have_received(:publish).once
+      Legion::Logging.log_writer.call(
+        { message: 'test' },
+        routing_key: 'legion.logging.log.warn.core.unknown',
+        headers:     { 'x-legion-identity-id' => 'ident-123' },
+        properties:  { content_type: 'application/json', type: 'log_event' }
+      )
+      expect(mock_exchange).to have_received(:publish).with(
+        kind_of(String),
+        routing_key:  'legion.logging.log.warn.core.unknown',
+        headers:      { 'x-legion-identity-id' => 'ident-123' },
+        content_type: 'application/json',
+        type:         'log_event'
+      )
     end
 
     it 'publishes via exchange when exception_writer is called' do


### PR DESCRIPTION
## Summary

- macOS 26 (Tahoe) changed `launchctl bootstrap` behavior: `RunAtLoad` no longer triggers immediate process spawn for services loaded mid-session. Instead launchd marks them `pended nondemand spawn = speculative` and defers indefinitely — affecting ALL brew services.
- Adds `legionio service start|stop|restart|status` CLI subcommand that calls `launchctl kickstart` after bootstrap to force immediate spawn.
- Updates `bootstrap_command.rb` to also kickstart after `brew services start` so `legionio bootstrap --start` works on macOS 26+.
- Resolves Legion process identity before LLM setup so `llm.registry` availability events are published with identity headers.
- Adds cached `identity.json` fallback ahead of unverified system identity when no fresh auth provider resolves yet.
- Adds `Legion::Identity::Broker.credential_for` as a raw-token compatibility wrapper for LLM provider discovery.

## Root Cause

On macOS 26 (Tahoe, build 25E253), `launchctl bootstrap gui/<uid> <plist>` loads the service but defers execution with `pended nondemand spawn = speculative`. The `RunAtLoad` key only fires at login, not mid-session. This is a platform behavior change from Sequoia.

`launchctl kickstart gui/<uid>/<label>` bypasses the speculative deferral and forces immediate process spawn. Confirmed working for both legionio and redis.

Separately, LLM setup was running before identity resolution, so `llm.registry` availability messages could be published before `Legion::Transport::Message` had identity state available for headers.

## Test plan

- [x] `bundle exec legionio service start` — kickstarts the service successfully (`runs = 1`)
- [x] `bundle exec legionio service stop` — bootout succeeds
- [x] `bundle exec legionio service status` — shows state/pid/runs
- [x] `bundle exec legionio service restart` — full stop + start cycle
- [x] `bundle exec rubocop` — 0 offenses on new/modified files
- [x] `bundle exec rspec spec/legion/cli/` — 1920 examples, no new failures
- [x] Verified same macOS 26 issue affects redis (universal platform issue, not legionio-specific)
- [x] `bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt`
- [x] `bundle exec rubocop -A`
