### PR TITLE
fix: remove --clear-sources from gem install (breaks pack reinstall)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion Changelog
 
+## [1.9.39] - 2026-05-30
+
+### Fixed
+- CLI: remove `--clear-sources` from `gem install` in bootstrap and setup commands (breaks pack reinstall when custom sources are configured)
+
 ## [1.9.38] - 2026-05-30
 
 ### Fixed

--- a/lib/legion/cli/bootstrap_command.rb
+++ b/lib/legion/cli/bootstrap_command.rb
@@ -293,7 +293,7 @@ module Legion
 
         def install_single_gem(name, gem_bin, out)
           puts "  Installing #{name}..." unless options[:json]
-          output, success = shell_capture("#{gem_bin} install #{name} --no-document --clear-sources --source https://rubygems.org/")
+          output, success = shell_capture("#{gem_bin} install #{name} --no-document --source https://rubygems.org/")
           if success
             out.success("  #{name} installed") unless options[:json]
             { name: name, status: 'installed' }

--- a/lib/legion/cli/setup_command.rb
+++ b/lib/legion/cli/setup_command.rb
@@ -501,7 +501,7 @@ module Legion
 
         def install_gem(name, gem_bin, out)
           puts "  Installing #{name}..." unless options[:json]
-          output = `#{gem_bin} install #{name} --no-document --clear-sources --source https://rubygems.org/ 2>&1`
+          output = `#{gem_bin} install #{name} --no-document --source https://rubygems.org/ 2>&1`
           if $CHILD_STATUS.success?
             out.success("  #{name} installed") unless options[:json]
             { name: name, status: 'installed' }

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.38'
+  VERSION = '1.9.39'
 end

--- a/spec/cli/bootstrap_command_spec.rb
+++ b/spec/cli/bootstrap_command_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe Legion::CLI::Bootstrap do
     context 'when gem installs successfully' do
       before do
         allow(cli).to receive(:shell_capture)
-          .with('/usr/bin/gem install lex-foo --no-document --clear-sources --source https://rubygems.org/')
+          .with('/usr/bin/gem install lex-foo --no-document --source https://rubygems.org/')
           .and_return(['Successfully installed lex-foo-0.1.0', true])
       end
 
@@ -410,7 +410,7 @@ RSpec.describe Legion::CLI::Bootstrap do
     context 'when gem install fails' do
       before do
         allow(cli).to receive(:shell_capture)
-          .with('/usr/bin/gem install lex-foo --no-document --clear-sources --source https://rubygems.org/')
+          .with('/usr/bin/gem install lex-foo --no-document --source https://rubygems.org/')
           .and_return(["ERROR: Could not find gem 'lex-foo'", false])
       end
 


### PR DESCRIPTION
## What

Brief description of the change.

## Why

What problem does this solve or what feature does it add?

## Checklist

- [ ] Tests pass (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] No new security concerns introduced
