### PR TITLE
fix: require legion-llm >= 0.10.1 for agentic tool loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion Changelog
 
+## [1.9.38] - 2026-05-30
+
+### Fixed
+- Gemspec: require legion-llm >= 0.10.1 (message translation, streaming, curator fixes required for Claude Code and Codex CLI agentic tool loops via vLLM)
+
 ## [1.9.37] - 2026-05-29
 
 ### Added

--- a/legionio.gemspec
+++ b/legionio.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'legion-apollo', '>= 0.4.0'
   spec.add_dependency 'legion-gaia', '>= 0.9.26'
-  spec.add_dependency 'legion-llm', '>= 0.9.1'
+  spec.add_dependency 'legion-llm', '>= 0.10.1'
   spec.add_dependency 'legion-tty', '>= 0.5.4'
   spec.add_dependency 'lex-node'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.37'
+  VERSION = '1.9.38'
 end


### PR DESCRIPTION
## Summary
- Bump minimum `legion-llm` dependency from `>= 0.9.1` to `>= 0.10.1`
- Version bump 1.9.37 → 1.9.38

## Why
The brew-installed LegionIO was pulling legion-llm 0.8.47 which lacks the critical message format translation fixes. Without 0.10.1+, the Anthropic namespace endpoint sends malformed messages to vLLM causing tool-calling failures (escalation exhausted errors).

## Test plan
- [x] `bundle exec legionio start` + `claude-legionio` works (local path gem)
- [x] After brew rebuild with this constraint, `legionio start` will pull the correct gem version