### PR TITLE
fix(cli): point legionio status at /api/ready and read data envelope

### DIFF
--- a/lib/legion/cli/status.rb
+++ b/lib/legion/cli/status.rb
@@ -25,7 +25,7 @@ module Legion
           port = options[:port] || 4567
           host = options[:host] || '127.0.0.1'
 
-          uri = URI("http://#{host}:#{port}/ready")
+          uri = URI("http://#{host}:#{port}/api/ready")
           response = Net::HTTP.get_response(uri)
           JSON.parse(response.body, symbolize_names: true)
         rescue StandardError => e
@@ -39,14 +39,15 @@ module Legion
             return
           end
 
-          ready = api_status[:ready]
+          payload = api_status[:data].is_a?(Hash) ? api_status[:data] : api_status
+          ready = payload[:ready]
           out.header('Legion Service')
           puts "  #{out.colorize('STATUS:', :cyan)} #{ready ? out.colorize('RUNNING', :green) : out.colorize('STARTING', :yellow)}"
           out.spacer
 
-          if api_status[:components]
+          if payload[:components]
             out.header('Components')
-            api_status[:components].each do |component, is_ready|
+            payload[:components].each do |component, is_ready|
               status_str = is_ready ? out.colorize('ready', :green) : out.colorize('not ready', :yellow)
               puts "  #{component.to_s.ljust(15)} #{status_str}"
             end


### PR DESCRIPTION
## Summary
`legionio status` reported NOT RUNNING/STARTING even when the daemon was fully up.

Two bugs in `Legion::CLI::Status`:
1. **Wrong path** — `check_api` requested `/ready`, but readiness is mounted at
   `/api/ready` (service_command, bootstrap_command, debug_command, system_status
   all already use `/api/ready`). The 404 makes check_api return nil → static
   "NOT RUNNING" view.
2. **Envelope not unwrapped** — even with the path fixed, `show_running` read
   `:ready`/`:components` from the top level, but the API contract wraps responses
   as `{ data: {...}, meta: {...} }`, so status would still never show RUNNING.

## Fix
- Point `check_api` at `/api/ready`.
- Unwrap the `data` envelope in `show_running` (defensive fallback to flat shape).

## Verification
Against a running 1.9.36 daemon, `legionio status` now prints STATUS: RUNNING
with all components green. (Before: NOT RUNNING + `GET /ready 404` in the log.)

## Notes
- No existing `spec/legion/cli/status_spec.rb`; happy to add a regression spec.
- Couldn't run `bundle exec rspec`/`rubocop` locally (bundle not installed); change
  is minimal and matches surrounding style.
