### PR TITLE
fix(cli+api): connect status + Teams OAuth token store (fixes #213, #212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion Changelog
 
+## [1.9.45] - 2026-07-02
+
+### Fixed
+- API: Teams delegated OAuth callback now forwards `tenant_id`/`client_id` to `Entra::Helpers::TokenManager.save_token(:delegated, …)` so browser-login tokens can be refreshed (previously omitted, forcing refresh to fall back to settings and silently fail for delegated-only logins). The unshipped `TokenCache` `require` that 500'd the callback was already removed in 1.9.43 (fixes #212)
+
 ## [1.9.44] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Legion Changelog
 
+## [1.9.44] - 2026-07-01
+
+### Fixed
+- CLI: `connect status` now reads the Entra `TokenManager` (`token_data(:delegated)` + `expired?`) for the `microsoft` provider instead of the legacy `Legion::Auth::TokenManager` secret store, which the delegated/Teams login never writes to — previously always reported `microsoft: not connected` after a successful login (fixes #213)
+- CLI: `connect microsoft` now forwards `--tenant_id`/`--client_id`/`--scope` (as `--scopes`) explicitly to the Teams auth flow instead of dropping flag values via `ARGV.select`
+
 ## [1.9.43] - 2026-06-25
 
 ### Fixed

--- a/lib/legion/api/auth_teams.rb
+++ b/lib/legion/api/auth_teams.rb
@@ -107,8 +107,9 @@ module Legion
             token_body = Legion::JSON.load(token_response.body)
 
             if token_body[:access_token]
-              # Store token via TokenCache if available
-              store_teams_token(token_body, entry[:scopes])
+              # Persist via the Entra TokenManager (the store the read path consults)
+              store_teams_token(token_body, entry[:scopes],
+                                tenant_id: entry[:tenant_id], client_id: entry[:client_id])
               AuthTeams.mutex.synchronize { entry[:result] = { authenticated: true } }
               content_type :html
               '<html><body><h2>Authentication successful!</h2><p>You can close this tab.</p></body></html>'
@@ -128,14 +129,16 @@ module Legion
         end
 
         module TeamsTokenHelper
-          def store_teams_token(token_body, scopes)
+          def store_teams_token(token_body, scopes, tenant_id: nil, client_id: nil)
             require 'legion/extensions/identity/entra/helpers/token_manager'
             Legion::Extensions::Identity::Entra::Helpers::TokenManager.save_token(
               :delegated,
               access_token:  token_body[:access_token],
               refresh_token: token_body[:refresh_token],
               expires_in:    token_body[:expires_in] || 3600,
-              scopes:        scopes
+              scopes:        scopes,
+              tenant_id:     tenant_id,
+              client_id:     client_id
             )
             Legion::Logging.info 'Teams delegated token stored' if defined?(Legion::Logging)
           rescue StandardError => e

--- a/lib/legion/cli/connect_command.rb
+++ b/lib/legion/cli/connect_command.rb
@@ -8,6 +8,7 @@ module Legion
       namespace :connect
 
       PROVIDERS = %w[microsoft github google].freeze
+      STATE_COLORS = { 'connected' => :green, 'revoked' => :red, 'not connected' => :yellow }.freeze
 
       desc 'microsoft', 'Connect a Microsoft account (OAuth2 delegated auth)'
       method_option :tenant_id,  type: :string, desc: 'Azure tenant ID'
@@ -17,7 +18,11 @@ module Legion
       method_option :no_browser, type: :boolean, default: false, desc: 'Print URL instead of launching browser'
       def microsoft
         say 'Delegating to Teams OAuth2 browser auth...', :blue
-        Legion::CLI::Auth.start(['teams'] + ARGV.select { |a| a.start_with?('--') })
+        forwarded = ['teams']
+        forwarded += ['--tenant_id', options[:tenant_id]] if options[:tenant_id]
+        forwarded += ['--client_id', options[:client_id]] if options[:client_id]
+        forwarded += ['--scopes', options[:scope]] if options[:scope]
+        Legion::CLI::Auth.start(forwarded)
       end
 
       desc 'github', 'Connect a GitHub account (OAuth2 device flow)'
@@ -31,14 +36,8 @@ module Legion
         require 'legion/auth/token_manager'
 
         PROVIDERS.each do |provider|
-          manager = Legion::Auth::TokenManager.new(provider: provider.to_sym)
-          if manager.token_valid?
-            say "  #{provider}: connected", :green
-          elsif manager.revoked?
-            say "  #{provider}: revoked", :red
-          else
-            say "  #{provider}: not connected", :yellow
-          end
+          state = provider_state(provider)
+          say "  #{provider}: #{state}", STATE_COLORS.fetch(state, :yellow)
         end
       end
 
@@ -50,6 +49,32 @@ module Legion
         end
 
         say "Disconnected #{provider} account.", :green
+      end
+
+      no_commands do
+        # Microsoft delegated login writes tokens via the Entra TokenManager
+        # (vault/local/memory), not the legacy Legion::Auth secret store — so
+        # status for :microsoft must consult the Entra store to avoid always
+        # reporting 'not connected' after a successful Teams/delegated login.
+        def provider_state(provider)
+          return microsoft_state if provider == 'microsoft'
+
+          manager = Legion::Auth::TokenManager.new(provider: provider.to_sym)
+          return 'connected' if manager.token_valid?
+          return 'revoked' if manager.revoked?
+
+          'not connected'
+        end
+
+        def microsoft_state
+          return 'not connected' unless defined?(Legion::Extensions::Identity::Entra::Helpers::TokenManager)
+
+          tm = Legion::Extensions::Identity::Entra::Helpers::TokenManager
+          data = tm.token_data(:delegated, refresh: false)
+          data && !tm.expired?(data) ? 'connected' : 'not connected'
+        rescue StandardError
+          'not connected'
+        end
       end
     end
   end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.44'
+  VERSION = '1.9.45'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.43'
+  VERSION = '1.9.44'
 end

--- a/spec/legion/api/auth_teams_spec.rb
+++ b/spec/legion/api/auth_teams_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/api/auth_teams'
+
+RSpec.describe Legion::API::Routes::AuthTeams::TeamsTokenHelper do
+  subject(:helper) { Object.new.extend(described_class) }
+
+  let(:token_manager) do
+    class_double('Legion::Extensions::Identity::Entra::Helpers::TokenManager', save_token: true)
+  end
+
+  let(:token_body) do
+    { access_token: 'at', refresh_token: 'rt', expires_in: 3600 }
+  end
+
+  before do
+    stub_const('Legion::Extensions::Identity::Entra::Helpers::TokenManager', token_manager)
+    allow(helper).to receive(:require).and_return(true)
+  end
+
+  describe '#store_teams_token' do
+    it 'persists the delegated token via the Entra TokenManager' do
+      helper.store_teams_token(token_body, 'OnlineMeetings.Read',
+                               tenant_id: 'tid', client_id: 'cid')
+
+      expect(token_manager).to have_received(:save_token).with(
+        :delegated,
+        access_token:  'at',
+        refresh_token: 'rt',
+        expires_in:    3600,
+        scopes:        'OnlineMeetings.Read',
+        tenant_id:     'tid',
+        client_id:     'cid'
+      )
+    end
+
+    it 'forwards tenant_id and client_id so the stored token can be refreshed' do
+      helper.store_teams_token(token_body, 'scope', tenant_id: 'tid', client_id: 'cid')
+
+      expect(token_manager).to have_received(:save_token)
+        .with(:delegated, hash_including(tenant_id: 'tid', client_id: 'cid'))
+    end
+
+    it 'does not raise when the token store fails (logs a warning instead)' do
+      allow(token_manager).to receive(:save_token).and_raise(StandardError, 'vault down')
+
+      expect { helper.store_teams_token(token_body, 'scope', tenant_id: 't', client_id: 'c') }
+        .not_to raise_error
+    end
+  end
+end

--- a/spec/legion/cli/connect_command_spec.rb
+++ b/spec/legion/cli/connect_command_spec.rb
@@ -6,11 +6,58 @@ require 'legion/cli/connect_command'
 
 RSpec.describe Legion::CLI::ConnectCommand do
   describe '#status' do
-    it 'shows status for all providers' do
+    before do
       allow(Legion::Auth::TokenManager).to receive(:new).and_return(
         instance_double(Legion::Auth::TokenManager, token_valid?: false, revoked?: false)
       )
-      expect { described_class.new.invoke(:status, []) }.to output(/not connected/).to_stdout
+    end
+
+    context 'when the microsoft delegated token is present via the Entra TokenManager' do
+      let(:entra_tm) { class_double('Legion::Extensions::Identity::Entra::Helpers::TokenManager') }
+
+      before do
+        stub_const('Legion::Extensions::Identity::Entra::Helpers::TokenManager', entra_tm)
+        allow(entra_tm).to receive(:token_data).with(:delegated, refresh: false)
+                                               .and_return({ access_token: 'abc', expires_at: Time.now + 3600 })
+        allow(entra_tm).to receive(:expired?).and_return(false)
+      end
+
+      it 'reports microsoft as connected' do
+        expect { described_class.new.invoke(:status, []) }.to output(/microsoft: connected/).to_stdout
+      end
+    end
+
+    context 'when no microsoft delegated token exists' do
+      before do
+        stub_const('Legion::Extensions::Identity::Entra::Helpers::TokenManager',
+                   class_double('Legion::Extensions::Identity::Entra::Helpers::TokenManager',
+                                token_data: nil, expired?: true))
+      end
+
+      it 'reports microsoft as not connected' do
+        expect { described_class.new.invoke(:status, []) }.to output(/microsoft: not connected/).to_stdout
+      end
+    end
+
+    it 'reports non-microsoft providers via the legacy Auth::TokenManager' do
+      hide_const('Legion::Extensions::Identity::Entra::Helpers::TokenManager')
+      expect { described_class.new.invoke(:status, []) }.to output(/github: not connected/).to_stdout
+    end
+  end
+
+  describe '#microsoft' do
+    it 'forwards tenant_id, client_id, and scope (as --scopes) to the teams auth flow' do
+      expect(Legion::CLI::Auth).to receive(:start).with(
+        ['teams', '--tenant_id', 'tid', '--client_id', 'cid', '--scopes', 'Calendars.Read']
+      )
+      cmd = described_class.new([], { tenant_id: 'tid', client_id: 'cid', scope: 'Calendars.Read' })
+      cmd.microsoft
+    end
+
+    it 'forwards only teams when no options are given' do
+      expect(Legion::CLI::Auth).to receive(:start).with(['teams'])
+      cmd = described_class.new([], {})
+      cmd.microsoft
     end
   end
 


### PR DESCRIPTION
Closes #213
Closes #212
Closes #220
Closes #221

## #213 — `connect status` misreports `microsoft: not connected`
`connect status` used the legacy `Legion::Auth::TokenManager#token_valid?`, which reads secret keys `microsoft_access_token` / `microsoft_token_expires_at`. The delegated/Teams login writes via `Entra::Helpers::TokenManager.save_token(:delegated, …)` (vault/local/memory) and never touches those keys, so status always returned false.

**Fix:**
- `status` routes the `microsoft` provider through `Entra::Helpers::TokenManager.token_data(:delegated, refresh: false)` + `expired?`, mirroring the Entra delegated `status`. Guarded with `defined?` + rescue. Other providers keep the legacy path.
- `connect microsoft` now forwards `tenant_id` / `client_id` / `scope` (as `--scopes`) explicitly instead of dropping flag values via `ARGV.select`.

> Note: #221 is a duplicate of #213 (identical report) — closed by the same change.

## #212 — Teams delegated OAuth callback token store
The original #212 500 (phantom `require` of the unshipped `MicrosoftTeams::Helpers::TokenCache` raising an uncatchable `LoadError`) was already resolved in 1.9.43 via #229. The remaining valid piece: the callback persisted the delegated token **without** `tenant_id` / `client_id`. `TokenManager#refresh_token` requires both from the stored data; without them refresh falls back to `settings_auth` (empty for delegated-only logins) and silently fails.

**Fix:** `store_teams_token` now forwards `tenant_id` / `client_id` from the pending `entry` hash into `save_token(:delegated, …)`.

> Note: #220 is a duplicate of #212 (identical report) — closed by the same change.

## Test Coverage
- `spec/legion/cli/connect_command_spec.rb` — Entra-backed microsoft status (connected / not connected), legacy path for other providers, `microsoft` arg forwarding.
- `spec/legion/api/auth_teams_spec.rb` — `store_teams_token` forwards tenant_id/client_id to the Entra TokenManager and swallows store failures.

## Verification
- rspec: 5144 passed, **0 failed** (6 pre-existing pending, unchanged)
- rubocop: **0 offenses** (915 files)

Version bumped to **1.9.45**; CHANGELOG updated for 1.9.44 and 1.9.45.
