### PR TITLE
B2: Fix CLI daemon_client require path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Legion Changelog
 
+## [1.9.50] - 2026-07-15
+### Fixed
+- Fix CLI daemon_client require path after legion-llm restructure
+
 ## [1.9.48] - 2026-07-02
 
 ### Security

--- a/lib/legion/api/openapi.rb
+++ b/lib/legion/api/openapi.rb
@@ -92,7 +92,7 @@ module Legion
         }
       end
 
-      def self.to_json
+      def self.to_json(*_args)
         require 'json'
         ::JSON.generate(spec)
       end

--- a/lib/legion/cli/chat/daemon_chat.rb
+++ b/lib/legion/cli/chat/daemon_chat.rb
@@ -4,7 +4,7 @@ require 'securerandom'
 require 'legion/cli/chat_command'
 
 begin
-  require 'legion/llm/daemon_client'
+  require 'legion/llm/call/daemon_client'
 rescue LoadError
   # legion-llm not yet loaded; DaemonClient must be defined before DaemonChat#ask is called.
 end

--- a/lib/legion/cli/chat/tools/model_comparison.rb
+++ b/lib/legion/cli/chat/tools/model_comparison.rb
@@ -56,7 +56,7 @@ module Legion
             return pricing if models_str.nil? || models_str.strip.empty?
 
             names = models_str.split(',').map(&:strip).map(&:downcase)
-            pricing.select { |k, _| names.any? { |n| k.downcase.include?(n) } }
+            pricing.select { |k, _| names.any? { |n| k.downcase.include?(n) } } # rubocop:disable Style/ArrayIntersect
           end
 
           def self.format_comparison(selected, tokens)

--- a/lib/legion/cli/chat_command.rb
+++ b/lib/legion/cli/chat_command.rb
@@ -184,7 +184,7 @@ module Legion
           Connection.log_level = options[:verbose] ? 'debug' : 'error'
           Connection.ensure_settings
 
-          require 'legion/llm/daemon_client'
+          require 'legion/llm/call/daemon_client'
           return if Legion::LLM::DaemonClient.available?
 
           raise CLI::Error,

--- a/lib/legion/version.rb
+++ b/lib/legion/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Legion
-  VERSION = '1.9.48'
+  VERSION = '1.9.50'
 end

--- a/spec/legion/cli/chat_command_spec.rb
+++ b/spec/legion/cli/chat_command_spec.rb
@@ -15,4 +15,10 @@ RSpec.describe Legion::CLI::Chat do
   it 'has a prompt command for headless mode' do
     expect(Legion::CLI::Chat.instance_methods).to include(:prompt)
   end
+
+  describe 'daemon_client require path' do
+    it 'resolves legion/llm/call/daemon_client without LoadError' do
+      expect { require 'legion/llm/call/daemon_client' }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `chat_command.rb` and `daemon_chat.rb` required `legion/llm/daemon_client` (old path)
- Updated to `legion/llm/call/daemon_client` (moved in legion-llm b600909, 2026-04-21)

## Test plan
- [x] `bundle exec rspec` — pass
- [x] `bundle exec rubocop` — 0 offenses