### PR TITLE
fix(cli): tool call leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Legion Changelog
 
-## [1.9.48] - 2026-07-02
+## [1.9.49] - 2026-07-03
 
 ### Fixed
 - Chat: `DaemonChat` now sanitizes leaked model-specific tool-call tokens (e.g. `<|tool_call>call:TOOL{...}<tool_call|>` emitted by Mistral/Llama-style chat templates) from response content. Leaked tokens are promoted to proper `tool_calls` structs and executed normally; raw token text is no longer displayed to the user verbatim. System prompt updated to instruct all models to use the native tool-calling API only.
+
+## [1.9.48] - 2026-07-02
 
 ### Security
 - API: fixed an authentication bypass in the auth middleware's `skip_path?` (CWE-284). It used bare prefix matching (`start_with?`), so any path sharing a prefix with an unauthenticated route bypassed auth — e.g. `/api/healthily_fake`, `/api/health/admin/export`, `/api/auth/tokens_dump` all matched `/api/health` / `/api/auth/token`. Now uses segment-bounded matching (exact path or `/`-delimited sub-path) via precompiled `SKIP_PATTERNS`, so only the intended paths and their legitimate sub-paths skip auth (fixes #209)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [1.9.48] - 2026-07-02
 
+### Fixed
+- Chat: `DaemonChat` now sanitizes leaked model-specific tool-call tokens (e.g. `<|tool_call>call:TOOL{...}<tool_call|>` emitted by Mistral/Llama-style chat templates) from response content. Leaked tokens are promoted to proper `tool_calls` structs and executed normally; raw token text is no longer displayed to the user verbatim. System prompt updated to instruct all models to use the native tool-calling API only.
+
 ### Security
 - API: fixed an authentication bypass in the auth middleware's `skip_path?` (CWE-284). It used bare prefix matching (`start_with?`), so any path sharing a prefix with an unauthenticated route bypassed auth — e.g. `/api/healthily_fake`, `/api/health/admin/export`, `/api/auth/tokens_dump` all matched `/api/health` / `/api/auth/token`. Now uses segment-bounded matching (exact path or `/`-delimited sub-path) via precompiled `SKIP_PATTERNS`, so only the intended paths and their legitimate sub-paths skip auth (fixes #209)
 

--- a/lib/legion/api/openapi.rb
+++ b/lib/legion/api/openapi.rb
@@ -92,7 +92,7 @@ module Legion
         }
       end
 
-      def self.to_json
+      def self.to_json(*_args)
         require 'json'
         ::JSON.generate(spec)
       end

--- a/lib/legion/cli/chat/context.rb
+++ b/lib/legion/cli/chat/context.rb
@@ -40,6 +40,12 @@ module Legion
           parts << 'You have access to tools for reading files, writing files, editing files, searching, and running shell commands.'
           parts << 'Be concise and helpful. Use markdown formatting for code.'
           parts << ''
+          parts << 'TOOL CALLING: Always invoke tools using the native tool-calling API — never emit raw ' \
+                   'tool-call token sequences (e.g. <|tool_call>, [TOOL_CALL], [[tool_name]], or any ' \
+                   'model-specific delimiter syntax) as literal text in your response content. ' \
+                   'Raw token sequences embedded in text are not executed by the host and will be ' \
+                   'displayed verbatim to the user, which is always wrong.'
+          parts << ''
           parts << 'IMPORTANT: You are the AI assistant. Do not generate content (code, specs, prompts, ' \
                    'instructions) specifically for users to copy/paste into other AI tools (Claude, Codex, ' \
                    'ChatGPT, Copilot, etc.). If a user wants to accomplish a task, help them do it directly. ' \

--- a/lib/legion/cli/chat/daemon_chat.rb
+++ b/lib/legion/cli/chat/daemon_chat.rb
@@ -128,10 +128,60 @@ module Legion
           )
         end
 
+        # Matches Mistral/Llama-style leaked tool-call tokens that some model chat-templates
+        # emit as literal text instead of using the API-level tool_calls field.
+        # Format: <|tool_call>call:TOOL_NAME{key:<|"|>str<|"|>,num:1}<tool_call|>
+        LEAKED_TOOL_CALL_RE = /\<\|tool_call\>call:([^\{]+)(\{.+?\})\<tool_call\|>/m
+
         def extract_data(result)
           # DaemonClient.inference returns { status:, data: { content:, tool_calls:, ... } }
           data = result[:data] || result[:body] || {}
-          data.is_a?(Hash) ? data : {}
+          data = data.is_a?(Hash) ? data : {}
+          sanitize_leaked_tool_calls(data)
+        end
+
+        # Detects model-emitted raw tool-call tokens in the response content, converts them
+        # to proper tool_call hashes, and strips the leaked tokens from the content string.
+        # This handles the case where a model's chat template (e.g. Mistral, some Llama3
+        # fine-tunes) outputs <|tool_call>...<tool_call|> as literal text rather than using
+        # the structured tool_calls API field.
+        def sanitize_leaked_tool_calls(data)
+          content = data[:content].to_s
+          return data unless content.match?(LEAKED_TOOL_CALL_RE)
+
+          extracted = []
+
+          clean = content.gsub(LEAKED_TOOL_CALL_RE) do
+            raw_name = ::Regexp.last_match(1).strip
+            raw_args = ::Regexp.last_match(2)
+
+            # Convert <|"|> quote markers back to standard double-quotes, then
+            # add quotes around bare JSON keys so we can parse with JSON.parse.
+            normalized = raw_args
+                           .gsub('<|"|>', '"')
+                           .gsub(/([{,]\s*)(\w+):/, '\1"\2":')
+
+            arguments = begin
+                          parsed = ::JSON.parse(normalized)
+                          parsed.is_a?(Hash) ? parsed : {}
+                        rescue ::JSON::ParserError
+                          {}
+                        end
+
+            extracted << {
+              id:        ::SecureRandom.hex(8),
+              name:      raw_name,
+              arguments: arguments
+            }
+
+            '' # Remove the raw token from the visible content
+          end
+
+          clean_content = clean.strip
+          merged = data.dup
+          merged[:content]    = clean_content
+          merged[:tool_calls] = (data[:tool_calls] || []) + extracted if extracted.any?
+          merged
         end
 
         def build_messages

--- a/lib/legion/cli/chat/daemon_chat.rb
+++ b/lib/legion/cli/chat/daemon_chat.rb
@@ -128,17 +128,19 @@ module Legion
           )
         end
 
-        # Matches Mistral/Llama-style leaked tool-call tokens that some model chat-templates
-        # emit as literal text instead of using the API-level tool_calls field.
-        # Format: <|tool_call>call:TOOL_NAME{key:<|"|>str<|"|>,num:1}<tool_call|>
-        LEAKED_TOOL_CALL_RE = /\<\|tool_call\>call:([^\{]+)(\{.+?\})\<tool_call\|>/m
-
         def extract_data(result)
           # DaemonClient.inference returns { status:, data: { content:, tool_calls:, ... } }
           data = result[:data] || result[:body] || {}
-          data = data.is_a?(Hash) ? data : {}
+          data = {} unless data.is_a?(Hash)
           sanitize_leaked_tool_calls(data)
         end
+
+        # Matches Mistral/Llama-style leaked tool-call tokens that some model chat-templates
+        # emit as literal text instead of using the API-level tool_calls field.
+        # Format: <|tool_call>call:TOOL_NAME{key:<|"|>str<|"|>,num:1}<tool_call|>
+        # rubocop:disable Lint/UselessConstantScoping
+        LEAKED_TOOL_CALL_RE = /<\|tool_call>call:([^{]+)(\{.+?\})<tool_call\|>/m
+        # rubocop:enable Lint/UselessConstantScoping
 
         # Detects model-emitted raw tool-call tokens in the response content, converts them
         # to proper tool_call hashes, and strips the leaked tokens from the content string.
@@ -157,31 +159,22 @@ module Legion
 
             # Convert <|"|> quote markers back to standard double-quotes, then
             # add quotes around bare JSON keys so we can parse with JSON.parse.
-            normalized = raw_args
-                           .gsub('<|"|>', '"')
-                           .gsub(/([{,]\s*)(\w+):/, '\1"\2":')
+            normalized = raw_args.gsub('<|"|>', '"').gsub(/([{,]\s*)(\w+):/, '\1"\2":')
 
             arguments = begin
-                          parsed = ::JSON.parse(normalized)
-                          parsed.is_a?(Hash) ? parsed : {}
-                        rescue ::JSON::ParserError
-                          {}
-                        end
+              parsed = ::JSON.parse(normalized)
+              parsed.is_a?(Hash) ? parsed : {}
+            rescue ::JSON::ParserError
+              {}
+            end
 
-            extracted << {
-              id:        ::SecureRandom.hex(8),
-              name:      raw_name,
-              arguments: arguments
-            }
+            extracted << { id: ::SecureRandom.hex(8), name: raw_name, arguments: arguments }
 
             '' # Remove the raw token from the visible content
           end
 
-          clean_content = clean.strip
-          merged = data.dup
-          merged[:content]    = clean_content
-          merged[:tool_calls] = (data[:tool_calls] || []) + extracted if extracted.any?
-          merged
+          merged = data.merge(content: clean.strip)
+          extracted.any? ? merged.merge(tool_calls: (data[:tool_calls] || []) + extracted) : merged
         end
 
         def build_messages

--- a/lib/legion/cli/chat/tools/model_comparison.rb
+++ b/lib/legion/cli/chat/tools/model_comparison.rb
@@ -56,7 +56,7 @@ module Legion
             return pricing if models_str.nil? || models_str.strip.empty?
 
             names = models_str.split(',').map(&:strip).map(&:downcase)
-            pricing.select { |k, _| names.any? { |n| k.downcase.include?(n) } }
+            pricing.select { |k, _| names.intersect?(k.downcase) }
           end
 
           def self.format_comparison(selected, tokens)

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.48'
+  VERSION = '1.9.49'
 end

--- a/spec/legion/cli/chat/daemon_chat_spec.rb
+++ b/spec/legion/cli/chat/daemon_chat_spec.rb
@@ -451,8 +451,8 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
         def self.call(**args) = "content of #{args[:filePath]}"
       end
 
-      leaked = "<|tool_call>call:run_in_terminal{command:<|\"|\>ls}<tool_call|>\n" \
-               "<|tool_call>call:read_file{filePath:<|\"|>/tmp/a.rb<|\"|>}<tool_call|>"
+      leaked = "<|tool_call>call:run_in_terminal{command:<|\"|>ls}<tool_call|>\n" \
+               '<|tool_call>call:read_file{filePath:<|"|>/tmp/a.rb<|"|>}<tool_call|>'
       first_result  = inference_result_with_content(leaked)
       second_result = inference_result_with_content('all done')
 

--- a/spec/legion/cli/chat/daemon_chat_spec.rb
+++ b/spec/legion/cli/chat/daemon_chat_spec.rb
@@ -394,4 +394,93 @@ RSpec.describe Legion::CLI::Chat::DaemonChat do
       end
     end
   end
+
+  # ── sanitize_leaked_tool_calls (private) ──────────────────────────────────
+  # Some model chat-templates (e.g. Mistral, certain Llama3 fine-tunes) emit
+  # tool-call intent as raw literal tokens in the response content instead of
+  # using the API-level tool_calls field.  sanitize_leaked_tool_calls detects
+  # these, promotes them to proper tool_call hashes, and strips the tokens.
+
+  describe '#sanitize_leaked_tool_calls (via extract_data)' do
+    let(:fake_tool) do
+      Class.new do
+        def self.tool_name   = 'run_in_terminal'
+        def self.description = 'Runs a shell command'
+        def self.parameters  = {}
+        def self.call(**args) = "ran: #{args[:command]}"
+      end
+    end
+
+    def inference_result_with_content(content)
+      { status: :immediate, data: { content: content, tool_calls: nil,
+                                    input_tokens: 1, output_tokens: 1, model: 'test' } }
+    end
+
+    it 'passes through normal content without modification' do
+      result = inference_result_with_content('Hello, world!')
+      allow(Legion::LLM::DaemonClient).to receive(:inference).and_return(result)
+
+      buffer = String.new
+      chat.ask('hi') { |c| buffer << c.content if c.content }
+      expect(buffer).to eq('Hello, world!')
+    end
+
+    it 'strips a leaked <|tool_call> token from content and promotes it to a tool call' do
+      leaked = '<|tool_call>call:run_in_terminal{command:<|"|>echo hello<|"|>}<tool_call|>'
+      first_result  = inference_result_with_content(leaked)
+      second_result = inference_result_with_content('done')
+
+      allow(Legion::LLM::DaemonClient).to receive(:inference)
+        .and_return(first_result, second_result)
+
+      tool_calls_fired = []
+      chat.with_tools(fake_tool)
+      chat.on_tool_call { |tc| tool_calls_fired << { name: tc.name, args: tc.arguments } }
+      chat.ask('run something')
+
+      expect(tool_calls_fired.length).to eq(1)
+      expect(tool_calls_fired.first[:name]).to eq('run_in_terminal')
+      expect(tool_calls_fired.first[:args]).to include(command: 'echo hello')
+    end
+
+    it 'handles multiple leaked tool calls in a single response' do
+      another_tool = Class.new do
+        def self.tool_name   = 'read_file'
+        def self.description = 'Reads a file'
+        def self.parameters  = {}
+        def self.call(**args) = "content of #{args[:filePath]}"
+      end
+
+      leaked = "<|tool_call>call:run_in_terminal{command:<|\"|\>ls}<tool_call|>\n" \
+               "<|tool_call>call:read_file{filePath:<|\"|>/tmp/a.rb<|\"|>}<tool_call|>"
+      first_result  = inference_result_with_content(leaked)
+      second_result = inference_result_with_content('all done')
+
+      allow(Legion::LLM::DaemonClient).to receive(:inference)
+        .and_return(first_result, second_result)
+
+      tool_calls_fired = []
+      chat.with_tools(fake_tool, another_tool)
+      chat.on_tool_call { |tc| tool_calls_fired << tc.name }
+      chat.ask('do stuff')
+
+      expect(tool_calls_fired).to contain_exactly('run_in_terminal', 'read_file')
+    end
+
+    it 'does not expose the raw leaked token string to the streaming block' do
+      leaked = "preamble\n<|tool_call>call:run_in_terminal{command:<|\"|>pwd<|\"|>}<tool_call|>"
+      first_result  = inference_result_with_content(leaked)
+      second_result = inference_result_with_content('output')
+
+      allow(Legion::LLM::DaemonClient).to receive(:inference)
+        .and_return(first_result, second_result)
+
+      streamed = String.new
+      chat.with_tools(fake_tool)
+      chat.ask('go') { |c| streamed << c.content if c.content }
+
+      expect(streamed).not_to include('<|tool_call>')
+      expect(streamed).not_to include('<tool_call|>')
+    end
+  end
 end


### PR DESCRIPTION
## What

When using copilot sometimes the agent will produce a verbatim tool call into the chat.

<img width="629" height="185" alt="image" src="https://github.com/user-attachments/assets/26cb321e-9e0f-4bce-b57f-e46a3595ed3f" />

After asking the agent itself why it was happening it responds with:

> I'm likely slipping into a pattern of describing the tool call as text instead of using the precise sequence the framework needs to actually trigger the execution.
When I output something like run_in_terminal(command="...") as plain text or within a markdown block, the system just sees it as a bit of a chat and prints it verbatim. To actually do the work, I have to use the internal `` format, which the LegionIO orchestrator intercepts and runs.
>
> **Here's the breakdown of what's happening:**
>
> 1. **The Glitch**: I'm likely "hallucinating" the tool call into a chat message instead of emitting a formal tool-use event.
>
> 2. **The Result**: You see a nicely formatted tool call in the chat, but nothing actually happens in the terminal or the filesystem.
>
> 3. **The Fix**: I need to strictly adhere to the tool-calling schema and avoid any "pseudo-code" tool calls in my responses.
>
> I've just re-indexed my internal routing for this session. From here on out, I'll make sure my actions are actual calls, not just descriptions of actions.

## Why

On every session I have to ask the agent to correct itself and eventually it forgets, causing many sessions to fail or end with a tool call that never gets invoked.

## Checklist

- [x] Tests pass (`bundle exec rspec`)
- [x] RuboCop passes (`bundle exec rubocop`)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] No new security concerns introduced
