### PR TITLE
fix(api): replace deleted TokenCache with TokenManager for Teams auth (fixes #229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Legion Changelog
 
+## [1.9.43] - 2026-06-25
+
+### Fixed
+- API: replaced deleted `MicrosoftTeams::Helpers::TokenCache` reference in `AuthTeams` with `Identity::Entra::Helpers::TokenManager.save_token`, fixing `legionio auth` failures (fixes #229)
+
+
 ## [1.9.42] - 2026-06-07
 
 ### Performance

--- a/lib/legion/api/auth_teams.rb
+++ b/lib/legion/api/auth_teams.rb
@@ -129,15 +129,14 @@ module Legion
 
         module TeamsTokenHelper
           def store_teams_token(token_body, scopes)
-            require 'legion/extensions/microsoft_teams/helpers/token_cache'
-            cache = Legion::Extensions::MicrosoftTeams::Helpers::TokenCache.new
-            cache.store_delegated_token(
+            require 'legion/extensions/identity/entra/helpers/token_manager'
+            Legion::Extensions::Identity::Entra::Helpers::TokenManager.save_token(
+              :delegated,
               access_token:  token_body[:access_token],
               refresh_token: token_body[:refresh_token],
               expires_in:    token_body[:expires_in] || 3600,
               scopes:        scopes
             )
-            cache.save_to_vault
             Legion::Logging.info 'Teams delegated token stored' if defined?(Legion::Logging)
           rescue StandardError => e
             Legion::Logging.warn "Failed to store Teams token: #{e.message}" if defined?(Legion::Logging)

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.42'
+  VERSION = '1.9.43'
 end


### PR DESCRIPTION
## Problem

```
cannot load such file -- legion/extensions/microsoft_teams/helpers/token_cache
```

 `lex-microsoft_teams` 0.6.52 removed `helpers/token_cache.rb` and migrated token storage to `lex-identity-entra`'s `TokenManager`. The `TeamsTokenHelper` in `auth_teams.rb` was never updated.

## Fix

Replaced `MicrosoftTeams::Helpers::TokenCache` with `Identity::Entra::Helpers::TokenManager.save_token` which handles vault → local → memory token storage in one call.

## Verification

- **rspec:** 5137 examples, 0 failures, 6 pending (pre-existing Azure Foundry skips)
- **rubocop -A:** 914 files, 0 offenses

Closes #229 