### PR TITLE
fix(cli): require legion/tools on the ask/chat-prompt path so chat tools load

### DIFF
--- a/lib/legion/cli/chat/daemon_chat.rb
+++ b/lib/legion/cli/chat/daemon_chat.rb
@@ -4,7 +4,7 @@ require 'securerandom'
 require 'legion/cli/chat_command'
 
 begin
-  require 'legion/llm/daemon_client'
+  require 'legion/llm/call/daemon_client'
 rescue LoadError
   # legion-llm not yet loaded; DaemonClient must be defined before DaemonChat#ask is called.
 end
@@ -118,7 +118,7 @@ module Legion
         private
 
         def call_daemon_inference
-          Legion::LLM::DaemonClient.inference(
+          Legion::LLM::Call::DaemonClient.inference(
             messages:        build_messages,
             tools:           build_tool_schemas,
             model:           @model.id,

--- a/lib/legion/cli/chat/tool_registry.rb
+++ b/lib/legion/cli/chat/tool_registry.rb
@@ -2,6 +2,21 @@
 
 require 'legion/cli/chat_command'
 
+# The chat tool classes below subclass Legion::Tools::Base, and
+# ExtensionToolLoader filters extension constants against it as well. On the
+# `ask` / `chat prompt` client path nothing boots Legion::Service, so neither
+# legion.rb nor legion/service.rb (the only files that require 'legion/tools')
+# has run, leaving Legion::Tools undefined. Require it here, before the tool
+# files load, or the first `require` below raises
+# `uninitialized constant Legion::Tools`.
+#
+# legion/tools eagerly loads Tools::Do/Status/Config, which `include
+# Legion::Logging::Helper` at class-definition time, so legion/logging must be
+# loaded first (it defines Helper) to keep the require order safe regardless of
+# how the registry is reached.
+require 'legion/logging'
+require 'legion/tools'
+
 require 'legion/cli/chat/tools/read_file'
 require 'legion/cli/chat/tools/write_file'
 require 'legion/cli/chat/tools/edit_file'

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -184,8 +184,8 @@ module Legion
           Connection.log_level = options[:verbose] ? 'debug' : 'error'
           Connection.ensure_settings
 
-          require 'legion/llm/daemon_client'
-          return if Legion::LLM::DaemonClient.available?
+          require 'legion/llm/call/daemon_client'
+          return if Legion::LLM::Call::DaemonClient.available?
 
           raise CLI::Error,
                 "LegionIO daemon is not running. Start it with: legionio start\n  " \

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -182,7 +182,10 @@ module Legion
         def setup_connection
           Connection.config_dir = options[:config_dir] if options[:config_dir]
           Connection.log_level = options[:verbose] ? 'debug' : 'error'
-          Connection.ensure_settings
+          # Merge LLM defaults (populates llm.daemon.url) so DaemonClient.available?
+          # can resolve the daemon. This is intentionally lighter than ensure_llm:
+          # we route through the daemon, so the local LLM stack is not booted here.
+          Connection.ensure_llm_settings
 
           require 'legion/llm/call/daemon_client'
           return if Legion::LLM::Call::DaemonClient.available?

--- a/lib/legion/cli/connection.rb
+++ b/lib/legion/cli/connection.rb
@@ -99,12 +99,29 @@ module Legion
           raise CLI::Error, 'lex-knowledge gem is not installed (gem install lex-knowledge)'
         end
 
-        def ensure_llm
-          return if @llm_ready
+        # Merge Legion::LLM::Settings.default into the :llm namespace without
+        # booting the local LLM stack. This is all the daemon-routing CLI paths
+        # (chat prompt / ask) need: the merge populates llm.daemon.url so
+        # Legion::LLM::Call::DaemonClient.available? can resolve the daemon.
+        # Full local init (providers, discovery, transports) is deliberately
+        # skipped — that work already happened in the running daemon.
+        def ensure_llm_settings
+          return if @llm_settings_ready
 
           ensure_settings
           require 'legion/llm'
           Legion::Settings.merge_settings(:llm, Legion::LLM::Settings.default)
+          @llm_settings_ready = true
+        rescue LoadError
+          raise CLI::Error, 'legion-llm gem is not installed (gem install legion-llm)'
+        rescue StandardError => e
+          raise CLI::Error, "LLM settings initialization failed: #{e.message}"
+        end
+
+        def ensure_llm
+          return if @llm_ready
+
+          ensure_llm_settings
           Legion::LLM.start
           @llm_ready = true
         rescue LoadError
@@ -127,6 +144,10 @@ module Legion
 
         def llm?
           @llm_ready == true
+        end
+
+        def llm_settings?
+          @llm_settings_ready == true
         end
 
         def shutdown

--- a/spec/legion/cli/chat/daemon_chat_spec.rb
+++ b/spec/legion/cli/chat/daemon_chat_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
   # Ensure the stub constant exists before each test.
   before do
-    unless defined?(Legion::LLM::DaemonClient)
+    unless defined?(Legion::LLM::Call::DaemonClient)
       stub_const('Legion::LLM', Module.new) unless defined?(Legion::LLM)
+      stub_const('Legion::LLM::Call', Module.new) unless defined?(Legion::LLM::Call)
       daemon_mod = Module.new
-      stub_const('Legion::LLM::DaemonClient', daemon_mod)
+      stub_const('Legion::LLM::Call::DaemonClient', daemon_mod)
     end
   end
 
@@ -28,7 +29,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         model:         'claude-sonnet-4-6'
       }
     }
-    allow(Legion::LLM::DaemonClient).to receive(:inference).and_return(result)
+    allow(Legion::LLM::Call::DaemonClient).to receive(:inference).and_return(result)
     result
   end
 
@@ -47,7 +48,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       stub_inference
       responses = []
       chat.ask('test') { |chunk| responses << chunk.content }
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(messages: array_including(hash_including(role: 'user', content: 'test')))
       )
     end
@@ -78,7 +79,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
     it 'passes caller and conversation_id to DaemonClient.inference' do
       stub_inference
       chat.ask('test')
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           caller:          hash_including(requested_by: hash_including(type: :human)),
           conversation_id: chat.conversation_id
@@ -95,7 +96,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       chat.with_instructions('You are a helpful assistant.')
       chat.ask('test')
 
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           messages: array_including(hash_including(role: 'system', content: 'You are a helpful assistant.'))
         )
@@ -121,7 +122,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       chat.with_tools(fake_tool)
       chat.ask('read something')
 
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           tools: array_including(hash_including(name: 'read_file'))
         )
@@ -154,7 +155,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       chat.add_message(role: :user, content: 'injected context')
       chat.ask('follow up')
 
-      expect(Legion::LLM::DaemonClient).to have_received(:inference).with(
+      expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).with(
         hash_including(
           messages: array_including(hash_including(role: 'user', content: 'injected context'))
         )
@@ -169,7 +170,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
       # After reset, only the new message should appear in the next inference call
       captured_messages = nil
-      allow(Legion::LLM::DaemonClient).to receive(:inference) do |messages:, **_|
+      allow(Legion::LLM::Call::DaemonClient).to receive(:inference) do |messages:, **_|
         captured_messages = messages
         {
           status: :immediate,
@@ -223,7 +224,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         }
       }
 
-      allow(Legion::LLM::DaemonClient).to receive(:inference)
+      allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
         .and_return(first_response, final_response)
 
       chat.with_tools(fake_tool)
@@ -257,7 +258,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         }
       }
 
-      allow(Legion::LLM::DaemonClient).to receive(:inference)
+      allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
         .and_return(first_response, final_response)
 
       chat.with_tools(fake_tool)
@@ -301,13 +302,13 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         stub_inference(content: 'follow up answer')
         chat.ask('follow up')
 
-        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+        expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).twice
       end
     end
 
     context 'when daemon returns an error status' do
       it 'raises CLI::Error' do
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return({ status: :error, error: 'connection refused' })
 
         expect { chat.ask('test') }.to raise_error(Legion::CLI::Error, /Daemon inference error/)
@@ -316,7 +317,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
     context 'when daemon is unavailable' do
       it 'raises CLI::Error' do
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return({ status: :unavailable })
 
         expect { chat.ask('test') }.to raise_error(Legion::CLI::Error, /unavailable/)
@@ -360,7 +361,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       end
 
       before do
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return(tool_call_response, final_response)
         chat.with_tools(fake_tool)
       end
@@ -368,7 +369,7 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       it 'loops until a non-tool response is received' do
         response = chat.ask('read main.rb')
         expect(response.content).to eq('Based on the file: it looks good.')
-        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+        expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).twice
       end
 
       it 'appends tool result messages to the conversation' do
@@ -376,17 +377,17 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
 
         # On the second call, messages should include the tool result
         second_call_messages = nil
-        allow(Legion::LLM::DaemonClient).to receive(:inference) do |messages:, **|
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference) do |messages:, **|
           second_call_messages ||= messages if second_call_messages.nil?
           final_response
         end
 
-        expect(Legion::LLM::DaemonClient).to have_received(:inference).twice
+        expect(Legion::LLM::Call::DaemonClient).to have_received(:inference).twice
       end
 
       it 'returns "Unknown tool: name" when tool is not registered' do
         chat.with_tools # clear tools
-        allow(Legion::LLM::DaemonClient).to receive(:inference)
+        allow(Legion::LLM::Call::DaemonClient).to receive(:inference)
           .and_return(tool_call_response, final_response)
 
         # Should not raise — returns graceful error string as tool result

--- a/spec/legion/cli/chat/tool_registry_spec.rb
+++ b/spec/legion/cli/chat/tool_registry_spec.rb
@@ -31,4 +31,41 @@ RSpec.describe Legion::CLI::Chat::ToolRegistry do
       expect(tools1).to eq(tools2)
     end
   end
+
+  # Regression guard for the `ask` / `chat prompt` client path.
+  #
+  # The chat tool files (Tools::ReadFile, etc.) subclass Legion::Tools::Base,
+  # but only legion.rb and legion/service.rb require 'legion/tools'. The CLI
+  # client path loads neither, so requiring this registry used to raise
+  # `uninitialized constant Legion::Tools`. tool_registry.rb must therefore
+  # pull in legion/tools itself.
+  #
+  # The spec suite loads the full `legion` entrypoint via spec_helper, which
+  # requires legion/tools as a side effect, so an in-process constant check
+  # cannot reproduce the failure. We assert the source-level contract instead:
+  # the registry must declare the require so the constant is satisfied on the
+  # client path where spec_helper's eager load is absent.
+  describe 'self-sufficiency on the CLI client path' do
+    let(:source) do
+      path = File.expand_path('../../../../lib/legion/cli/chat/tool_registry.rb', __dir__)
+      File.read(path)
+    end
+
+    it "requires 'legion/tools' before the chat tool files" do
+      tools_require   = source.index(%r{^\s*require ['"]legion/tools['"]})
+      first_tool_file = source.index(%r{^\s*require ['"]legion/cli/chat/tools/})
+
+      # nil here means the require is missing — Legion::Tools::Base would be
+      # undefined on the client path and requiring the registry would raise.
+      expect(tools_require).not_to be_nil
+      expect(tools_require).to be < first_tool_file
+    end
+
+    it 'resolves Legion::Tools::Base as the superclass of every builtin tool' do
+      expect(defined?(Legion::Tools::Base)).to eq('constant')
+      described_class.builtin_tools.each do |tool|
+        expect(tool.ancestors).to include(Legion::Tools::Base)
+      end
+    end
+  end
 end

--- a/spec/legion/cli/chat_command_spec.rb
+++ b/spec/legion/cli/chat_command_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 require 'legion/cli'
+require 'legion/cli/connection'
+require 'legion/llm/call/daemon_client'
 
 RSpec.describe Legion::CLI::Chat do
   it 'is defined as a Thor subcommand' do
@@ -14,5 +16,40 @@ RSpec.describe Legion::CLI::Chat do
 
   it 'has a prompt command for headless mode' do
     expect(Legion::CLI::Chat.instance_methods).to include(:prompt)
+  end
+
+  describe '#setup_connection' do
+    subject(:chat) { described_class.new([], options) }
+
+    let(:options) { {} }
+
+    before do
+      allow(Legion::CLI::Connection).to receive(:ensure_llm_settings)
+      allow(Legion::LLM::Call::DaemonClient).to receive(:available?).and_return(true)
+    end
+
+    # Regression guard: the daemon URL lives under the :llm settings namespace,
+    # which is only populated by merging Legion::LLM::Settings.default. Before the
+    # fix, setup_connection called only ensure_settings, so llm.daemon.url was
+    # never set and DaemonClient.available? returned false even with a live daemon.
+    it 'merges the LLM defaults via ensure_llm_settings before checking the daemon' do
+      chat.send(:setup_connection)
+      expect(Legion::CLI::Connection).to have_received(:ensure_llm_settings)
+    end
+
+    it 'returns without raising when the daemon is available' do
+      expect { chat.send(:setup_connection) }.not_to raise_error
+    end
+
+    context 'when the daemon is not available' do
+      before { allow(Legion::LLM::Call::DaemonClient).to receive(:available?).and_return(false) }
+
+      it 'raises CLI::Error instructing the user to start the daemon' do
+        expect { chat.send(:setup_connection) }.to raise_error(
+          Legion::CLI::Error,
+          /daemon is not running/
+        )
+      end
+    end
   end
 end

--- a/spec/legion/cli/connection_spec.rb
+++ b/spec/legion/cli/connection_spec.rb
@@ -27,10 +27,28 @@ end
 require 'legion/crypt'
 require 'legion/cache'
 
+# Pre-load legion-llm (or stub it) so Legion::LLM and Legion::LLM::Settings
+# exist before the mocks below are attached — same rationale as legion-data.
+begin
+  require 'legion/llm'
+rescue LoadError
+  module Legion
+    module LLM
+      module Settings
+        def self.default = {}
+      end
+
+      def self.start(**) = nil
+      def self.shutdown(**) = nil
+    end
+  end
+  $LOADED_FEATURES << 'legion/llm'
+end
+
 RSpec.describe Legion::CLI::Connection do
   before do
     %i[@logging_ready @settings_ready @data_ready @transport_ready
-       @crypt_ready @cache_ready @llm_ready @config_dir @log_level].each do |ivar|
+       @crypt_ready @cache_ready @llm_ready @llm_settings_ready @config_dir @log_level].each do |ivar|
       described_class.instance_variable_set(ivar, nil)
     end
   end
@@ -311,6 +329,108 @@ RSpec.describe Legion::CLI::Connection do
   end
 
   # ---------------------------------------------------------------------------
+  # ensure_llm_settings
+  # ---------------------------------------------------------------------------
+  describe '.ensure_llm_settings' do
+    before do
+      stub_logging_and_settings
+      allow(Legion::Settings).to receive(:merge_settings)
+      allow(Legion::LLM::Settings).to receive(:default).and_return({ daemon: { url: 'http://127.0.0.1:4567' } })
+      allow(Legion::LLM).to receive(:start)
+    end
+
+    it 'calls ensure_settings first' do
+      described_class.ensure_llm_settings
+      expect(Legion::Settings).to have_received(:load)
+    end
+
+    it 'merges the LLM defaults into the :llm namespace (populating daemon.url)' do
+      described_class.ensure_llm_settings
+      expect(Legion::Settings).to have_received(:merge_settings)
+        .with(:llm, { daemon: { url: 'http://127.0.0.1:4567' } })
+    end
+
+    it 'does NOT boot the local LLM stack (Legion::LLM.start)' do
+      described_class.ensure_llm_settings
+      expect(Legion::LLM).not_to have_received(:start)
+    end
+
+    it 'sets @llm_settings_ready to true' do
+      described_class.ensure_llm_settings
+      expect(described_class.instance_variable_get(:@llm_settings_ready)).to be(true)
+    end
+
+    it 'is idempotent: only merges once' do
+      described_class.ensure_llm_settings
+      described_class.ensure_llm_settings
+      expect(Legion::Settings).to have_received(:merge_settings).once
+    end
+
+    context 'when LoadError is raised (gem not available)' do
+      before { allow(Legion::LLM::Settings).to receive(:default).and_raise(LoadError, 'cannot load') }
+
+      it 'raises CLI::Error with gem install hint' do
+        expect { described_class.ensure_llm_settings }.to raise_error(
+          Legion::CLI::Error,
+          /legion-llm gem is not installed/
+        )
+      end
+    end
+
+    context 'when the merge fails with StandardError' do
+      before { allow(Legion::Settings).to receive(:merge_settings).and_raise(StandardError, 'bad schema') }
+
+      it 'raises CLI::Error with the settings failure message' do
+        expect { described_class.ensure_llm_settings }.to raise_error(
+          Legion::CLI::Error,
+          /LLM settings initialization failed: bad schema/
+        )
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # ensure_llm (delegates the settings merge to ensure_llm_settings, then boots)
+  # ---------------------------------------------------------------------------
+  describe '.ensure_llm' do
+    before do
+      stub_logging_and_settings
+      allow(Legion::Settings).to receive(:merge_settings)
+      allow(Legion::LLM::Settings).to receive(:default).and_return({})
+      allow(Legion::LLM).to receive(:start)
+    end
+
+    it 'merges LLM defaults and boots the local LLM stack' do
+      described_class.ensure_llm
+      expect(Legion::Settings).to have_received(:merge_settings).with(:llm, {})
+      expect(Legion::LLM).to have_received(:start)
+    end
+
+    it 'sets both @llm_settings_ready and @llm_ready to true' do
+      described_class.ensure_llm
+      expect(described_class.instance_variable_get(:@llm_settings_ready)).to be(true)
+      expect(described_class.instance_variable_get(:@llm_ready)).to be(true)
+    end
+
+    it 'is idempotent: does not boot a second time' do
+      described_class.ensure_llm
+      described_class.ensure_llm
+      expect(Legion::LLM).to have_received(:start).once
+    end
+
+    context 'when Legion::LLM.start fails with StandardError' do
+      before { allow(Legion::LLM).to receive(:start).and_raise(StandardError, 'discovery failed') }
+
+      it 'raises CLI::Error with the initialization failure message' do
+        expect { described_class.ensure_llm }.to raise_error(
+          Legion::CLI::Error,
+          /LLM initialization failed: discovery failed/
+        )
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Predicate methods
   # ---------------------------------------------------------------------------
   describe '.settings?' do
@@ -352,6 +472,20 @@ RSpec.describe Legion::CLI::Connection do
       allow(Legion::Transport::Connection).to receive(:setup)
       described_class.ensure_transport
       expect(described_class.transport?).to be(true)
+    end
+  end
+
+  describe '.llm_settings?' do
+    it 'returns false when defaults have not been merged' do
+      expect(described_class.llm_settings?).to be(false)
+    end
+
+    it 'returns true after ensure_llm_settings succeeds' do
+      stub_logging_and_settings
+      allow(Legion::Settings).to receive(:merge_settings)
+      allow(Legion::LLM::Settings).to receive(:default).and_return({})
+      described_class.ensure_llm_settings
+      expect(described_class.llm_settings?).to be(true)
     end
   end
 


### PR DESCRIPTION
## Summary

`legionio ask "..."` (and its long form `legionio chat prompt "..."`) aborts with:

```
Error: uninitialized constant Legion::Tools
```

once the daemon gate is passed. This happens because the chat tool registry loads the
built-in chat tools — each defined as `class X < Legion::Tools::Base` — without ever
requiring `legion/tools`, which is the file that defines `Legion::Tools` and
`Legion::Tools::Base`.

This PR requires `legion/tools` (preceded by `legion/logging`) at the top of
`lib/legion/cli/chat/tool_registry.rb`, before the tool files load.

This is the third fix in the `ask` chain and **stacks on the two preceding PRs** (see
*Dependencies* below).

## Root cause

The `ask` path runs in the lightweight CLI client process and never boots
`Legion::Service`:

- `exe/legionio` requires `legion/cli`. `legion/cli.rb` requires only Thor and a handful of
  CLI files (`output`, `connection`, `error*`); it does **not** require `legion.rb` or
  `legion/tools`.
- `ask` maps to `Legion::CLI::Chat.start(['prompt', ...])`. `Chat#prompt` runs
  `setup_connection`, then `create_chat`, which does
  `require 'legion/cli/chat/tool_registry'`.
- `tool_registry.rb` then `require`s every `lib/legion/cli/chat/tools/*.rb`. The very first,
  `read_file.rb`, evaluates `class ReadFile < Legion::Tools::Base`. It also lazily loads
  `extension_tool_loader.rb`, which references `Legion::Tools::Base` at line 27.
- `Legion::Tools` lives in `lib/legion/tools.rb` (with `lib/legion/tools/base.rb`), but the
  only files that `require 'legion/tools'` are `legion.rb` and `legion/service.rb` — both
  daemon / full-boot paths. Neither is loaded on the CLI client path.

So the superclass reference resolves against an undefined constant and Ruby raises
`uninitialized constant Legion::Tools`.

**Why CI/specs did not catch it:** `spec/spec_helper.rb` requires `legion`, which
transitively requires `legion/tools`. In the test process `Legion::Tools::Base` is therefore
always already defined, so `spec/legion/cli/chat/tool_registry_spec.rb` passes even though the
real CLI client process fails. The failure only reproduces where `legion` itself is not
eagerly loaded — i.e. the actual `ask` / `chat prompt` client path.

## Fix

In `lib/legion/cli/chat/tool_registry.rb`, before the `chat/tools/*` requires:

```ruby
require 'legion/logging'
require 'legion/tools'
```

- `legion/tools` defines `Legion::Tools` / `Legion::Tools::Base`, satisfying both the
  built-in tool files and `ExtensionToolLoader`.
- `legion/logging` is required first because `legion/tools.rb` eagerly loads
  `Tools::Do`, `Tools::Status`, and `Tools::Config`, which `include Legion::Logging::Helper`
  at class-definition time. `legion/logging.rb` defines `Helper`, so loading it first keeps
  the require order valid no matter how the registry is reached. (This matches the existing
  precedent in commit *"Load logging before extension helpers."*)

`tool_registry.rb` is the right place rather than `extension_tool_loader.rb`: the built-in
tool files load there first and unconditionally, while the loader is required lazily
afterwards — so fixing the registry covers both consumers, and only the registry is needed
on the minimal path.

The added requires are cheap and side-effect-free for the CLI: `legion/tools` and its eager
submodules pull in only stdlib (`digest`, `time`, `securerandom`); `legion/logging` adds
`json`, `logger`, and `rainbow`. No daemon, transport, or database code is loaded.

## Dependencies

This change is the top of the `ask`-chain stack and should merge **after** both preceding fixes:

1. **#197** — `fix(cli): correct daemon_client require path after legion-llm restructure`.
2. **#198** — `fix(cli): merge LLM settings on the ask/chat-prompt path so the daemon resolves`.

This PR's branch (`fix/cli-ask-chat-tools-require`) is stacked on #198's branch, so against
`main` its diff shows all three commits (#197 → #198 → this) until the lower PRs merge, after
which GitHub reduces it to just this change. Please merge #197 and #198 first.

## Verification

Error progression along the `ask` chain (each fix uncovers the next bug):

| Stage | Command | Result |
|------|---------|--------|
| Bugs 1+2 only | `legionio ask "say hi in 3 words"` | `Error: uninitialized constant Legion::Tools` (raised while requiring `legion/cli/chat/tools/read_file` from `tool_registry.rb`) |
| + this fix | `legionio ask "say hi in exactly 3 words"` | **Returns a model reply — `Hello there friend!`** Tool registry loads, `create_chat` succeeds, the request routes through the daemon to the LLM, and the response prints. |

**Verified live** against a running 1.9.36 daemon (apollo vLLM mesh) with all three `ask`-chain fixes applied: `legionio ask "say hi in exactly 3 words"` → `Hello there friend!`.

Static trace confirming the root cause and the fix:

- `legion/cli.rb` does not require `legion.rb` / `legion/tools`; only `legion.rb:14` and
  `legion/service.rb:999` require `legion/tools`, neither on the CLI path.
- `chat_command.rb#create_chat` requires `legion/cli/chat/tool_registry`, which requires the
  `chat/tools/*` files that subclass `Legion::Tools::Base`.
- After the fix, `Legion::Tools::Base` is defined before those requires run.
- The eager `Tools::Do/Status/Config` `include Legion::Logging::Helper`; `legion/logging`
  (required first) defines `Helper`, so the require order is safe.

Downstream of `create_chat`, `daemon_chat.rb` calls `Legion::LLM::Call::DaemonClient.inference`;
that constant is already loaded unconditionally by `setup_connection` (PR-E) via
`require 'legion/llm/call/daemon_client'` before `create_chat` runs, so there is no further
missing-require hazard on this path.

To reproduce/confirm locally against a running daemon:

```
legionio ask "say hi in 3 words"
```

It should return/stream a short model reply instead of the `Legion::Tools` error. (The
configured model has "thinking" enabled and may take a while; partial/streaming output is
expected and sufficient.)

## Tests

Extended `spec/legion/cli/chat/tool_registry_spec.rb` with a regression group,
*"self-sufficiency on the CLI client path"*:

- asserts `tool_registry.rb` requires `legion/tools` **before** the `chat/tools/*` requires.
  This is the assertion that genuinely fails on the base branch — because `spec_helper`
  eagerly loads `legion`, an in-process constant check cannot reproduce the runtime failure,
  so the test verifies the source-level contract that guarantees the constant on the client
  path;
- asserts `Legion::Tools::Base` resolves and is an ancestor of every built-in tool.

## Notes

- Minimal, additive change: two `require`s plus an explanatory comment in
  `tool_registry.rb`, and one spec group. No behavior change for the daemon/full-boot paths,
  where `legion/tools` is already loaded (Ruby `require` is idempotent).
- The new requires are intentionally placed in the registry rather than threaded through
  `legion/cli.rb`, to keep the CLI boot path lean — `legion/tools` loads only when chat
  tooling is actually needed.
