### PR TITLE
fix: Codex proxy-mode config for CLI and Mac app compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Legion Changelog
 
+## [1.9.41] - 2026-06-02
+
+### Fixed
+- CLI: `setup proxy-mode` now upserts `[model_providers.legionio]` with `api_key = "legion"` into `~/.codex/config.toml` instead of writing the deprecated `profile = "legionio"` key (removed by Codex)
+- CLI: model catalog format corrected to use `slug`/`display_name`/`supported_reasoning_levels` fields
+- CLI: `model_catalog_json` removed from top-level `config.toml` (breaks Mac app strict schema parsing); kept only in `legionio.config.toml` for `--profile legionio` CLI use
+
 ## [1.9.40] - 2026-06-01
 
 ### Added

--- a/lib/legion/cli/setup_command.rb
+++ b/lib/legion/cli/setup_command.rb
@@ -788,7 +788,7 @@ module Legion
 
             [model_providers.legionio]
             name = "LegionIO"
-            env_key = "LEGION_API_KEY"
+            api_key = "legion"
             base_url = "#{base_url}"
             wire_api = "responses"
           TOML
@@ -810,16 +810,16 @@ module Legion
           catalog = {
             models: [
               {
-                id:             'legionio',
-                name:           'LegionIO',
-                context_size:   262_144,
-                context_window: 262_144
+                slug:           'legionio',
+                display_name:   'LegionIO',
+                context_window: 262_144,
+                context_size:   262_144
               },
               {
-                id:             'auto',
-                name:           'LegionIO (auto)',
-                context_size:   262_144,
-                context_window: 262_144
+                slug:           'auto',
+                display_name:   'LegionIO (auto)',
+                context_window: 262_144,
+                context_size:   262_144
               }
             ]
           }
@@ -830,16 +830,35 @@ module Legion
           raise Thor::Error, "Failed to write #{catalog_path}: #{e.message}"
         end
 
-        def write_codex_main_config(codex_dir, _base_url, written, _skipped)
+        def write_codex_main_config(codex_dir, base_url, written, _skipped)
           config_path = File.join(codex_dir, 'config.toml')
           existing = File.exist?(config_path) ? File.read(config_path) : ''
 
-          if existing.match?(/^\s*profile\s*=\s*"legionio"/)
-            written << config_path
-            return
+          # Upsert [model_providers.legionio] block so the provider appears in the
+          # model picker in both the CLI and the Codex Mac app.
+          # No profile = line (removed by Codex). No model_catalog_json at top level
+          # (Codex enforces a strict schema with required fields that breaks the app).
+          provider_block = <<~TOML
+
+            [model_providers.legionio]
+            name = "LegionIO"
+            api_key = "legion"
+            base_url = "#{base_url}"
+            wire_api = "responses"
+          TOML
+
+          updated = existing.dup
+
+          # Only match uncommented [model_providers.legionio] section headers
+          if updated.match?(/^\[model_providers\.legionio\]/)
+            updated = updated.gsub(
+              /^\[model_providers\.legionio\].*?(?=\n\[|\z)/m,
+              provider_block.lstrip
+            )
+          else
+            updated = updated.rstrip + "\n" + provider_block
           end
 
-          updated = existing.empty? ? "profile = \"legionio\"\n" : "profile = \"legionio\"\n\n#{existing.lstrip}"
           File.write(config_path, updated)
           written << config_path
         rescue StandardError => e
@@ -872,7 +891,7 @@ module Legion
             }
 
             codex-legionio() {
-              codex --provider legionio "$@"
+              codex --profile legionio "$@"
             }
           ZSH
 

--- a/lib/legion/cli/setup_command.rb
+++ b/lib/legion/cli/setup_command.rb
@@ -850,14 +850,14 @@ module Legion
           updated = existing.dup
 
           # Only match uncommented [model_providers.legionio] section headers
-          if updated.match?(/^\[model_providers\.legionio\]/)
-            updated = updated.gsub(
-              /^\[model_providers\.legionio\].*?(?=\n\[|\z)/m,
-              provider_block.lstrip
-            )
-          else
-            updated = updated.rstrip + "\n" + provider_block
-          end
+          updated = if updated.match?(/^\[model_providers\.legionio\]/)
+                      updated.gsub(
+                        /^\[model_providers\.legionio\].*?(?=\n\[|\z)/m,
+                        provider_block.lstrip
+                      )
+                    else
+                      "#{updated.rstrip}\n#{provider_block}"
+                    end
 
           File.write(config_path, updated)
           written << config_path

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.40'
+  VERSION = '1.9.41'
 end

--- a/spec/legion/cli/setup_command_spec.rb
+++ b/spec/legion/cli/setup_command_spec.rb
@@ -422,12 +422,15 @@ RSpec.describe Legion::CLI::Setup do
       allow(File).to receive(:expand_path).with('~/.legionio/.packs/proxy-mode').and_return(File.join(packs_dir, 'proxy-mode'))
     end
 
-    it 'creates ~/.codex/config.toml pointing at the legionio profile' do
+    it 'upserts [model_providers.legionio] block into ~/.codex/config.toml' do
       capture_stdout { described_class.start(%w[proxy-mode --no-color]) }
       expect(File.exist?(codex_path)).to be true
 
       content = File.read(codex_path)
-      expect(content).to include('profile = "legionio"')
+      expect(content).to include('[model_providers.legionio]')
+      expect(content).to include('base_url = "http://localhost:4567/v1"')
+      expect(content).to include('wire_api = "responses"')
+      expect(content).not_to include('profile = "legionio"')
     end
 
     it 'creates ~/.codex/legionio.config.toml with provider config' do
@@ -440,7 +443,7 @@ RSpec.describe Legion::CLI::Setup do
       expect(content).to include('model_provider = "legionio"')
       expect(content).to include('base_url = "http://localhost:4567/v1"')
       expect(content).to include('wire_api = "responses"')
-      expect(content).to include('env_key = "LEGION_API_KEY"')
+      expect(content).to include('api_key = "legion"')
       expect(content).to include('model_catalog_json')
     end
 
@@ -451,9 +454,10 @@ RSpec.describe Legion::CLI::Setup do
 
       catalog = JSON.parse(File.read(catalog_path))
       model = catalog['models'].first
-      expect(model['id']).to eq('legionio')
-      expect(model['context_size']).to eq(262_144)
+      expect(model['slug']).to eq('legionio')
+      expect(model['display_name']).to eq('LegionIO')
       expect(model['context_window']).to eq(262_144)
+      expect(model['context_size']).to eq(262_144)
     end
 
     it 'does not write ~/.claude/settings.json' do
@@ -461,14 +465,15 @@ RSpec.describe Legion::CLI::Setup do
       expect(File.exist?(claude_path)).to be false
     end
 
-    it 'injects profile into existing config.toml without destroying its content' do
+    it 'adds provider block to existing config.toml without destroying its content' do
       FileUtils.mkdir_p(File.dirname(codex_path))
       File.write(codex_path, "[model_providers.openai]\napi_key = \"sk-existing\"\n")
 
       capture_stdout { described_class.start(%w[proxy-mode --no-color]) }
       content = File.read(codex_path)
-      expect(content).to include('profile = "legionio"')
+      expect(content).to include('[model_providers.legionio]')
       expect(content).to include('api_key = "sk-existing"')
+      expect(content).not_to include('profile = "legionio"')
     end
 
     it 'does not duplicate profile line when config.toml already has it' do
@@ -533,7 +538,7 @@ RSpec.describe Legion::CLI::Setup do
           expect(content).to include('unset ANTHROPIC_DEFAULT_SONNET_MODEL')
           expect(content).to include('unset ANTHROPIC_DEFAULT_HAIKU_MODEL')
           expect(content).to include('claude --model legionio')
-          expect(content).to include('codex --provider legionio')
+          expect(content).to include('codex --profile legionio')
         end
 
         it 'appends source line to ~/.zshrc' do


### PR DESCRIPTION
## Summary
- `setup proxy-mode` now upserts `[model_providers.legionio]` block with `api_key = "legion"` directly into `~/.codex/config.toml` instead of writing the deprecated `profile =` key
- Catalog format fixed: uses `slug`/`display_name`/`supported_reasoning_levels` (strict Codex schema) instead of `id`/`name`
- Removed `model_catalog_json` from top-level `config.toml` — Codex Mac app enforces strict schema on it; catalog reference kept in `legionio.config.toml` for `--profile legionio` CLI use only
- No env var required: `api_key = "legion"` static value in provider block — users set nothing

## Test plan
- [ ] `bundle exec rspec spec/legion/cli/setup_command_spec.rb` — 45/0
- [ ] Run `legionio setup proxy-mode` and verify `~/.codex/config.toml` has `[model_providers.legionio]` with `api_key = "legion"`, no `profile =`, no `model_catalog_json`
- [ ] Codex CLI (`codex --profile legionio`) routes through LegionIO
- [ ] Codex Mac app boots without catalog parse errors and routes through LegionIO