### PR TITLE
fix(cli): merge LLM settings on the ask/chat-prompt path so the daemon resolves

### DIFF
--- a/lib/legion/cli/chat/daemon_chat.rb
+++ b/lib/legion/cli/chat/daemon_chat.rb
@@ -4,7 +4,7 @@ require 'securerandom'
 require 'legion/cli/chat_command'
 
 begin
-  require 'legion/llm/daemon_client'
+  require 'legion/llm/call/daemon_client'
 rescue LoadError
   # legion-llm not yet loaded; DaemonClient must be defined before DaemonChat#ask is called.
 end
@@ -118,7 +118,7 @@ module Legion
         private
 
         def call_daemon_inference
-          Legion::LLM::DaemonClient.inference(
+          Legion::LLM::Call::DaemonClient.inference(
             messages:        build_messages,
             tools:           build_tool_schemas,
             model:           @model.id,

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -184,8 +184,8 @@ module Legion
           Connection.log_level = options[:verbose] ? 'debug' : 'error'
           Connection.ensure_settings
 
-          require 'legion/llm/daemon_client'
-          return if Legion::LLM::DaemonClient.available?
+          require 'legion/llm/call/daemon_client'
+          return if Legion::LLM::Call::DaemonClient.available?
 
           raise CLI::Error,
                 "LegionIO daemon is not running. Start it with: legionio start\n  " \

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -182,7 +182,10 @@ module Legion
         def setup_connection
           Connection.config_dir = options[:config_dir] if options[:config_dir]
           Connection.log_level = options[:verbose] ? 'debug' : 'error'
-          Connection.ensure_settings
+          # Merge LLM defaults (populates llm.daemon.url) so DaemonClient.available?
+          # can resolve the daemon. This is intentionally lighter than ensure_llm:
+          # we route through the daemon, so the local LLM stack is not booted here.
+          Connection.ensure_llm_settings
 
           require 'legion/llm/call/daemon_client'
           return if Legion::LLM::Call::DaemonClient.available?

--- a/lib/legion/cli/connection.rb
+++ b/lib/legion/cli/connection.rb
@@ -99,12 +99,29 @@ module Legion
           raise CLI::Error, 'lex-knowledge gem is not installed (gem install lex-knowledge)'
         end
 
-        def ensure_llm
-          return if @llm_ready
+        # Merge Legion::LLM::Settings.default into the :llm namespace without
+        # booting the local LLM stack. This is all the daemon-routing CLI paths
+        # (chat prompt / ask) need: the merge populates llm.daemon.url so
+        # Legion::LLM::Call::DaemonClient.available? can resolve the daemon.
+        # Full local init (providers, discovery, transports) is deliberately
+        # skipped — that work already happened in the running daemon.
+        def ensure_llm_settings
+          return if @llm_settings_ready
 
           ensure_settings
           require 'legion/llm'
           Legion::Settings.merge_settings(:llm, Legion::LLM::Settings.default)
+          @llm_settings_ready = true
+        rescue LoadError
+          raise CLI::Error, 'legion-llm gem is not installed (gem install legion-llm)'
+        rescue StandardError => e
+          raise CLI::Error, "LLM settings initialization failed: #{e.message}"
+        end
+
+        def ensure_llm
+          return if @llm_ready
+
+          ensure_llm_settings
           Legion::LLM.start
           @llm_ready = true
         rescue LoadError
@@ -127,6 +144,10 @@ module Legion
 
         def llm?
           @llm_ready == true
+        end
+
+        def llm_settings?
+          @llm_settings_ready == true
         end
 
         def shutdown

--- a/spec/legion/cli/chat/daemon_chat_spec.rb
+++ b/spec/legion/cli/chat/daemon_chat_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
   # Ensure the stub constant exists before each test.
   before do
-    unless defined?(Legion::LLM::DaemonClient)
+    unless defined?(Legion::LLM::Call::DaemonClient)
       stub_const('Legion::LLM', Module.new) unless defined?(Legion::LLM)
+      stub_const('Legion::LLM::Call', Module.new) unless defined?(Legion::LLM::Call)
       daemon_mod = Module.new
-      stub_const('Legion::LLM::DaemonClient', daemon_mod)
+      stub_const('Legion::LLM::Call::DaemonClient', daemon_mod)
     end
   end
 
@@ -28,7 +29,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         model:         'claude-sonnet-4-6'
       }
     }
-    allow(Legion::LLM::DaemonClient).to receive(:inference).and_return(result)
+    allow(Legion::LLM::Call::DaemonClient).to receive(:inference).and_return(result)
     result
   end
 
@@ -47,7 +48,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       stub_inference
       responses = []
       chat.ask('test') { |chunk| responses << chunk.content }
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(messages: array_including(hash_including(role: 'user', content: 'test')))
       )
     end
@@ -78,7 +79,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
     it 'passes caller and conversation_id to DaemonClient.inference' do
       stub_inference
       chat.ask('test')
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           caller:          hash_including(requested_by: hash_including(type: :human)),
           conversation_id: chat.conversation_id
@@ -95,7 +96,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       chat.with_instructions('You are a helpful assistant.')
       chat.ask('test')
 
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           messages: array_including(hash_including(role: 'system', content: 'You are a helpful assistant.'))
         )
@@ -121,7 +122,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       chat.with_tools(fake_tool)
       chat.ask('read something')
 
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           tools: array_including(hash_including(name: 'read_file'))
         )
@@ -154,7 +155,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       chat.add_message(role: :user, content: 'injected context')
       chat.ask('follow up')
 
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           messages: array_including(hash_including(role: 'user', content: 'injected context'))
         )
@@ -169,7 +170,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
       # After reset, only the new message should appear in the next inference call
       captured_messages = nil
-      allow(Legion::LLM::DaemonClient).to receive(:inference) do |messages:, **_|
+      allow(Legion::LLM::Call::DaemonClient).to receive(:inference) do |messages:, **_|
         captured_messages = messages
         {
           status: :immediate,
@@ -223,7 +224,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         }
       }
 
-      allow(Legion::LLM::DaemonClient).to receive(:inference)
+      allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
         .and_return(first_response, final_response)
 
       chat.with_tools(fake_tool)
@@ -257,7 +258,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         }
       }
 
-      allow(Legion::LLM::DaemonClient).to receive(:inference)
+      allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
         .and_return(first_response, final_response)
 
       chat.with_tools(fake_tool)
@@ -301,13 +302,13 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         stub_inference(content: 'follow up answer')
         chat.ask('follow up')
 
-        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+        expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).twice
       end
     end
 
     context 'when daemon returns an error status' do
       it 'raises CLI::Error' do
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return({ status: :error, error: 'connection refused' })
 
         expect { chat.ask('test') }.to raise_error(Legion::CLI::Error, /Daemon inference error/)
@@ -316,7 +317,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
     context 'when daemon is unavailable' do
       it 'raises CLI::Error' do
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return({ status: :unavailable })
 
         expect { chat.ask('test') }.to raise_error(Legion::CLI::Error, /unavailable/)
@@ -360,7 +361,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       end
 
       before do
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return(tool_call_response, final_response)
         chat.with_tools(fake_tool)
       end
@@ -368,7 +369,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       it 'loops until a non-tool response is received' do
         response = chat.ask('read main.rb')
         expect(response.content).to eq('Based on the file: it looks good.')
-        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+        expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).twice
       end
 
       it 'appends tool result messages to the conversation' do
@@ -376,17 +377,17 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
         # On the second call, messages should include the tool result
         second_call_messages = nil
-        allow(Legion::LLM::DaemonClient).to receive(:inference) do |messages:, **|
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference) do |messages:, **|
           second_call_messages ||= messages if second_call_messages.nil?
           final_response
         end
 
-        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+        expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).twice
       end
 
       it 'returns "Unknown tool: name" when tool is not registered' do
         chat.with_tools # clear tools
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return(tool_call_response, final_response)
 
         # Should not raise — returns graceful error string as tool result

--- a/spec/legion/cli/chat_command_spec.rb
+++ b/spec/legion/cli/chat_command_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 require 'legion/cli'
+require 'legion/cli/connection'
+require 'legion/llm/call/daemon_client'
 
 RSpec.describe Legion::CLI::Chat do
   it 'is defined as a Thor subcommand' do
@@ -14,5 +16,40 @@ RSpec.describe Legion::CLI::Chat do
 
   it 'has a prompt command for headless mode' do
     expect(Legion::CLI::Chat.instance_methods).to include(:prompt)
+  end
+
+  describe '#setup_connection' do
+    subject(:chat) { described_class.new([], options) }
+
+    let(:options) { {} }
+
+    before do
+      allow(Legion::CLI::Connection).to receive(:ensure_llm_settings)
+      allow(Legion::LLM::Call::DaemonClient).to receive(:available?).and_return(true)
+    end
+
+    # Regression guard: the daemon URL lives under the :llm settings namespace,
+    # which is only populated by merging Legion::LLM::Settings.default. Before the
+    # fix, setup_connection called only ensure_settings, so llm.daemon.url was
+    # never set and DaemonClient.available? returned false even with a live daemon.
+    it 'merges the LLM defaults via ensure_llm_settings before checking the daemon' do
+      chat.send(:setup_connection)
+      expect(Legion::CLI::Connection).to have_received(:ensure_llm_settings)
+    end
+
+    it 'returns without raising when the daemon is available' do
+      expect { chat.send(:setup_connection) }.not_to raise_error
+    end
+
+    context 'when the daemon is not available' do
+      before { allow(Legion::LLM::Call::DaemonClient).to receive(:available?).and_return(false) }
+
+      it 'raises CLI::Error instructing the user to start the daemon' do
+        expect { chat.send(:setup_connection) }.to raise_error(
+          Legion::CLI::Error,
+          /daemon is not running/
+        )
+      end
+    end
   end
 end

--- a/spec/legion/cli/connection_spec.rb
+++ b/spec/legion/cli/connection_spec.rb
@@ -27,10 +27,28 @@ end
 require 'legion/crypt'
 require 'legion/cache'
 
+# Pre-load legion-llm (or stub it) so Legion::LLM and Legion::LLM::Settings
+# exist before the mocks below are attached — same rationale as legion-data.
+begin
+  require 'legion/llm'
+rescue LoadError
+  module Legion
+    module LLM
+      module Settings
+        def self.default = {}
+      end
+
+      def self.start(**) = nil
+      def self.shutdown(**) = nil
+    end
+  end
+  $LOADED_FEATURES << 'legion/llm'
+end
+
 RSpec.describe Legion::CLI::Connection do
   before do
     %i[@logging_ready @settings_ready @data_ready @transport_ready
-       @crypt_ready @cache_ready @llm_ready @config_dir @log_level].each do |ivar|
+       @crypt_ready @cache_ready @llm_ready @llm_settings_ready @config_dir @log_level].each do |ivar|
       described_class.instance_variable_set(ivar, nil)
     end
   end
@@ -311,6 +329,108 @@ RSpec.describe Legion::CLI::Connection do
   end
 
   # ---------------------------------------------------------------------------
+  # ensure_llm_settings
+  # ---------------------------------------------------------------------------
+  describe '.ensure_llm_settings' do
+    before do
+      stub_logging_and_settings
+      allow(Legion::Settings).to receive(:merge_settings)
+      allow(Legion::LLM::Settings).to receive(:default).and_return({ daemon: { url: 'http://127.0.0.1:4567' } })
+      allow(Legion::LLM).to receive(:start)
+    end
+
+    it 'calls ensure_settings first' do
+      described_class.ensure_llm_settings
+      expect(Legion::Settings).to have_received(:load)
+    end
+
+    it 'merges the LLM defaults into the :llm namespace (populating daemon.url)' do
+      described_class.ensure_llm_settings
+      expect(Legion::Settings).to have_received(:merge_settings)
+        .with(:llm, { daemon: { url: 'http://127.0.0.1:4567' } })
+    end
+
+    it 'does NOT boot the local LLM stack (Legion::LLM.start)' do
+      described_class.ensure_llm_settings
+      expect(Legion::LLM).not_to have_received(:start)
+    end
+
+    it 'sets @llm_settings_ready to true' do
+      described_class.ensure_llm_settings
+      expect(described_class.instance_variable_get(:@llm_settings_ready)).to be(true)
+    end
+
+    it 'is idempotent: only merges once' do
+      described_class.ensure_llm_settings
+      described_class.ensure_llm_settings
+      expect(Legion::Settings).to have_received(:merge_settings).once
+    end
+
+    context 'when LoadError is raised (gem not available)' do
+      before { allow(Legion::LLM::Settings).to receive(:default).and_raise(LoadError, 'cannot load') }
+
+      it 'raises CLI::Error with gem install hint' do
+        expect { described_class.ensure_llm_settings }.to raise_error(
+          Legion::CLI::Error,
+          /legion-llm gem is not installed/
+        )
+      end
+    end
+
+    context 'when the merge fails with StandardError' do
+      before { allow(Legion::Settings).to receive(:merge_settings).and_raise(StandardError, 'bad schema') }
+
+      it 'raises CLI::Error with the settings failure message' do
+        expect { described_class.ensure_llm_settings }.to raise_error(
+          Legion::CLI::Error,
+          /LLM settings initialization failed: bad schema/
+        )
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ensure_llm (delegates the settings merge to ensure_llm_settings, then boots)
+  # ---------------------------------------------------------------------------
+  describe '.ensure_llm' do
+    before do
+      stub_logging_and_settings
+      allow(Legion::Settings).to receive(:merge_settings)
+      allow(Legion::LLM::Settings).to receive(:default).and_return({})
+      allow(Legion::LLM).to receive(:start)
+    end
+
+    it 'merges LLM defaults and boots the local LLM stack' do
+      described_class.ensure_llm
+      expect(Legion::Settings).to have_received(:merge_settings).with(:llm, {})
+      expect(Legion::LLM).to have_received(:start)
+    end
+
+    it 'sets both @llm_settings_ready and @llm_ready to true' do
+      described_class.ensure_llm
+      expect(described_class.instance_variable_get(:@llm_settings_ready)).to be(true)
+      expect(described_class.instance_variable_get(:@llm_ready)).to be(true)
+    end
+
+    it 'is idempotent: does not boot a second time' do
+      described_class.ensure_llm
+      described_class.ensure_llm
+      expect(Legion::LLM).to have_received(:start).once
+    end
+
+    context 'when Legion::LLM.start fails with StandardError' do
+      before { allow(Legion::LLM).to receive(:start).and_raise(StandardError, 'discovery failed') }
+
+      it 'raises CLI::Error with the initialization failure message' do
+        expect { described_class.ensure_llm }.to raise_error(
+          Legion::CLI::Error,
+          /LLM initialization failed: discovery failed/
+        )
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Predicate methods
   # ---------------------------------------------------------------------------
   describe '.settings?' do
@@ -352,6 +472,20 @@ RSpec.describe Legion::CLI::Connection do
       allow(Legion::Transport::Connection).to receive(:setup)
       described_class.ensure_transport
       expect(described_class.transport?).to be(true)
+    end
+  end
+
+  describe '.llm_settings?' do
+    it 'returns false when defaults have not been merged' do
+      expect(described_class.llm_settings?).to be(false)
+    end
+
+    it 'returns true after ensure_llm_settings succeeds' do
+      stub_logging_and_settings
+      allow(Legion::Settings).to receive(:merge_settings)
+      allow(Legion::LLM::Settings).to receive(:default).and_return({})
+      described_class.ensure_llm_settings
+      expect(described_class.llm_settings?).to be(true)
     end
   end
 


### PR DESCRIPTION
> **Stacked on #197.** This branch contains #197's commit (the daemon_client require-path fix) plus this change. Review the settings-merge commit here; once #197 merges, GitHub will reduce this diff to just this change.

## Summary
`legionio ask "..."` and `legionio chat prompt` aborted with
`LegionIO daemon is not running. Start it with: legionio start` even when the daemon
was running and reachable.

## Root cause
`Legion::CLI::Chat#setup_connection` called only `Connection.ensure_settings`, which
loads `Legion::Settings` but never merges `Legion::LLM::Settings.default`. The daemon
URL (`llm.daemon.url`) lives in the `:llm` settings namespace and is only populated by
that merge, so `Legion::LLM::Call::DaemonClient.available?` always returned `false` on
this path — the command aborted even with a live daemon. The only place that performed
the merge, `Connection.ensure_llm`, is not on the `ask`/`chat prompt` path (and it also
boots the full local LLM stack, which these daemon-routing commands don't need).

## Fix
Extract `Connection.ensure_llm_settings`: merge `Legion::LLM::Settings.default` into the
`:llm` namespace (populating `llm.daemon.url`) **without** booting the local LLM stack —
all the daemon-routing CLI paths require. `setup_connection` now calls
`ensure_llm_settings` before checking `DaemonClient.available?`; `ensure_llm` is
refactored to reuse it (no behavior change for full local init). Adds an
`llm_settings?` predicate and maps load/runtime failures to a clear `CLI::Error`.

## Dependency
Stacked on **#197** (the `daemon_client` require-path fix) — base branch
`fix/cli-ask-daemon-client-require`. The require fix is a prerequisite to even reach
`available?`.

## Verification
With #197 + this change applied to a running 1.9.36 daemon (apollo vLLM mesh serving a
model):

- **Before:** `legionio ask "..."` → `LegionIO daemon is not running...`
- **After:** `setup_connection` succeeds (no "daemon not running") and execution proceeds
  past the daemon gate — confirming `llm.daemon.url` is now populated and
  `DaemonClient.available?` resolves the live daemon.

Note: end-to-end `ask` then reaches a **separate, pre-existing downstream issue** in chat
tool loading (`uninitialized constant Legion::Tools`), independent of this change and
tracked separately. This PR's scope — making the daemon resolvable on the
`ask`/`chat prompt` path — is complete and verified by the before/after above.

Added specs: `setup_connection` calls `ensure_llm_settings`, and behaves correctly when
the daemon is available / unavailable.

## Notes
- Syntax-checked on all changed files; behavior verified end-to-end as above. The full
  rspec suite requires the `legion-*` path-gem bundle, which isn't installable in my
  environment.
