### PR TITLE
fix(api): /api/extensions/tools 500 — call helpers on correct receiver (fixes #227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion Changelog
 
+## [1.9.46] - 2026-07-02
+
+### Fixed
+- API: `GET /api/extensions/tools` no longer 500s with `undefined method 'filter_tool_entries'`. The route block runs in the Sinatra instance context but `filter_tool_entries`/`serialize_tool_entry` are class methods on `Routes::Extensions`; they are now called on the explicit receiver, matching the pattern used by the other catalog routes. Added request specs for `/api/extensions/tools` (fixes #227)
+
 ## [1.9.45] - 2026-07-02
 
 ### Fixed

--- a/lib/legion/api/extensions.rb
+++ b/lib/legion/api/extensions.rb
@@ -32,8 +32,8 @@ module Legion
 
         def self.register_tools_route(app)
           app.get '/api/extensions/tools' do
-            entries = filter_tool_entries(Array(Legion::Settings::Extensions.tools), params)
-            tools = entries.map { |e| serialize_tool_entry(e) }
+            entries = Routes::Extensions.filter_tool_entries(Array(Legion::Settings::Extensions.tools), params)
+            tools = entries.map { |e| Routes::Extensions.serialize_tool_entry(e) }
             json_response({ total: tools.size, tools: tools })
           end
         end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.45'
+  VERSION = '1.9.46'
 end

--- a/spec/legion/api/extensions_spec.rb
+++ b/spec/legion/api/extensions_spec.rb
@@ -137,6 +137,41 @@ RSpec.describe Legion::API::Routes::Extensions do
     end
   end
 
+  describe 'GET /api/extensions/tools' do
+    let(:tool_entries) do
+      [
+        { name: 'get_key', description: 'Get a key', extension: 'redis', runner: 'keys',
+          deferred: false, trigger_words: %w[redis key], source: 'lex', sticky: false },
+        { name: 'run_query', description: 'Run a query', extension: 'data', runner: 'sql',
+          deferred: true, trigger_words: [], source: 'lex', sticky: false }
+      ]
+    end
+
+    before do
+      allow(Legion::Settings::Extensions).to receive(:tools).and_return(tool_entries)
+    end
+
+    it 'returns 200 with serialized tools (regression: helpers are class methods, not instance)' do
+      get '/api/extensions/tools'
+      expect(last_response.status).to eq(200)
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:data][:total]).to eq(2)
+      expect(body[:data][:tools].map { |t| t[:name] }).to contain_exactly('get_key', 'run_query')
+    end
+
+    it 'filters by ?extension= param' do
+      get '/api/extensions/tools?extension=redis'
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:data][:tools].map { |t| t[:name] }).to contain_exactly('get_key')
+    end
+
+    it 'filters by ?deferred= param' do
+      get '/api/extensions/tools?deferred=true'
+      body = Legion::JSON.load(last_response.body)
+      expect(body[:data][:tools].map { |t| t[:name] }).to contain_exactly('run_query')
+    end
+  end
+
   describe 'GET /api/extension_catalog/available' do
     it 'returns the full ecosystem list' do
       get '/api/extension_catalog/available'


### PR DESCRIPTION
Closes #227
Closes #218

> Note: #218 is a duplicate of #227 (identical report) — closed by the same change.

## Problem
`GET /api/extensions/tools` returned HTTP 500 with `undefined method 'filter_tool_entries'`.

## Root Cause
The route block (`lib/legion/api/extensions.rb:34-38`) runs in the Sinatra **instance** context, but `filter_tool_entries` and `serialize_tool_entry` are defined as **class methods** on `Routes::Extensions` (inside `class << self`, lines 217/225). Bare calls resolved against the Sinatra instance → `NoMethodError`.

The other catalog routes in this file already call class methods on the explicit receiver (e.g. `Routes::Extensions.extension_entries`, line 51); this route was inconsistent.

## Fix
Call the helpers on the explicit `Routes::Extensions` receiver, matching the established pattern:

```ruby
entries = Routes::Extensions.filter_tool_entries(Array(Legion::Settings::Extensions.tools), params)
tools   = entries.map { |e| Routes::Extensions.serialize_tool_entry(e) }
```

## Test Coverage
`spec/legion/api/extensions_spec.rb` — new `GET /api/extensions/tools` block:
- returns 200 with serialized tools (the regression guard)
- filters by `?extension=`
- filters by `?deferred=`

The route previously had **no** coverage, which is how the regression slipped in.

## Verification
- rspec: 5147 passed, **0 failed** (6 pre-existing pending)
- rubocop: **0 offenses** (915 files)

Version bumped to **1.9.46**; CHANGELOG updated.
