### PR TITLE
fix(cli): correct daemon_client require path after legion-llm restructure

### DIFF
--- a/lib/legion/cli/chat/daemon_chat.rb
+++ b/lib/legion/cli/chat/daemon_chat.rb
@@ -4,7 +4,7 @@ require 'securerandom'
 require 'legion/cli/chat_command'
 
 begin
-  require 'legion/llm/daemon_client'
+  require 'legion/llm/call/daemon_client'
 rescue LoadError
   # legion-llm not yet loaded; DaemonClient must be defined before DaemonChat#ask is called.
 end
@@ -118,7 +118,7 @@ module Legion
         private
 
         def call_daemon_inference
-          Legion::LLM::DaemonClient.inference(
+          Legion::LLM::Call::DaemonClient.inference(
             messages:        build_messages,
             tools:           build_tool_schemas,
             model:           @model.id,

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -184,8 +184,8 @@ module Legion
           Connection.log_level = options[:verbose] ? 'debug' : 'error'
           Connection.ensure_settings
 
-          require 'legion/llm/daemon_client'
-          return if Legion::LLM::DaemonClient.available?
+          require 'legion/llm/call/daemon_client'
+          return if Legion::LLM::Call::DaemonClient.available?
 
           raise CLI::Error,
                 "LegionIO daemon is not running. Start it with: legionio start\n  " \

--- a/spec/legion/cli/chat/daemon_chat_spec.rb
+++ b/spec/legion/cli/chat/daemon_chat_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
   # Ensure the stub constant exists before each test.
   before do
-    unless defined?(Legion::LLM::DaemonClient)
+    unless defined?(Legion::LLM::Call::DaemonClient)
       stub_const('Legion::LLM', Module.new) unless defined?(Legion::LLM)
+      stub_const('Legion::LLM::Call', Module.new) unless defined?(Legion::LLM::Call)
       daemon_mod = Module.new
-      stub_const('Legion::LLM::DaemonClient', daemon_mod)
+      stub_const('Legion::LLM::Call::DaemonClient', daemon_mod)
     end
   end
 
@@ -28,7 +29,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         model:         'claude-sonnet-4-6'
       }
     }
-    allow(Legion::LLM::DaemonClient).to receive(:inference).and_return(result)
+    allow(Legion::LLM::Call::DaemonClient).to receive(:inference).and_return(result)
     result
   end
 
@@ -47,7 +48,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       stub_inference
       responses = []
       chat.ask('test') { |chunk| responses << chunk.content }
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(messages: array_including(hash_including(role: 'user', content: 'test')))
       )
     end
@@ -78,7 +79,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
     it 'passes caller and conversation_id to DaemonClient.inference' do
       stub_inference
       chat.ask('test')
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           caller:          hash_including(requested_by: hash_including(type: :human)),
           conversation_id: chat.conversation_id
@@ -95,7 +96,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       chat.with_instructions('You are a helpful assistant.')
       chat.ask('test')
 
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           messages: array_including(hash_including(role: 'system', content: 'You are a helpful assistant.'))
         )
@@ -121,7 +122,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       chat.with_tools(fake_tool)
       chat.ask('read something')
 
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           tools: array_including(hash_including(name: 'read_file'))
         )
@@ -154,7 +155,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       chat.add_message(role: :user, content: 'injected context')
       chat.ask('follow up')
 
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           messages: array_including(hash_including(role: 'user', content: 'injected context'))
         )
@@ -169,7 +170,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
       # After reset, only the new message should appear in the next inference call
       captured_messages = nil
-      allow(Legion::LLM::DaemonClient).to receive(:inference) do |messages:, **_|
+      allow(Legion::LLM::Call::DaemonClient).to receive(:inference) do |messages:, **_|
         captured_messages = messages
         {
           status: :immediate,
@@ -223,7 +224,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         }
       }
 
-      allow(Legion::LLM::DaemonClient).to receive(:inference)
+      allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
         .and_return(first_response, final_response)
 
       chat.with_tools(fake_tool)
@@ -257,7 +258,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         }
       }
 
-      allow(Legion::LLM::DaemonClient).to receive(:inference)
+      allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
         .and_return(first_response, final_response)
 
       chat.with_tools(fake_tool)
@@ -301,13 +302,13 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         stub_inference(content: 'follow up answer')
         chat.ask('follow up')
 
-        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+        expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).twice
       end
     end
 
     context 'when daemon returns an error status' do
       it 'raises CLI::Error' do
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return({ status: :error, error: 'connection refused' })
 
         expect { chat.ask('test') }.to raise_error(Legion::CLI::Error, /Daemon inference error/)
@@ -316,7 +317,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
     context 'when daemon is unavailable' do
       it 'raises CLI::Error' do
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return({ status: :unavailable })
 
         expect { chat.ask('test') }.to raise_error(Legion::CLI::Error, /unavailable/)
@@ -360,7 +361,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       end
 
       before do
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return(tool_call_response, final_response)
         chat.with_tools(fake_tool)
       end
@@ -368,7 +369,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       it 'loops until a non-tool response is received' do
         response = chat.ask('read main.rb')
         expect(response.content).to eq('Based on the file: it looks good.')
-        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+        expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).twice
       end
 
       it 'appends tool result messages to the conversation' do
@@ -376,17 +377,17 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
         # On the second call, messages should include the tool result
         second_call_messages = nil
-        allow(Legion::LLM::DaemonClient).to receive(:inference) do |messages:, **|
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference) do |messages:, **|
           second_call_messages ||= messages if second_call_messages.nil?
           final_response
         end
 
-        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+        expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).twice
       end
 
       it 'returns "Unknown tool: name" when tool is not registered' do
         chat.with_tools # clear tools
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return(tool_call_response, final_response)
 
         # Should not raise — returns graceful error string as tool result


### PR DESCRIPTION
## Summary

`legionio ask "..."` and `legionio chat prompt` crash immediately, before any
LLM request is attempted:

```
LoadError: cannot load such file -- legion/llm/daemon_client
  from .../legionio-1.9.36/lib/legion/cli/chat_command.rb:187:in 'Legion::CLI::Chat#setup_connection'
  from .../legionio-1.9.36/lib/legion/cli/chat_command.rb:96:in  'Legion::CLI::Chat#prompt'
```

This makes the headline `ask` shortcut and `chat prompt` unusable on a stock install,
even when the daemon is running and a backend is serving models.

## Root cause

The `legion-llm` v0.7 restructure moved the daemon client and renamed its constant:

| Before | After |
|--------|-------|
| `lib/legion/llm/daemon_client.rb` | `lib/legion/llm/call/daemon_client.rb` |
| `Legion::LLM::DaemonClient` | `Legion::LLM::Call::DaemonClient` |

(In `legion-llm` history this is the `R100` rename in "starting restructure of Legion::LLM",
followed by the module-declaration rename in "rename all module/class declarations to match
new file paths".)

The CLI was never updated. Two files still point at the old location:

- `lib/legion/cli/chat_command.rb:187-188` (`setup_connection`)
- `lib/legion/cli/chat/daemon_chat.rb:7,121`

`legion-llm` does ship a backward-compat alias (`lib/legion/llm/compat.rb`, via
`const_missing`) that maps `Legion::LLM::DaemonClient` → `Legion::LLM::Call::DaemonClient`.
However, that alias is only installed once the **full `legion/llm` facade** is loaded
(`llm.rb` requires `compat.rb`). The `ask` / `chat prompt` path does not load the facade:

```
Legion::CLI::Interactive#ask
  -> Legion::CLI::Chat.start(['prompt', ...])
    -> setup_connection
       Connection.ensure_settings            # loads Legion::Settings only
       require 'legion/llm/daemon_client'     # <-- old path; LoadError here
```

`ensure_llm` (the only place that does `require 'legion/llm'` + `Legion::LLM.start`) is
never called on this path. So:

1. the bare `require` fails outright with `LoadError` (the reported crash), and
2. even if only the require path were corrected, the bare constant would then raise
   `NameError`, because `compat.rb`'s `const_missing` is not installed in this path
   (`call/daemon_client.rb` pulls in only `net/http`, `uri`, `json`, `securerandom`,
   `legion/logging/helper` — not the facade).

## Fix

Point the require at the new path and reference the canonical constant in both files, so the
reference resolves directly off the required file with no dependency on the facade or the
deprecated alias:

- `require 'legion/llm/daemon_client'` → `require 'legion/llm/call/daemon_client'`
- `Legion::LLM::DaemonClient` → `Legion::LLM::Call::DaemonClient`

Applied in `chat_command.rb` and `daemon_chat.rb`, and the `daemon_chat` specs are updated to
stub the canonical constant (nesting the stub under `Legion::LLM::Call`).

Using the canonical constant (rather than only fixing the require path and leaning on the
deprecated alias) is the minimal change that is correct on **every** code path — including the
`ask` path where the facade and its `const_missing` shim are absent — and it avoids the
per-invocation deprecation warning the alias would otherwise emit.

## Verification

Patched the installed `legionio-1.9.36` gem identically and ran the real CLI against a running
daemon with a live backend serving a model.

**Before** (`legionio ask "say hi in 3 words"`):

```
<internal:.../kernel_require.rb>:136:in 'Kernel#require': cannot load such file -- legion/llm/daemon_client (LoadError)
        from .../legionio-1.9.36/lib/legion/cli/chat_command.rb:187:in 'Legion::CLI::Chat#setup_connection'
        from .../legionio-1.9.36/lib/legion/cli/chat_command.rb:96:in  'Legion::CLI::Chat#prompt'
```

**After** (same command, patched):

```
LegionIO daemon is not running. Start it with: legionio start
All LLM requests must route through the daemon.
```

No more `LoadError` / `NameError`: the require resolves, the canonical
`Legion::LLM::Call::DaemonClient` constant resolves, and execution reaches
`Legion::LLM::Call::DaemonClient.available?` and proceeds into the daemon-routing guard —
i.e. it now reaches the daemon/LLM call path instead of crashing at load time.

Static checks:
- Ruby 3.4 `-c` syntax check passes on all three changed files.
- Changed lines are ≤ 62 chars (repo `Layout/LineLength` Max = 160); hash alignment preserved.

I was not able to run `bundle exec rubocop` / `rspec` in my environment (no dev bundle
available); the change is a pure path/identifier substitution with alignment preserved.

## Notes

- Fix is intentionally scoped to the stale require path + constant. The `legion-llm` side is
  already correct (file present at the new path; compat alias present for facade consumers).
- Separately and out of scope here: on the bare `ask` / `chat prompt` path,
  `DaemonClient.available?` returns `false` because `Legion::LLM::Settings.default` (which
  carries `llm.daemon.url`) is not merged into settings on that path — `ensure_llm` /
  `Legion::LLM.start` is not invoked. That surfaces the "daemon is not running" message even
  when the daemon is up. It is a pre-existing, separate issue and was not introduced by this
  change; happy to follow up in a separate PR if desired.
