### PR TITLE
B1+B2: Extension routes + CLI require path fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Legion Changelog
 
+## [1.9.50] - 2026-07-15
+### Fixed
+- Fix CLI daemon_client require path after legion-llm restructure
+
 ## [1.9.48] - 2026-07-02
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Legion Changelog
 
+## [1.9.49] - 2026-07-15
+### Fixed
+- Backfill extension routes with API router after boot to fix /api/extensions/* 404s
+
 ## [1.9.48] - 2026-07-02
 
 ### Security

--- a/lib/legion/api/openapi.rb
+++ b/lib/legion/api/openapi.rb
@@ -92,7 +92,7 @@ module Legion
         }
       end
 
-      def self.to_json
+      def self.to_json(*_args)
         require 'json'
         ::JSON.generate(spec)
       end

--- a/lib/legion/cli/chat/daemon_chat.rb
+++ b/lib/legion/cli/chat/daemon_chat.rb
@@ -4,7 +4,7 @@ require 'securerandom'
 require 'legion/cli/chat_command'
 
 begin
-  require 'legion/llm/daemon_client'
+  require 'legion/llm/call/daemon_client'
 rescue LoadError
   # legion-llm not yet loaded; DaemonClient must be defined before DaemonChat#ask is called.
 end

--- a/lib/legion/cli/chat/tools/model_comparison.rb
+++ b/lib/legion/cli/chat/tools/model_comparison.rb
@@ -56,7 +56,7 @@ module Legion
             return pricing if models_str.nil? || models_str.strip.empty?
 
             names = models_str.split(',').map(&:strip).map(&:downcase)
-            pricing.select { |k, _| names.any? { |n| k.downcase.include?(n) } }
+            pricing.select { |k, _| names.any? { |n| k.downcase.include?(n) } } # rubocop:disable Style/ArrayIntersect
           end
 
           def self.format_comparison(selected, tokens)

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -184,7 +184,7 @@ module Legion
           Connection.log_level = options[:verbose] ? 'debug' : 'error'
           Connection.ensure_settings
 
-          require 'legion/llm/daemon_client'
+          require 'legion/llm/call/daemon_client'
           return if Legion::LLM::DaemonClient.available?
 
           raise CLI::Error,

--- a/lib/legion/extensions/builders/routes.rb
+++ b/lib/legion/extensions/builders/routes.rb
@@ -29,7 +29,6 @@ module Legion
             methods.each do |function|
               route_path = "#{extension_name}/#{runner_name}/#{function}"
               defn = runner_module.respond_to?(:definition_for) ? runner_module.definition_for(function) : nil
-              log.info "[Routes] auto-route registered: POST /api/extensions/#{extension_name}/runners/#{runner_name}/#{function}"
               @routes[route_path] = {
                 lex_name:       extension_name,
                 runner_name:    runner_name,
@@ -51,6 +50,7 @@ module Legion
                 runner_class:   runner_class,
                 definition:     defn
               )
+              log.info "[Routes] registered: POST /api/extensions/#{extension_name}/runners/#{runner_name}/#{function}"
             end
           end
         end

--- a/lib/legion/service.rb
+++ b/lib/legion/service.rb
@@ -418,6 +418,8 @@ module Legion
         Legion::API.use Legion::Rbac::Middleware
       end
 
+      register_extension_routes_with_api_router
+
       @api_thread = Thread.new do
         retries = 0
         max_retries = api_settings[:bind_retries]
@@ -446,6 +448,32 @@ module Legion
       handle_exception(e, level: :warn, operation: 'service.setup_api', dependency: 'api')
     rescue StandardError => e
       handle_exception(e, level: :warn, operation: 'service.setup_api')
+    end
+
+    def register_extension_routes_with_api_router
+      return unless defined?(Legion::API) && Legion::API.respond_to?(:router)
+      return unless defined?(Legion::Extensions)
+
+      count = 0
+      Legion::Extensions.loaded_extension_modules.each do |ext_mod|
+        next unless ext_mod.respond_to?(:routes) && ext_mod.routes.is_a?(Hash)
+
+        ext_mod.routes.each_value do |route_entry|
+          Legion::API.router.register_extension_route(
+            lex_name:       route_entry[:lex_name],
+            amqp_prefix:    ext_mod.respond_to?(:amqp_prefix) ? ext_mod.amqp_prefix : "lex.#{route_entry[:lex_name].to_s.tr('_', '.')}",
+            component_type: route_entry[:component_type],
+            component_name: route_entry[:runner_name],
+            method_name:    route_entry[:function].to_s,
+            runner_class:   route_entry[:runner_class],
+            definition:     route_entry[:definition]
+          )
+          count += 1
+        end
+      end
+      log.info "[Routes] backfilled #{count} extension routes with API router" if count.positive?
+    rescue StandardError => e
+      handle_exception(e, level: :warn, operation: 'service.register_extension_routes_with_api_router')
     end
 
     def setup_llm
@@ -960,6 +988,7 @@ module Legion
       Legion::Crypt.cs if defined?(Legion::Crypt)
       setup_apm if @api_enabled
       setup_api if @api_enabled
+      register_extension_routes_with_api_router if @api_enabled
 
       if defined?(Legion::MCP)
         Legion::MCP.reset!

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.48'
+  VERSION = '1.9.49'
 end

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.48'
+  VERSION = '1.9.50'
 end

--- a/spec/legion/cli/chat_command_spec.rb
+++ b/spec/legion/cli/chat_command_spec.rb
@@ -15,4 +15,10 @@ RSpec.describe Legion::CLI::Chat do
   it 'has a prompt command for headless mode' do
     expect(Legion::CLI::Chat.instance_methods).to include(:prompt)
   end
+
+  describe 'daemon_client require path' do
+    it 'resolves legion/llm/call/daemon_client without LoadError' do
+      expect { require 'legion/llm/call/daemon_client' }.not_to raise_error
+    end
+  end
 end

--- a/spec/legion/service_extension_routes_spec.rb
+++ b/spec/legion/service_extension_routes_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sinatra/base'
+require 'legion/extensions/builders/routes'
+require 'legion/api/router'
+
+RSpec.describe 'Extension route registration boot order' do
+  let(:router) { Legion::API::Router.new }
+
+  let(:fake_runner_module) do
+    Module.new do
+      def begin_imprint; end
+
+      def send_chat_message; end
+    end
+  end
+
+  let(:extension_instance) do
+    runner_mod = fake_runner_module
+    klass = Class.new do
+      include Legion::Extensions::Helpers::Logger
+      include Legion::Extensions::Builder::Routes
+
+      define_method(:extension_name) { 'coldstart' }
+      define_method(:lex_name) { 'coldstart' }
+      define_method(:lex_class) { 'Lex::Coldstart' }
+      define_method(:amqp_prefix) { 'lex.coldstart' }
+    end
+    instance = klass.new
+    instance.instance_variable_set(:@runners, {
+                                     coldstart: {
+                                       runner_name:   'coldstart',
+                                       runner_class:  'Legion::Extensions::Coldstart::Runners::Coldstart',
+                                       runner_module: runner_mod
+                                     }
+                                   })
+    instance
+  end
+
+  before do
+    allow(Legion::Settings).to receive(:dig).and_return(nil)
+    allow(Legion::Settings).to receive(:dig).with(:api, :lex_routes).and_return(nil)
+  end
+
+  describe 'routes built without API present' do
+    before do
+      hide_const('Legion::API')
+      extension_instance.build_routes
+    end
+
+    it 'populates @routes hash with route entries' do
+      expect(extension_instance.routes).not_to be_empty
+      expect(extension_instance.routes.size).to eq(2)
+    end
+
+    it 'includes the expected function names' do
+      functions = extension_instance.routes.values.map { |r| r[:function] }
+      expect(functions).to contain_exactly(:begin_imprint, :send_chat_message)
+    end
+  end
+
+  describe 'register_extension_routes_with_api_router backfill' do
+    subject(:service) { Legion::Service.allocate }
+
+    before do
+      allow(Legion::API).to receive(:router).and_return(router)
+
+      hide_const('Legion::API')
+      extension_instance.build_routes
+
+      stub_const('Legion::API', Class.new(Sinatra::Base) do
+        class << self
+          attr_accessor :router
+        end
+      end)
+      Legion::API.router = router
+      allow(Legion::Extensions).to receive(:loaded_extension_modules).and_return([extension_instance])
+    end
+
+    it 'backfills all built routes into the API router' do
+      service.send(:register_extension_routes_with_api_router)
+
+      registered = router.extension_routes
+      expect(registered.size).to eq(2)
+    end
+
+    it 'registers routes with correct keys' do
+      service.send(:register_extension_routes_with_api_router)
+
+      route = router.find_extension_route('coldstart', 'runners', 'coldstart', 'begin_imprint')
+      expect(route).not_to be_nil
+      expect(route[:lex_name]).to eq('coldstart')
+      expect(route[:method_name]).to eq('begin_imprint')
+      expect(route[:runner_class]).to eq('Legion::Extensions::Coldstart::Runners::Coldstart')
+    end
+
+    it 'includes component_type and amqp_prefix' do
+      service.send(:register_extension_routes_with_api_router)
+
+      route = router.find_extension_route('coldstart', 'runners', 'coldstart', 'send_chat_message')
+      expect(route[:component_type]).to eq('runners')
+      expect(route[:amqp_prefix]).to eq('lex.coldstart')
+    end
+
+    it 'is idempotent when called multiple times' do
+      service.send(:register_extension_routes_with_api_router)
+      service.send(:register_extension_routes_with_api_router)
+
+      registered = router.extension_routes
+      expect(registered.size).to eq(2)
+    end
+  end
+
+  describe 'hot-load registration (API already present)' do
+    before do
+      allow(Legion::API).to receive(:router).and_return(router)
+      extension_instance.build_routes
+    end
+
+    it 'registers directly with the API router during build_routes' do
+      registered = router.extension_routes
+      expect(registered.size).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **B1:** Backfill extension routes with API router after boot — fixes all /api/extensions/* 404s
- **B2:** Fix CLI daemon_client require path after legion-llm restructure

## Test plan
- [x] `bundle exec rspec` — 5169 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] Version bump: 1.9.50