### PR TITLE
fix(cli): resolve Vault lease credentials before direct CLI connections

### DIFF
--- a/lib/legion/cli/connection.rb
+++ b/lib/legion/cli/connection.rb
@@ -39,6 +39,7 @@ module Legion
           return if @data_ready
 
           ensure_settings
+          ensure_secrets_resolved
           require 'legion/data'
           Legion::Settings.merge_settings(:data, Legion::Data::Settings.default)
           Legion::Data.setup
@@ -53,6 +54,7 @@ module Legion
           return if @transport_ready
 
           ensure_settings
+          ensure_secrets_resolved
           require 'legion/transport'
           Legion::Settings.merge_settings('transport', Legion::Transport::Settings.default)
           Legion::Transport::Connection.setup
@@ -76,6 +78,29 @@ module Legion
           raise CLI::Error, 'legion-crypt gem is not installed (gem install legion-crypt)'
         rescue StandardError => e
           raise CLI::Error, "crypt initialization failed: #{e.message}"
+        end
+
+        # Resolve lease:// and vault:// credential references before a direct
+        # backend connection. Mirrors the daemon boot order (Crypt.start ->
+        # resolve_secrets! -> connect): short-lived CLI processes must start
+        # Crypt so the LeaseManager/Vault client exists, otherwise unresolved
+        # lease:// strings are passed verbatim to the database/broker driver.
+        #
+        # Skipped when legion-crypt is not installed (e.g. a local-dev bundle
+        # with plaintext creds) so data/transport still connect. A genuine Crypt
+        # failure still surfaces via ensure_crypt as a CLI::Error.
+        def ensure_secrets_resolved
+          return if @crypt_ready
+          return unless crypt_available?
+
+          ensure_crypt
+        end
+
+        def crypt_available?
+          Gem::Specification.find_by_name('legion-crypt')
+          true
+        rescue Gem::MissingSpecError
+          false
         end
 
         def ensure_cache

--- a/lib/legion/cli/doctor/database_check.rb
+++ b/lib/legion/cli/doctor/database_check.rb
@@ -75,6 +75,9 @@ module Legion
 
         def check_network_db(adapter, _database)
           require 'legion/data'
+          # Resolve lease:// and vault:// credential references before connecting,
+          # otherwise the literal reference is passed to the database driver.
+          Connection.ensure_secrets_resolved if defined?(Connection) && Connection.respond_to?(:ensure_secrets_resolved)
           Legion::Data.setup
           Result.new(name: name, status: :pass, message: "#{adapter} connection ok")
         rescue LoadError

--- a/spec/legion/cli/connection_spec.rb
+++ b/spec/legion/cli/connection_spec.rb
@@ -106,12 +106,21 @@ RSpec.describe Legion::CLI::Connection do
       allow(Legion::Settings).to receive(:merge_settings)
       allow(Legion::Data::Settings).to receive(:default).and_return({})
       allow(Legion::Data).to receive(:setup)
+      allow(described_class).to receive(:ensure_secrets_resolved)
     end
 
     context 'when legion-data is available and connects successfully' do
       it 'calls Legion::Data.setup' do
         described_class.ensure_data
         expect(Legion::Data).to have_received(:setup)
+      end
+
+      it 'resolves lease:// secrets before connecting to the database' do
+        call_order = []
+        allow(described_class).to receive(:ensure_secrets_resolved) { call_order << :resolve }
+        allow(Legion::Data).to receive(:setup) { call_order << :data_setup }
+        described_class.ensure_data
+        expect(call_order).to eq(%i[resolve data_setup])
       end
 
       it 'sets @data_ready to true' do
@@ -158,12 +167,21 @@ RSpec.describe Legion::CLI::Connection do
       allow(Legion::Settings).to receive(:merge_settings)
       allow(Legion::Transport::Settings).to receive(:default).and_return({})
       allow(Legion::Transport::Connection).to receive(:setup)
+      allow(described_class).to receive(:ensure_secrets_resolved)
     end
 
     context 'when legion-transport is available and connects successfully' do
       it 'calls Legion::Transport::Connection.setup' do
         described_class.ensure_transport
         expect(Legion::Transport::Connection).to have_received(:setup)
+      end
+
+      it 'resolves lease:// secrets before connecting to the broker' do
+        call_order = []
+        allow(described_class).to receive(:ensure_secrets_resolved) { call_order << :resolve }
+        allow(Legion::Transport::Connection).to receive(:setup) { call_order << :transport_setup }
+        described_class.ensure_transport
+        expect(call_order).to eq(%i[resolve transport_setup])
       end
 
       it 'sets @transport_ready to true' do
@@ -274,6 +292,56 @@ RSpec.describe Legion::CLI::Connection do
   end
 
   # ---------------------------------------------------------------------------
+  # ensure_secrets_resolved
+  # ---------------------------------------------------------------------------
+  describe '.ensure_secrets_resolved' do
+    context 'when legion-crypt is available' do
+      before do
+        allow(described_class).to receive(:crypt_available?).and_return(true)
+        allow(described_class).to receive(:ensure_crypt)
+      end
+
+      it 'starts crypt so lease:// references can be resolved' do
+        described_class.ensure_secrets_resolved
+        expect(described_class).to have_received(:ensure_crypt)
+      end
+
+      it 'is a no-op once crypt is already ready' do
+        described_class.instance_variable_set(:@crypt_ready, true)
+        described_class.ensure_secrets_resolved
+        expect(described_class).not_to have_received(:ensure_crypt)
+      end
+    end
+
+    context 'when legion-crypt is not installed' do
+      before do
+        allow(described_class).to receive(:crypt_available?).and_return(false)
+        allow(described_class).to receive(:ensure_crypt)
+      end
+
+      it 'skips crypt so plaintext-credential setups still connect' do
+        expect { described_class.ensure_secrets_resolved }.not_to raise_error
+        expect(described_class).not_to have_received(:ensure_crypt)
+      end
+    end
+
+    context 'when crypt is available but fails to start' do
+      before do
+        allow(described_class).to receive(:crypt_available?).and_return(true)
+        allow(described_class).to receive(:ensure_crypt)
+          .and_raise(Legion::CLI::Error, 'crypt initialization failed: vault unavailable')
+      end
+
+      it 'propagates the CLI::Error so the failure is visible' do
+        expect { described_class.ensure_secrets_resolved }.to raise_error(
+          Legion::CLI::Error,
+          /crypt initialization failed/
+        )
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # ensure_cache
   # ---------------------------------------------------------------------------
   describe '.ensure_cache' do
@@ -335,6 +403,7 @@ RSpec.describe Legion::CLI::Connection do
       allow(Legion::Settings).to receive(:merge_settings)
       allow(Legion::Data::Settings).to receive(:default).and_return({})
       allow(Legion::Data).to receive(:setup)
+      allow(described_class).to receive(:ensure_secrets_resolved)
       described_class.ensure_data
       expect(described_class.data?).to be(true)
     end
@@ -350,6 +419,7 @@ RSpec.describe Legion::CLI::Connection do
       allow(Legion::Settings).to receive(:merge_settings)
       allow(Legion::Transport::Settings).to receive(:default).and_return({})
       allow(Legion::Transport::Connection).to receive(:setup)
+      allow(described_class).to receive(:ensure_secrets_resolved)
       described_class.ensure_transport
       expect(described_class.transport?).to be(true)
     end


### PR DESCRIPTION

## Summary
One-shot CLI commands that connect **directly** to PostgreSQL or RabbitMQ fail
against a Vault-backed (mesh) deployment because they never resolve `lease://name#key`
(and `vault://path#key`) credential references before opening the connection. The
literal reference string is passed to the driver:

```
$ legionio task list
[data] FATAL Sequel::DatabaseConnectionError: PG::ConnectionBad: connection to server
at "10.x.x.x", port 5432 failed: could not initiate GSSAPI security context: ...
connection to server ... failed: FATAL:  role "lease://postgresql#username" does not exist
```

The daemon is healthy and serves real data — only short-lived CLI processes that open
their own backend connection are affected. This routes those commands (and the
`doctor` database check) through a shared lease-resolution step that mirrors the daemon
boot order, fixing all of them at once.

## Root cause
`Legion::CLI::Connection.ensure_data` and `.ensure_transport` call `ensure_settings`,
which runs `Legion::Settings.resolve_secrets!` — but the resolver only resolves
`lease://` references when **Vault is already connected** (`Resolver#vault_connected?`).
In a fresh CLI process `Legion::Crypt` has not started, so Vault is not connected and
the `LeaseManager` does not exist; nothing resolves and the raw `lease://...` string is
handed to the driver.

Only `ensure_crypt` runs `Legion::Crypt.start` (which connects Vault and instantiates
`Legion::Crypt::LeaseManager`) and then re-runs `resolve_secrets!`. The daemon does this
at boot — `Crypt.start -> resolve_secrets! -> setup_transport/setup_data`
(`lib/legion/service.rb`) — and `check_command` follows the same order
(`settings -> crypt -> resolve_secrets_after_crypt -> data/transport`), which is why
`legionio check` reports 7/7. The one-shot CLI commands skipped the crypt step.

`legionio doctor`'s `DatabaseCheck#check_network_db` calls `Legion::Data.setup`
directly, and `doctor diagnose` deliberately loads settings with `resolve_secrets:
false` and never starts crypt, so its DB check fails the same way.

`legionio broker stats` is **not** affected: it talks to the RabbitMQ management HTTP
API with its own `--user/--password` (default `guest/guest`) and never touches the
lease-backed AMQP credentials. That contrast is what isolates the root cause to the
direct-connection path.

## Fix
Add a single shared primitive on `Connection` and call it from the direct-connection
entry points, instead of editing every command:

- `Connection.ensure_secrets_resolved` — starts crypt (via `ensure_crypt`) so
  `lease://`/`vault://` references resolve before a direct backend connection, mirroring
  the daemon boot order.
  - Idempotent: no-op once crypt is ready (`Crypt.start` is itself guarded).
  - No-op when `legion-crypt` is not installed (local-dev / plaintext-credential
    bundles still connect), gated by `crypt_available?`.
  - A genuine Crypt failure still surfaces as a `CLI::Error`, so the user gets a clear
    message rather than a confusing `role "lease://..." does not exist`.
- `ensure_data` and `ensure_transport` call `ensure_secrets_resolved` right after
  `ensure_settings`, before connecting.
- `DatabaseCheck#check_network_db` calls `Connection.ensure_secrets_resolved` (guarded
  by `defined?`/`respond_to?`) before `Legion::Data.setup`.

```ruby
# lib/legion/cli/connection.rb
def ensure_secrets_resolved
  return if @crypt_ready
  return unless crypt_available?

  ensure_crypt
end
```

I considered routing read commands to the daemon HTTP API (e.g. `task list` ->
`GET /api/tasks`), but that only helps reads, only when the daemon is up, and would not
fix `task trigger` (transport), `doctor`, or the other direct-DB commands. Making the
direct path resolve leases the same way the daemon does is smaller and consistent with
the existing `Connection` design.

## Affected commands
Now resolve `lease://`/`vault://` credentials before connecting:

- **Direct DB** (`Connection.ensure_data`): `task` (list / show / logs / purge /
  trigger), `audit`, `chain`, `dataset`, `eval`, `lex`, `prompt`, `rbac`, `setup`,
  `trace`, `worker`, `workflow`.
- **Direct transport** (`Connection.ensure_transport`): `task trigger` / `task run`.
- **Diagnostics**: `legionio doctor` database check.

`knowledge` and `telemetry` were already unaffected — they use the daemon HTTP API
(`ApiClient`), not a direct connection.

## Verification
Against a running daemon with Vault-issued dynamic Postgres credentials referenced as
`lease://postgresql#username` / `#password`.

**Before**
```
$ legionio task list
[data] FATAL Sequel::DatabaseConnectionError: PG::ConnectionBad: ...
connection to server ... failed: FATAL:  role "lease://postgresql#username" does not exist

$ legionio doctor
  FAIL 0.0  Database   postgres connection failed: Sequel::DatabaseConnectionError: ...
            role "lease://postgresql#username" does not exist
```

**After**
```
$ legionio task list
  ID  FUNCTION  STATUS     CREATED              RELATIONSHIP
  ──  ────────  ─────────  ───────────────────  ────────────
  42  602       completed  2026-05-13 09:22:37  -
  41  597       completed  2026-05-13 09:22:37  -
  ...

$ legionio doctor
  pass 1.0  Database   postgres connection ok
```

`legionio broker stats` and `legionio check` (7/7) continue to pass unchanged.

## Notes
- Tooling for this repo (Ruby >= 3.4) was not available on the default PATH, so I ran
  the checks against the 3.4.9 runtime that ships with the gem:
  - **rubocop** (project `.rubocop.yml`): 0 offenses on the 3 changed files.
  - **rspec**: `spec/legion/cli/connection_spec.rb` 55 examples, 0 failures (includes
    the new `.ensure_secrets_resolved` coverage and ordering assertions for
    `ensure_data`/`ensure_transport`); `task_command_spec.rb` + `doctor_command_spec.rb`
    + `doctor_spec.rb` 34 examples, 0 failures (no regressions).
- A regression spec is included for `connection.rb`. The `doctor` database-network path
  has no existing spec; happy to add a `doctor/database_check_spec.rb` that stubs
  `Connection.ensure_secrets_resolved` and `Legion::Data.setup` if preferred.
